### PR TITLE
fix: TypeError in anki db check when note types does not exist in anki db

### DIFF
--- a/ankihub/gui/anki_db_check.py
+++ b/ankihub/gui/anki_db_check.py
@@ -68,6 +68,10 @@ def _decks_with_missing_ankihub_nids():
         mids = ankihub_db.note_types_for_ankihub_deck(ah_did)
         for mid in mids:
             note_type = mw.col.models.get(mid)
+
+            if note_type is None:
+                continue
+
             ankihub_id_field = next(
                 (
                     field_dict


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/ankipalace/ankihub_addon/pull/365.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

