### PR TITLE
Fix error on mw.progress.finish()

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -7,6 +7,7 @@ from .config import config
 from .errors import setup_error_handler
 from .gui import browser, editor
 from .gui.menu import setup_ankihub_menu
+from .progress import setup_progress_manager
 from .sync import setup_sync_on_startup
 
 
@@ -35,5 +36,8 @@ def run():
 
     setup_error_handler()
     LOGGER.debug("Set up error handler.")
+
+    setup_progress_manager()
+    LOGGER.debug("Set up progress manager")
 
     return mw

--- a/ankihub/progress.py
+++ b/ankihub/progress.py
@@ -1,0 +1,38 @@
+from typing import Callable, Optional
+
+from anki.hooks import wrap
+from aqt import sip
+from aqt.progress import ProgressManager
+
+
+def with_patched_isdeleted(
+    self: ProgressManager, _old: Callable[[ProgressManager], None]
+):
+    original_is_deleted = sip.isdeleted
+
+    def patched_isdeleted(x: Optional[sip.simplewrapper]) -> bool:
+        if x is None:
+            return True
+
+        return original_is_deleted(x)
+
+    sip.isdeleted = patched_isdeleted  # type: ignore
+    try:
+        _old(self)
+    finally:
+        sip.isdeleted = original_is_deleted
+
+
+def setup_progress_manager():
+
+    # This patch prevents some unnecessary errors when Anki
+    # tries to close the progress window when it is already closed.
+    # Users reported errors like this:
+    # TypeError: isdeleted() argument 1 must be sip.simplewrapper, not None after ProgressManager._closeWin was called.
+    # See for example https://github.com/ankipalace/ankihub_addon/issues/227
+    # Not sure how the value can be None, maybe it's caused by another add-on.
+    ProgressManager._closeWin = wrap(
+        old=ProgressManager._closeWin,
+        new=with_patched_isdeleted,
+        pos="around",
+    )


### PR DESCRIPTION
This is an attempt to address these issues:
Closes #215
Closes #222
Closes #227 

Maybe it will not resolve them completely in all cases, but I think it will help in some cases (combination of add-ons + Anki version) and in others it could lead to other errors getting thrown that lead us to the cause of the issue.

In these issues users report about errors like this:
```
Caught exception:
Traceback (most recent call last):
File "aqt/errors.py", line 73, in onTimeout
File "aqt/progress.py", line 156, in clear
File "aqt/progress.py", line 143, in finish
File "aqt/progress.py", line 184, in _closeWin
TypeError: isdeleted() argument 1 must be sip.simplewrapper, not None
```

Anki tries to close the progress dialog window but it is already closed and it crashes. The problem seems to be caused by another add-on, because normally `ProgressManager._closeWin` is only called here:
https://github.com/ankitects/anki/blob/c4d71eae2f5760059f0378e622db5ed615e934ab/qt/aqt/progress.py#L229-L230
so if `self._win` was `None`, `self._closeWin` should not get called and then line 274 here would also not get executed:
https://github.com/ankitects/anki/blob/c4d71eae2f5760059f0378e622db5ed615e934ab/qt/aqt/progress.py#L261-L274

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/229"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

