### PR TITLE
use relative import as module name is not guranteed

### DIFF
--- a/ankihub/messages/messages.py
+++ b/ankihub/messages/messages.py
@@ -2,7 +2,7 @@ import pathlib
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from ankihub.constants import BUG_REPORT_FORM
+from ..constants import BUG_REPORT_FORM
 
 templates = (pathlib.Path(__file__).parent / "templates").absolute()
 env = Environment(loader=FileSystemLoader(templates), autoescape=select_autoescape())


### PR DESCRIPTION
Add-on downloaded via ankiweb may have different module name

This fixes an error that happens if add-on folder name is not 'ankihub'