### PR TITLE
fix: Clear login dialog fields on profile change

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -129,11 +129,16 @@ class AnkiHubLogin(QWidget):
             value,
         )
 
+    def clear_fields(self):
+        self.username_or_email_box_text.setText("")
+        self.password_box_text.setText("")
+
     @classmethod
     def display_login(cls):
         if cls._window is None:
             cls._window = cls()
         else:
+            cls._window.clear_fields()
             cls._window.activateWindow()
             cls._window.raise_()
             cls._window.show()


### PR DESCRIPTION
Previously, when you would enter something in the fields of the login dialog and changed the Anki profile, the fields retained their values. This is not desirable, as it makes no sense to use the same AnkiHub account on two different Anki profiles.