### PR TITLE
clear col.models._cache because of Anki bug

### DIFF
--- a/ankihub/register_decks.py
+++ b/ankihub/register_decks.py
@@ -131,6 +131,7 @@ def upload_deck(did: DeckId) -> Response:
     out_file = out_dir / f"{deck_name}-{deck_uuid}.apkg"
     exporter.exportInto(str(out_file))
     LOGGER.debug(f"Deck {deck_name} exported to {out_file}")
+    mw.col.models._clear_cache()
     client = AnkiHubClient()
     response = client.upload_deck(file=out_file, anki_id=did)
     return response
@@ -138,6 +139,7 @@ def upload_deck(did: DeckId) -> Response:
 
 def create_collaborative_deck(deck_name: str) -> Response:
     LOGGER.debug("Creating collaborative deck")
+    mw.col.models._clear_cache()
     deck_id = mw.col.decks.id(deck_name)
     model_ids = get_note_types_in_deck(deck_id)
     note_types = [mw.col.models.get(model_id) for model_id in model_ids]


### PR DESCRIPTION
This fixes a bug where creating two collaborative decks that both use the Basic note type, leads to an error "NoneType is not object subscriptable" ( https://www.notion.so/ankipalace/AnkiHub-testing-update-ideas-3bca019d54494b2787ba226463dcae35#ad6664390cc8446993370c8aa77da0ed )


This is due to an anki bug where `col.models._cache` becomes invalid after export: https://github.com/ankitects/anki/issues/1939

On export, mw.col.models._cache may become invalid.
So if the basic note type is exported twice, "NoneType is not object subscriptable" error is thrown 
because `note_type = models.by_name(name)` is `None` in `modify_note_type` method.

`models` is cleared at the start of upload as well in case user has exported the deck via anki before (instead of AnkiHub export)