### PR TITLE
fix: create change suggestion for note from which all tags were removed

### DIFF
--- a/ankihub/suggestions.py
+++ b/ankihub/suggestions.py
@@ -194,7 +194,7 @@ def change_note_suggestion(
     note_data = to_note_data(note, diff=True)
     assert note_data.ankihub_note_uuid is not None
 
-    if not note_data.fields and not note_data.tags:
+    if not note_data.fields and note_data.tags is None:
         return None
 
     return ChangeNoteSuggestion(


### PR DESCRIPTION
This PR fixes a small bug that prevents the creation of change note suggestions for notes when the only change is to remove all tags from the note. Before this PR the add-on would tell the user that no changes were detected for the note.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/433"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

