### PR TITLE
feat: tweak optional tag suggestion dialog

### DIFF
--- a/ankihub/gui/optional_tag_suggestion_dialog.py
+++ b/ankihub/gui/optional_tag_suggestion_dialog.py
@@ -18,8 +18,8 @@ from aqt.qt import (
 from aqt.utils import showInfo, tooltip
 
 from .. import LOGGER
-from ..optional_tag_suggestions import OptionalTagsSuggestionHelper
 from ..addon_ankihub_client import AnkiHubRequestError
+from ..optional_tag_suggestions import OptionalTagsSuggestionHelper
 
 
 class OptionalTagsSuggestionDialog(QDialog):
@@ -193,15 +193,13 @@ class OptionalTagsSuggestionDialog(QDialog):
                     )
                     item.setToolTip("Unknown error")
 
-        # enable/disable submit button depending on if there are valid suggestions
-        valid_groups_exist = any(
-            response.success for response in tag_group_validation_responses
-        )
+        # pre-select all valid tag groups
+        for tag_group in self._valid_tag_groups:
+            for i in range(self.tag_group_list.count()):
+                item = self.tag_group_list.item(i)
+                if item.text() == tag_group:
+                    item.setSelected(True)
+                    break
 
-        self.submit_btn.setEnabled(valid_groups_exist)
-        if not valid_groups_exist:
-            self.submit_btn.setToolTip(
-                "There are no valid suggestions. Please check the tooltips of the tag groups for more information."
-            )
-        else:
-            self.submit_btn.setToolTip("")
+        # enable submit button (it was disabled while validating)
+        self.submit_btn.setDisabled(False)


### PR DESCRIPTION
changes:
- optional tag suggestion dialog now is closed automatically after submitting suggestions
- valid tag groups are pre-selected to make it easier for the user

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/428"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

