### PR TITLE
fix: delay addon update prompt when progress dialog is shown

### DIFF
--- a/ankihub/addons.py
+++ b/ankihub/addons.py
@@ -93,12 +93,12 @@ def setup_addons():
     # lead to a deadlock when AnkiHub is syncing and there is an add-on update.
     addons.prompt_to_update = wrap(  # type: ignore
         old=addons.prompt_to_update,
-        new=delay_when_progress_dialog_is_open,
+        new=with_delay_when_progress_dialog_is_open,
         pos="around",
     )
 
 
-def delay_when_progress_dialog_is_open(*args, **kwargs) -> Any:
+def with_delay_when_progress_dialog_is_open(*args, **kwargs) -> Any:
     _old: Callable = kwargs["_old"]
     del kwargs["_old"]
 


### PR DESCRIPTION
Prevent the situation that the add-on update dialog is shown while the progress dialog is open which can lead to a UI deadlock when AnkiHub is syncing and there is an add-on update.
User report: https://community.ankihub.net/t/cannot-open-anki-without-disabling-add-ons/417.

![image](https://user-images.githubusercontent.com/31575114/218873830-91c25381-f64e-4fb4-a0c0-c8c3812c1e76.png)
