### PR TITLE
use addonFromModule(__name__) to get ankihub module name

### DIFF
--- a/ankihub/addons.py
+++ b/ankihub/addons.py
@@ -48,7 +48,9 @@ def on_deleteAddon(self, module: str) -> None:
     addon_dir = Path(self.addonsFolder(module))
     for file in addon_dir.rglob("*"):
         os.chmod(file, 0o777)
-    LOGGER.debug(f"On deleteAddon changed file permissions for all files in {addon_dir}")
+    LOGGER.debug(
+        f"On deleteAddon changed file permissions for all files in {addon_dir}"
+    )
 
 
 def with_hidden_progress_dialog(*args, **kwargs) -> Any:


### PR DESCRIPTION
Fix when ankihub addon module name is not 'ankihub'.

I also removed some logs as they don't seem useful

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/287"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

