### PR TITLE
fix: change order of item names in test

### DIFF
--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1677,9 +1677,9 @@ def test_browser_treeview_contains_ankihub_tag_items(
             "Not Modified After Sync",
             "Updated Today",
             "Updated Since Last Review",
+            TAG_FOR_OPTIONAL_TAGS,
             TAG_FOR_PROTECTING_FIELDS,
             SUBDECK_TAG,
-            TAG_FOR_OPTIONAL_TAGS,
         ]
 
 


### PR DESCRIPTION
Fixes mistake in test introduced in #390.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/391"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

