### PR TITLE
fix: Let Updated Today search node only match stuff updated today instead of last 24 hours

### DIFF
--- a/ankihub/gui/custom_search_nodes.py
+++ b/ankihub/gui/custom_search_nodes.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional, Sequence
 
 from anki.utils import ids2str
@@ -106,8 +106,13 @@ class UpdatedInTheLastXDaysSearchNode(CustomSearchNode):
                 f"Invalid value for {self.parameter_name}: {self.value}. Must be a positive integer."
             )
 
-        threshold_timestamp = int(datetime.now().timestamp() - (days * 24 * 60 * 60))
-        ids = self._retain_ids_where(ids, f"ah_notes.mod > {threshold_timestamp}")
+        threshold_timestamp = int(
+            (
+                datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                - timedelta(days=days - 1)
+            ).timestamp()
+        )
+        ids = self._retain_ids_where(ids, f"ah_notes.mod >= {threshold_timestamp}")
 
         return ids
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3,7 +3,7 @@ import gzip
 import json
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import sleep
 from typing import Dict, List, Optional
@@ -1422,7 +1422,10 @@ def test_UpdatedInTheLastXDaysSearchNode(anki_session_with_addon: AnkiSession):
                 == all_nids
             )
 
-            mw.col.db.execute("UPDATE ankihub_db.notes SET mod = mod - 24 * 60 * 60")
+            yesterday_timestamp = int((datetime.now() - timedelta(days=1)).timestamp())
+            mw.col.db.execute(
+                f"UPDATE ankihub_db.notes SET mod = {yesterday_timestamp}"
+            )
 
             assert (
                 UpdatedInTheLastXDaysSearchNode(browser, "1").filter_ids(all_nids) == []


### PR DESCRIPTION
Changing this because it was confusing.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

