### PR TITLE
escape special characters from file name

### DIFF
--- a/ankihub/register_decks.py
+++ b/ankihub/register_decks.py
@@ -127,6 +127,7 @@ def upload_deck(did: DeckId) -> Response:
     exporter.includeTags = True
     deck_uuid = uuid.uuid4()
     out_dir = pathlib.Path(tempfile.mkdtemp())
+    deck_name = re.sub('[\\\\/?<>:*|"^]', "_", deck_name)
     out_file = out_dir / f"{deck_name}-{deck_uuid}.apkg"
     exporter.exportInto(str(out_file))
     LOGGER.debug(f"Deck {deck_name} exported to {out_file}")


### PR DESCRIPTION
Fix error when uploading deck that has a special character like `/` in its name.

Copied from Anki:
https://github.com/ankitects/anki/blob/a8e34ce419699b8e61a055173e1ffb411f3fa501/qt/aqt/exporting.py#L131