### PR TITLE
feat: Remove AnkiHub_Update tags and inform user about replacement

### DIFF
--- a/ankihub/gui/anki_db_check.py
+++ b/ankihub/gui/anki_db_check.py
@@ -132,12 +132,15 @@ def _check_ankihub_update_tags() -> None:
     LOGGER.debug("Notes with AnkiHub_Update tag found.")
 
     if not ask_user(
-        "The AnkiHub add-on has improved the way you can see which notes were updated (and for what reason). "
+        "The AnkiHub add-on has improved the way you can see which notes were updated (and for what reason)! "
+        "<br><br>"
         "Previously, you could see this by looking at the <b>AnkiHub_Update</b> tags that were added to notes "
-        "when they were updated.<br><br>"
+        "when they were updated. "
+        "<br><br>"
         "Now, you can see this information in the left sidebar of the Anki browser when you click on the<br>"
         "<b>AnkiHub -> Updated Today</b> category. "
-        "The <b>AnkiHub_Update</b> tags can be safely removed from all notes.<br><br>"
+        "<br><br>"
+        "The <b>AnkiHub_Update</b> tags can be safely removed from all notes. "
         "Do you want to remove the <b>AnkiHub_Update</b> tags from all notes now?",
         title="AnkiHub",
     ):


### PR DESCRIPTION
Cleans up after and informs users about changes introduced in these PRs:
https://github.com/ankipalace/ankihub_addon/pull/353
https://github.com/ankipalace/ankihub_addon/pull/360

## Screenshot
This dialog shows up when the add-on finds that some notes in the users Anki collection have `AnkiHub_Update` tags:
<img src="https://user-images.githubusercontent.com/31575114/212479273-95a7c351-8e07-466a-8207-f6684f4f87e6.png" width=500>


<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/384"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

