### PR TITLE
fix: error when opening Anki related to the mashumaro serialization library

### DIFF
--- a/ankihub/lib/mashumaro/core/meta/helpers.py
+++ b/ankihub/lib/mashumaro/core/meta/helpers.py
@@ -176,7 +176,13 @@ def type_name(
         if short:
             return t.__qualname__
         else:
-            return f"{t.__module__}.{t.__qualname__}"
+            # patched for ankihub_addon to support module names starting with a number
+            # as Anki installs an add-on downloaded from AnkiWeb in a directory named by a number - its AnkiWeb id
+            result = f"{t.__module__}.{t.__qualname__}"
+            if re.match("[0-9].+", result):
+                top_level, rest = result.split(".", maxsplit=1)
+                result = f'globals()["{top_level}"].{rest}'
+            return result
     except AttributeError:
         return str(t)
 


### PR DESCRIPTION
This release https://github.com/ankipalace/ankihub_addon/releases/tag/2022-11-21.2 caused an error when opening Anki with the add-on installed:

```
When loading '⁨AnkiHub⁩': 
⁨Traceback (most recent call last): 
  File "aqt.addons", line 244, in loadAddons 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/__init__.py", line 25, in <module> 
    from .error_reporting import report_exception_and_upload_logs 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/error_reporting.py", line 12, in <module> 
    from .addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/addon_ankihub_client.py", line 10, in <module> 
    from .ankihub_client import AnkiHubClient, AnkiHubRequestError 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/ankihub_client.py", line 67, in <module> 
    class NoteInfo(DataClassJSONMixinWithConfig): 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/lib/mashumaro/mixins/dict.py", line 21, in __init_subclass__ 
    compile_mixin_unpacker(cls, **builder_params["unpacker"]) 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/lib/mashumaro/core/meta/mixin.py", line 44, in compile_mixin_unpacker 
    builder.add_unpack_method() 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/lib/mashumaro/core/meta/builder.py", line 458, in add_unpack_method 
    self.compile() 
  File "/Users/maximiliankinne/Library/Application Support/Anki2/addons21/1322529746/lib/mashumaro/core/meta/builder.py", line 303, in compile 
    exec(code, self.globals, self.__dict__) 
  File "<string>", line 39 
    raise MissingField('fields',typing.List[1322529746.ankihub_client.Field],cls) 
                                                       ^ 
SyntaxError: invalid syntax
```

This error was caused because the `mashumaro` (https://github.com/Fatal1ty/mashumaro) serialization library couldn't handle the module name of the add-on starting with a number. (Anki installs add-ons downloaded from AnkiWeb into directories named by their AnkiWeb id which consists of numbers). 

This PR patches `mashumaro` to support module names that start with numbers. 

The change causes `mashuamaro` to generate code like this:
```python
            try:
                kwargs['fields'] = [globals()["1234"].ankihub_client.Field.from_dict(value) for value in value]
            except Exception as e:
                raise InvalidFieldValue('fields',typing.List[globals()["1234"].ankihub_client.Field],value,cls)
```

instead of:

```python
            try:
                kwargs['fields'] = [1234.ankihub_client.Field.from_dict(value) for value in value]
            except Exception as e:
                raise InvalidFieldValue('fields',typing.List[1234.ankihub_client.Field],value,cls)
```

## Context
PR that introduced the usage of the `mashumaro` library: https://github.com/ankipalace/ankihub_addon/pull/349