### PR TITLE
Fix: Add check for out of sync config

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -11,7 +11,7 @@ from .addons import setup_addons
 from .errors import setup_error_handler
 from .gui import browser, editor
 from .gui.db_check import check_ankihub_db
-from .gui.anki_db_check import check_for_missing_ankihub_ids
+from .gui.anki_db_check import check_anki_db
 from .gui.menu import setup_ankihub_menu
 from .progress import setup_progress_manager
 from .settings import config
@@ -58,9 +58,7 @@ def run():
 
 def on_startup_syncs_done() -> None:
     # Called after AnkiWeb sync and AnkiHub sync are done after starting Anki.
-    check_ankihub_db()
-
-    check_for_missing_ankihub_ids()
+    check_ankihub_db(on_success=check_anki_db)
 
 
 def on_startup_ankiweb_sync_done() -> None:

--- a/ankihub/gui/anki_db_check.py
+++ b/ankihub/gui/anki_db_check.py
@@ -12,7 +12,7 @@ from ..reset_changes import reset_local_changes_to_notes
 from ..settings import ANKIHUB_NOTE_TYPE_FIELD_NAME, config
 
 
-def check_for_missing_ankihub_ids():
+def check_anki_db():
     # This is a fix for a bug in another add-on that removed the AnkiHub ID field from note types.
     # To restore the missing ankihub_ids this function resets local changes to the affected decks
     # when the user confirms the dialog.

--- a/ankihub/gui/db_check.py
+++ b/ankihub/gui/db_check.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List, Optional
 
 from aqt.utils import askUser, showInfo, showWarning
 
@@ -8,51 +8,70 @@ from ..settings import config
 from .decks import cleanup_after_deck_install, download_and_install_deck
 
 
-def check_ankihub_db():
-    dids_with_missing_values = ankihub_db.ankihub_dids_of_decks_with_missing_values()
+def check_ankihub_db(on_success: Optional[Callable[[], None]] = None):
+    ah_dids_with_missing_values = ankihub_db.ankihub_dids_of_decks_with_missing_values()
+    ah_dids_missing_from_config = decks_missing_from_config()
+    ah_dids_with_something_missing = list(
+        set(ah_dids_with_missing_values) | set(ah_dids_missing_from_config)
+    )
 
-    if not dids_with_missing_values:
-        LOGGER.debug("No decks with missing values found.")
+    if not ah_dids_with_something_missing:
+        LOGGER.debug("No decks with something missing found.")
+        on_success()
         return
 
-    LOGGER.debug(f"Decks with missing values found: {dids_with_missing_values}")
+    LOGGER.debug(f"Decks with missing values found: {ah_dids_with_missing_values}")
+    LOGGER.debug(f"Decks missing from config found: {ah_dids_missing_from_config}")
 
-    deck_names = sorted(
-        [
-            config.private_config.decks[deck_id]["name"]
-            for deck_id in dids_with_missing_values
-        ],
-        key=str.lower,
-    )
+    if ah_dids_missing_from_config:
+        messsage_begin = "AnkiHub has detected that some decks have missing values in the database.<br><br>"
+    else:
+        deck_names = sorted(
+            [
+                config.private_config.decks[deck_id]["name"]
+                for deck_id in ah_dids_with_missing_values
+            ],
+            key=str.lower,
+        )
+        messsage_begin = (
+            "AnkiHub has detected that the following deck(s) have missing values in the database:<br>"
+            f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
+        )
 
     if askUser(
         text=(
-            "AnkiHub has detected that the following deck(s) have missing values in the database:<br>"
-            f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
-            "The add-on needs to download and import these decks again. This may take a while.<br><br>"
+            messsage_begin
+            + "The add-on needs to download and import these decks again. This may take a while.<br><br>"
             "A full sync with AnkiWeb might be necessary after the reset, so it's recommended "
             "to sync changes from other devices before doing this.<br><br>"
             "Do you want to fix the missing values now?"
         ),
         title="AnkiHub Database Check",
     ):
-        download_and_install_decks(dids_with_missing_values)
+        download_and_install_decks(
+            ah_dids_with_something_missing, on_success=on_success
+        )
 
 
-def download_and_install_decks(ankihub_dids: List[str]):
+def download_and_install_decks(
+    ankihub_dids: List[str], on_success: Optional[Callable[[], None]] = None
+):
     # Installs decks one by one and then cleans up.
     # If a deck install fails, the other deck installs and the cleanup are **not** executed.
     # (The cleanup is not essential, it's just nice to have.)
     if not ankihub_dids:
         showInfo("All decks have been downloaded and imported.", title="AnkiHub")
         cleanup_after_deck_install(multiple_decks=True)
+
+        if on_success:
+            on_success()
         return
 
     cur_did = ankihub_dids.pop()
 
     download_and_install_deck(
         cur_did,
-        on_success=lambda: download_and_install_decks(ankihub_dids),
+        on_success=lambda: download_and_install_decks(ankihub_dids, on_success),
         on_failure=show_failure_message,
         cleanup=False,
     )
@@ -63,3 +82,10 @@ def show_failure_message() -> None:
         "AnkiHub was unable to download and import all deck(s).",
         title="AnkiHub",
     )
+
+
+def decks_missing_from_config() -> List[str]:
+    ah_dids_from_ankihub_db = ankihub_db.ankihub_deck_ids()
+    ah_dids_from_config = [ah_did for ah_did in config.private_config.decks]
+
+    return list(set(ah_dids_from_ankihub_db) - set(ah_dids_from_config))


### PR DESCRIPTION
This PR makes it so that when a deck is in the ankihub database, but not in the private config (see https://sentry.io/organizations/ankihub/issues/3783178024/?project=6546414), the add-on offers the user to fix this by downloading and importing the deck again.

## Screenshot
![image](https://user-images.githubusercontent.com/31575114/209440283-73656c32-724c-44e8-937a-6c7f193dd06d.png)

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

