### PR TITLE
fix: Protect optional tags

### DIFF
--- a/ankihub/importing.py
+++ b/ankihub/importing.py
@@ -23,6 +23,7 @@ from .note_conversion import (
     TAG_FOR_PROTECTING_ALL_FIELDS,
     get_fields_protected_by_tags,
     is_internal_tag,
+    is_optional_tag,
 )
 from .settings import config
 from .utils import (
@@ -437,7 +438,10 @@ def updated_tags(
     # keep addon internal tags
     internal = [tag for tag in cur_tags if is_internal_tag(tag)]
 
-    result = list(set(protected) | set(internal) | set(incoming_tags))
+    # keep optional tags
+    optional = [tag for tag in cur_tags if is_optional_tag(tag)]
+
+    result = list(set(protected) | set(internal) | set(optional) | set(incoming_tags))
     return result
 
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -23,7 +23,7 @@ def test_lowest_level_common_ancestor_deck_name(anki_session_with_addon: AnkiSes
 
 def test_updated_tags(anki_session_with_addon: AnkiSession):
     from ankihub.importing import updated_tags
-    from ankihub.note_conversion import ADDON_INTERNAL_TAGS
+    from ankihub.note_conversion import ADDON_INTERNAL_TAGS, TAG_FOR_OPTIONAL_TAGS
 
     assert set(
         updated_tags(
@@ -85,6 +85,16 @@ def test_updated_tags(anki_session_with_addon: AnkiSession):
         )
     ) == set(["marked", "leech"])
 
+    # keep optional tags
+    optional_tag = f"{TAG_FOR_OPTIONAL_TAGS}::tag_group::tag"
+    assert set(
+        updated_tags(
+            cur_tags=[optional_tag],
+            incoming_tags=[],
+            protected_tags=[],
+        )
+    ) == set([optional_tag])
+
 
 def test_normalize_url(anki_session_with_addon: AnkiSession):
     from ankihub.error_reporting import normalize_url
@@ -121,10 +131,7 @@ def test_remove_note_type_name_modifications(anki_session_with_addon: AnkiSessio
 
 
 def test_add_subdeck_tags_to_notes(anki_session_with_addon: AnkiSession):
-    from ankihub.subdecks import (
-        SUBDECK_TAG,
-        add_subdeck_tags_to_notes,
-    )
+    from ankihub.subdecks import SUBDECK_TAG, add_subdeck_tags_to_notes
 
     with anki_session_with_addon.profile_loaded():
         mw = anki_session_with_addon.mw
@@ -158,10 +165,7 @@ def test_add_subdeck_tags_to_notes(anki_session_with_addon: AnkiSession):
 def test_add_subdeck_tags_to_notes_with_spaces_in_deck_name(
     anki_session_with_addon: AnkiSession,
 ):
-    from ankihub.subdecks import (
-        SUBDECK_TAG,
-        add_subdeck_tags_to_notes,
-    )
+    from ankihub.subdecks import SUBDECK_TAG, add_subdeck_tags_to_notes
 
     with anki_session_with_addon.profile_loaded():
         mw = anki_session_with_addon.mw


### PR DESCRIPTION
User report: https://community.ankihub.net/t/protect-new-optional-tag/734/4

Until now optional tags were not protected. This means that an update to a note downloaded from AnkiHub removed the optional tags the note had. This is fixed by this PR.