### PR TITLE
feat: Add note about AnkiHub subscription requirement to dialog 

### DIFF
--- a/ankihub/gui/decks.py
+++ b/ankihub/gui/decks.py
@@ -458,7 +458,7 @@ def download_and_install_deck(
         elif e.response.status_code == 403:
             deck_url = f"{url_view_deck()}{ankihub_did}"
             showInfo(
-                f"Please first subscribe to the deck on the AnkiHub website.<br><br>"
+                f"Please first subscribe to the deck on the AnkiHub website.<br>"
                 f"Link to the deck: <a href='{deck_url}'>{deck_url}</a><br>"
                 "<br>"
                 "Note that you also need an active AnkiHub subscription.<br>"


### PR DESCRIPTION
Discussion: https://community.ankihub.net/t/help-downloading-deck/871/2

Users sometimes try to install decks without having an AnkiHub subscription. This PR changes the text on the dialog that is shown when the api returns a HTTP 403 response to account for the fact that this could also be the reason of the response.

![image](https://user-images.githubusercontent.com/31575114/220476411-50e1b7a5-bf07-4770-a64b-e03d089a09c3.png)
