### PR TITLE
chore: Reduce logs when importing deck (also on sync)

### DIFF
--- a/ankihub/importing.py
+++ b/ankihub/importing.py
@@ -1,5 +1,4 @@
 """Import NoteInfo objects into Anki, create/update decks and note types if necessary"""
-
 import uuid
 from pprint import pformat
 from typing import Dict, Iterable, List, Optional, Set, Tuple
@@ -16,9 +15,6 @@ from . import LOGGER, settings
 from .addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from .ankihub_client import Field, NoteInfo
 from .db import ankihub_db
-from .subdecks import (
-    build_subdecks_and_move_cards_to_them,
-)
 from .note_conversion import (
     TAG_FOR_PROTECTING_ALL_FIELDS,
     get_fields_protected_by_tags,
@@ -26,6 +22,7 @@ from .note_conversion import (
     is_optional_tag,
 )
 from .settings import config
+from .subdecks import build_subdecks_and_move_cards_to_them
 from .utils import (
     create_deck_with_id,
     create_note_type_with_id,
@@ -34,6 +31,7 @@ from .utils import (
     lowest_level_common_ancestor_did,
     modify_note_type_templates,
     reset_note_types_of_notes,
+    truncated_list,
 )
 
 
@@ -130,8 +128,12 @@ class AnkiHubImporter:
             dids_for_note = set(c.did for c in note.cards())
             dids = dids | dids_for_note
 
-        LOGGER.info(f"Created {len(self.created_nids)} notes: {self.created_nids}")
-        LOGGER.info(f"Updated {len(self.updated_nids)} notes: {self.updated_nids}")
+        LOGGER.info(
+            f"Created {len(self.created_nids)} notes: {truncated_list(self.created_nids, limit=50)}"
+        )
+        LOGGER.info(
+            f"Updated {len(self.updated_nids)} notes: {truncated_list(self.updated_nids, limit=50)}"
+        )
 
         if first_import_of_deck:
             local_did = self._cleanup_first_time_deck_import(dids, local_did)

--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -1,7 +1,7 @@
 import re
 import time
 from pprint import pformat
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from anki.decks import DeckId
 from anki.errors import NotFoundError
@@ -15,8 +15,8 @@ from .settings import (
     ANKI_MINOR,
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
     ANKIHUB_NOTE_TYPE_MODIFICATION_STRING,
-    URL_VIEW_NOTE,
     ANKIHUB_TEMPLATE_END_COMMENT,
+    URL_VIEW_NOTE,
 )
 
 
@@ -78,7 +78,7 @@ def highest_level_did(dids: Iterable[DeckId]) -> DeckId:
 def create_note_with_id(note: Note, anki_id: NoteId, anki_did: DeckId) -> Note:
     """Create a new note, add it to the appropriate deck and override the note id with
     the note id of the original note creator."""
-    LOGGER.info(f"Trying to create note: {anki_id=}")
+    LOGGER.debug(f"Trying to create note: {anki_id=}")
 
     mw.col.add_note(note, DeckId(anki_did))
 
@@ -338,3 +338,8 @@ def create_backup() -> None:
     except Exception as exc:
         LOGGER.info("Backup failed")
         raise exc
+
+
+def truncated_list(values: List[Any], limit: int) -> List[Any]:
+    assert limit > 0
+    return values[:limit] + ["..."] if len(values) > limit else values


### PR DESCRIPTION
This reduces the amount of log lines that are generated when importing a deck (also happens during sync). The purpose is to not clutter logs and some users previously reported errors that were caused by high volumes of log output in a short time. 