### PR TITLE
fix: public config setup and test fixture

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -33,7 +33,6 @@ PROFILE_WILL_CLOSE = False
 def run():
     """Call this function in __init__.py when Anki starts."""
 
-    config.setup_public_config()
     setup_logger()
     LOGGER.info("Set up logger.")
 

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -98,15 +98,12 @@ class PrivateConfig(DataClassJSONMixin):
 class Config:
     def __init__(self):
         # self.public_config is editable by the user using a built-in Anki feature.
-        self.public_config: Optional[Dict[str, Any]] = None
+        migrate_public_config()
+        self.public_config: Dict[str, Any] = mw.addonManager.getConfig(ADDON_PATH.name)
         self._private_config: Optional[PrivateConfig] = None
         self._private_config_path: Optional[Path] = None
         self.token_change_hook: Optional[Callable[[], None]] = None
         self.subscriptions_change_hook: Optional[Callable[[], None]] = None
-
-    def setup_public_config(self):
-        migrate_public_config()
-        self.public_config = mw.addonManager.getConfig(ADDON_PATH.name)
 
     def setup_private_config(self):
         # requires the profile setup to be completed unlike self.setup_pbulic_config

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -38,15 +38,14 @@ def anki_session_with_addon_data(
     Instead the tests run the code in the ankihub folder of the repo.
     """
 
-    from ankihub.entry_point import profile_setup
-    from ankihub.settings import config, setup_logger
-
     config_path = REPO_ROOT_PATH / "ankihub" / "config.json"
     with open(config_path) as f:
         config_dict = json.load(f)
     anki_session.create_addon_config(package_name="ankihub", default_config=config_dict)
 
-    config.setup_public_config()
+    # code in settings.py depends on the public config being initialized
+    from ankihub.entry_point import profile_setup
+    from ankihub.settings import setup_logger
 
     setup_logger()
 


### PR DESCRIPTION
7352c332204bd086a8dedd3538a307618adac75f (pushed to main accidentally) changed the code that initializes the config which resulted in test failures. This PR fixes this.