### PR TITLE
move login window to top on display

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -108,6 +108,8 @@ class AnkiHubLogin(QWidget):
         if cls._window is None:
             cls._window = cls()
         else:
+            cls._window.activateWindow()
+            cls._window.raise_()
             cls._window.show()
         return cls._window
 


### PR DESCRIPTION
Move the login window to the front when `display_login` is called.