### PR TITLE
fix: prevent silent addon update errors

### DIFF
--- a/ankihub/addons.py
+++ b/ankihub/addons.py
@@ -72,6 +72,7 @@ def check_future_for_exceptions(*args: Any, **kwargs: Any) -> None:
     if future is None:
         raise ValueError("Could not find future argument")
 
+    # throws exception if there was one in the future
     future.result()
 
 


### PR DESCRIPTION
User report errors of silent add-on update failures for the ankihub add-on.
This PR doesn't fix the errors, but it makes it so that these errors do not happen silently and instead an error message is shown to the user + we get error reports on sentry.

User report: https://community.ankihub.net/t/bug-improve-ankihub-addon-update-process/557/7