### PR TITLE
Rename existing note types when adjusting them

### DIFF
--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -187,6 +187,7 @@ def adjust_note_types(remote_note_types: Dict[NotetypeId, NotetypeDict]) -> None
     LOGGER.debug("Beginning adjusting note types...")
 
     create_missing_note_types(remote_note_types)
+    rename_note_types(remote_note_types)
     ensure_local_and_remote_fields_are_same(remote_note_types)
     modify_note_type_templates(remote_note_types.keys())
 
@@ -222,6 +223,16 @@ def create_missing_note_types(
         new_note_type = remote_note_types[mid]
         create_note_type_with_id(new_note_type, mid)
         LOGGER.debug(f"Created missing note type {mid}")
+
+
+def rename_note_types(remote_note_types: Dict[NotetypeId, NotetypeDict]) -> None:
+    for mid, remote_note_type in remote_note_types.items():
+        local_note_type = mw.col.models.get(mid)
+        if local_note_type["name"] != remote_note_type["name"]:
+            local_note_type["name"] = remote_note_type["name"]
+            mw.col.models.ensure_name_unique(local_note_type)
+            mw.col.models.update_dict(local_note_type)
+            LOGGER.debug(f"Renamed note type {mid=} to {local_note_type['name']}")
 
 
 def ensure_local_and_remote_fields_are_same(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -403,6 +403,8 @@ def test_adjust_note_types(anki_session_with_addon: AnkiSession):
         new_field = mw.col.models.new_field("foo")
         new_field["ord"] = 2
         mw.col.models.add_field(ankihub_basic_2, new_field)
+        # ... and change the name
+        ankihub_basic_2["name"] = "AnkiHub Basic 2 (new)"
 
         remote_note_types = {
             ankihub_basic_1["id"]: ankihub_basic_1,
@@ -412,6 +414,9 @@ def test_adjust_note_types(anki_session_with_addon: AnkiSession):
 
         assert mw.col.models.by_name("AnkiHub Basic 1") is not None
         assert mw.col.models.get(ankihub_basic_2["id"])["flds"][3]["name"] == "foo"
+        assert (
+            mw.col.models.get(ankihub_basic_2["id"])["name"] == "AnkiHub Basic 2 (new)"
+        )
 
 
 def test_reset_note_types_of_notes(anki_session_with_addon: AnkiSession):


### PR DESCRIPTION
This PR makes it so that note types are renamed back to the name they have on AnkiHub when synching.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

