### PR TITLE
chore: Prevent docker layer cache from filling up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       - run: docker-compose pull
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
+        with:
+          key: ${{ github.workflow }}-${{ env.MONTH }}-{hash}
+          restore-keys: |
+            ${{ github.workflow }}-${{ env.MONTH }}-
       - run: |
           docker-compose build
           docker-compose run --rm django python manage.py makemigrations


### PR DESCRIPTION
Use a monthly rotating cache key to prevent docker layer cache from filling up.
Solution found here: https://github.com/ankipalace/ankihub/issues/620.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/401"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

