### PR TITLE
Try to fix the "no such table: ankihub_db.notes" DB error

### DIFF
--- a/ankihub/db.py
+++ b/ankihub/db.py
@@ -6,6 +6,7 @@ from anki.dbproxy import DBProxy
 from anki.models import NotetypeId
 from anki.notes import NoteId
 from aqt import mw
+from aqt.gui_hooks import collection_did_load, collection_did_temporarily_close
 
 from . import LOGGER
 from .settings import ANKIHUB_NOTE_TYPE_FIELD_NAME, DB_PATH
@@ -173,3 +174,11 @@ class AnkiHubDB:
 
 
 ankihub_db = AnkiHubDB()
+
+
+def setup_ankihub_database():
+    """Sets up the AnkiHub database and attaches it to the Anki database connection
+    when Anki opens its database.
+    """
+    collection_did_load.append(lambda _: ankihub_db.setup())
+    collection_did_temporarily_close.append(lambda _: ankihub_db.setup())

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -7,6 +7,7 @@ from aqt.gui_hooks import main_window_did_init
 
 from . import LOGGER
 from .addons import setup_addons
+from .db import setup_ankihub_database
 from .errors import setup_error_handler
 from .gui import browser, editor
 from .gui.menu import setup_ankihub_menu
@@ -52,6 +53,9 @@ def run():
     from . import media_export  # noqa: F401
 
     LOGGER.debug("Loaded media_export.")
+
+    setup_ankihub_database()
+    LOGGER.debug("Set up ankihub database.")
 
     return mw
 


### PR DESCRIPTION
This PR tries to fix these issues:
https://sentry.io/organizations/ankihub/issues/3694579949/?project=6546414&query=is%3Aunresolved&referrer=issue-stream
https://sentry.io/organizations/ankihub/issues/3698553210/?project=6546414&query=is%3Aunresolved&referrer=issue-stream

The issues have this error in common:
```
DbError { info: "SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some(\"no such table: ankihub_db.notes\"))", kind: Other }
```


I'm not sure why users get this error but I added two changes that might help:
- The ankihub database now gets attached before every access to it (when using the methods of `AnkiHubDB` and when it is not attached yet). I don't know why it was not attached at the time the errors happened (it gets attached on these anki hooks: `collection_did_temporarily_close` and `collection_did_load`), but maybe some add-on interferes / resets the database connection?
- Added a call to `mw.col.db.commit()` in the `setup()` method of `AnkiHubDB`. This is needed to commit the migrations of the ankihub database when there were any.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

