### PR TITLE
fix: add newlines below end comment

### DIFF
--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -272,7 +272,7 @@ def add_ankihub_end_comment_to_template(template: Dict) -> None:
             continue
 
         template[key] = (
-            template[key].rstrip("\n ") + "\n\n" + ANKIHUB_TEMPLATE_END_COMMENT
+            template[key].rstrip("\n ") + "\n\n" + ANKIHUB_TEMPLATE_END_COMMENT + "\n\n"
         )
         LOGGER.debug(
             f"Added ANKIHUB_TEMPLATE_END_COMMENT to template {template['name']} on side {key}"


### PR DESCRIPTION
Adds newlines below the end comment for card templates introduced in #403 so that it is easier for the user to add content below the comment.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/404"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

