### PR TITLE
Make it possible to cancel AnkiHub sync

### DIFF
--- a/ankihub/sync.py
+++ b/ankihub/sync.py
@@ -42,6 +42,8 @@ def sync_with_ankihub() -> None:
     for ankihub_did in config.private_config.decks.keys():
         success = sync_deck_with_ankihub(ankihub_did)
         if not success:
+            # Should we restore from backup on a failure?
+            # Also it would probably be good to count the number of updated notes and decks and display that to the user
             break
 
 


### PR DESCRIPTION
Now when you press the close window button of the progress dialog the sync process will abort.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/180"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

