### PR TITLE
feat: add suspend_new_cards_of_existing_notes config option

### DIFF
--- a/ankihub/config.json
+++ b/ankihub/config.json
@@ -2,5 +2,6 @@
     "ankihub_url": "https://app.ankihub.net",
     "hotkey": "Alt+u",
     "report_errors": true,
-    "sync_on_startup": true
+    "sync_on_startup": true,
+    "suspend_new_cards_of_existing_notes": "if_siblings_are_suspended"
 }

--- a/ankihub/config.md
+++ b/ankihub/config.md
@@ -1,0 +1,10 @@
+
+**suspend_new_cards_of_existing_notes**
+
+options:
+
+- `"if_siblings_are_suspended"`
+
+- `"never"`
+
+- `"always"`


### PR DESCRIPTION
Closes #311.

Adds a new (public) config option `suspend_new_cards_of_existing_notes`
Possible values are:
- `"never"`
- `"always"`
- `"if_siblings_are_suspended"`


<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

