### PR TITLE
fix: wrong number of synced notes showed after sync

### DIFF
--- a/ankihub/importing.py
+++ b/ankihub/importing.py
@@ -36,13 +36,13 @@ from .utils import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class AnkiHubImportResult:
     ankihub_did: uuid.UUID
     anki_did: DeckId
     updated_nids: List[NoteId]
     created_nids: List[NoteId]
-    skippped_nids: List[NoteId]
+    skipped_nids: List[NoteId]
     first_import_of_deck: bool
 
     def __repr__(self):
@@ -51,9 +51,9 @@ class AnkiHubImportResult:
 
 class AnkiHubImporter:
     def __init__(self):
-        self.created_nids: List[NoteId] = []
-        self.updated_nids: List[NoteId] = []
-        self.skipped_nids: List[NoteId] = []
+        self._created_nids: List[NoteId] = []
+        self._updated_nids: List[NoteId] = []
+        self._skipped_nids: List[NoteId] = []
 
     def import_ankihub_deck(
         self,
@@ -120,9 +120,9 @@ class AnkiHubImporter:
         subdecks: bool = False,
         subdecks_for_new_notes_only: bool = False,
     ) -> AnkiHubImportResult:
-        self.created_nids = []
-        self.updated_nids = []
-        self.skipped_nids = []
+        self._created_nids = []
+        self._updated_nids = []
+        self._skipped_nids = []
 
         first_import_of_deck = local_did is None
 
@@ -152,14 +152,14 @@ class AnkiHubImporter:
         ankihub_db.transfer_mod_values_from_anki_db(notes_data=notes_data)
 
         LOGGER.info(
-            f"Created {len(self.created_nids)} notes: {truncated_list(self.created_nids, limit=50)}"
+            f"Created {len(self._created_nids)} notes: {truncated_list(self._created_nids, limit=50)}"
         )
         LOGGER.info(
-            f"Updated {len(self.updated_nids)} notes: {truncated_list(self.updated_nids, limit=50)}"
+            f"Updated {len(self._updated_nids)} notes: {truncated_list(self._updated_nids, limit=50)}"
         )
         LOGGER.info(
-            f"Skippped {len(self.skipped_nids)} notes: "
-            f"{truncated_list(self.skipped_nids, limit=50)}"
+            f"Skippped {len(self._skipped_nids)} notes: "
+            f"{truncated_list(self._skipped_nids, limit=50)}"
         )
 
         if first_import_of_deck:
@@ -167,9 +167,9 @@ class AnkiHubImporter:
 
         if subdecks or subdecks_for_new_notes_only:
             if subdecks_for_new_notes_only:
-                anki_nids = list(self.created_nids)
+                anki_nids = list(self._created_nids)
             else:
-                anki_nids = list(self.created_nids + self.updated_nids)
+                anki_nids = list(self._created_nids + self._updated_nids)
 
             build_subdecks_and_move_cards_to_them(
                 ankihub_did=ankihub_did, nids=anki_nids
@@ -178,9 +178,9 @@ class AnkiHubImporter:
         result = AnkiHubImportResult(
             ankihub_did=ankihub_did,
             anki_did=local_did,
-            created_nids=self.created_nids,
-            updated_nids=self.updated_nids,
-            skippped_nids=self.skipped_nids,
+            created_nids=self._created_nids,
+            updated_nids=self._updated_nids,
+            skipped_nids=self._skipped_nids,
             first_import_of_deck=first_import_of_deck,
         )
         return result
@@ -227,7 +227,7 @@ class AnkiHubImporter:
             LOGGER.debug(
                 f"Note {note_data.ankihub_note_uuid} does not exist in AnkiHub DB, skipping"
             )
-            self.skipped_nids.append(NoteId(note_data.anki_nid))
+            self._skipped_nids.append(NoteId(note_data.anki_nid))
             return None
 
         note_before_changes = None
@@ -311,7 +311,7 @@ class AnkiHubImporter:
                 first_import_of_deck,
             ):
                 note.flush()
-                self.updated_nids.append(note.id)
+                self._updated_nids.append(note.id)
                 LOGGER.debug(f"Updated note: {note_data.anki_nid=}")
             else:
                 LOGGER.debug(f"No changes, skipping {note_data.anki_nid=}")
@@ -331,7 +331,7 @@ class AnkiHubImporter:
             note = create_note_with_id(
                 note, anki_id=NoteId(note_data.anki_nid), anki_did=anki_did
             )
-            self.created_nids.append(note.id)
+            self._created_nids.append(note.id)
             LOGGER.debug(f"Created note: {note_data.anki_nid=}")
         return note
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -740,14 +740,15 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
                 remote_note_types={},
                 protected_fields={},
                 protected_tags=[],
-            ).anki_did
+            )
+            anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             assert (
@@ -755,8 +756,8 @@ class TestAnkiHubImporter:
             )  # we have no mechanism for importing subdecks from a csv yet, so ti will be just onen deck
             assert anki_did == list(new_dids)[0]
 
-            assert len(ankihub_importer.created_nids) == 3
-            assert len(ankihub_importer.updated_nids) == 0
+            assert len(import_result.created_nids) == 3
+            assert len(import_result.updated_nids) == 0
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -781,22 +782,23 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
                 remote_note_types={},
                 protected_fields={},
                 protected_tags=[],
-            ).anki_did
+            )
+            anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             assert not new_dids
             assert anki_did == existing_did
 
             # no notes should be changed because they already exist
-            assert len(ankihub_importer.created_nids) == 0
-            assert len(ankihub_importer.updated_nids) == 0
+            assert len(import_result.created_nids) == 0
+            assert len(import_result.updated_nids) == 0
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -826,14 +828,15 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
                 remote_note_types={},
                 protected_fields={},
                 protected_tags=[],
-            ).anki_did
+            )
+            anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             # when the existing cards are in multiple seperate decks a new deck is created
@@ -841,8 +844,8 @@ class TestAnkiHubImporter:
             assert anki_did == list(new_dids)[0]
 
             # no notes should be changed because they already exist
-            assert len(ankihub_importer.created_nids) == 0
-            assert len(ankihub_importer.updated_nids) == 0
+            assert len(import_result.created_nids) == 0
+            assert len(import_result.updated_nids) == 0
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -879,21 +882,22 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
                 remote_note_types={},
                 protected_fields={},
                 protected_tags=[],
-            ).anki_did
+            )
+            anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             assert not new_dids
             assert anki_did == existing_did
 
-            assert len(ankihub_importer.created_nids) == 1
-            assert len(ankihub_importer.updated_nids) == 2
+            assert len(import_result.created_nids) == 1
+            assert len(import_result.updated_nids) == 2
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -914,7 +918,7 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            second_anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
@@ -922,15 +926,16 @@ class TestAnkiHubImporter:
                 protected_fields={},
                 protected_tags=[],
                 local_did=first_local_did,
-            ).anki_did
+            )
+            second_anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             assert len(new_dids) == 0
             assert first_local_did == second_anki_did
 
             # no notes should be changed because they already exist
-            assert len(ankihub_importer.created_nids) == 0
-            assert len(ankihub_importer.updated_nids) == 0
+            assert len(import_result.created_nids) == 0
+            assert len(import_result.updated_nids) == 0
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -960,7 +965,7 @@ class TestAnkiHubImporter:
             ankihub_deck_uuid = next_deterministic_uuid()
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            second_anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ankihub_deck_uuid,
                 notes_data=ankihub_sample_deck_notes_data(),
                 deck_name="test",
@@ -968,7 +973,8 @@ class TestAnkiHubImporter:
                 protected_fields={},
                 protected_tags=[],
                 local_did=first_local_did,
-            ).anki_did
+            )
+            second_anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             # deck with first_local_did should be recreated
@@ -977,8 +983,8 @@ class TestAnkiHubImporter:
             assert second_anki_did == first_local_did
 
             # no notes should be changed because they already exist
-            assert len(ankihub_importer.created_nids) == 0
-            assert len(ankihub_importer.updated_nids) == 0
+            assert len(import_result.created_nids) == 0
+            assert len(import_result.updated_nids) == 0
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ankihub_deck_uuid
@@ -1005,7 +1011,7 @@ class TestAnkiHubImporter:
             # import the deck again, now with the changed note data
             dids_before_import = all_dids()
             ankihub_importer = AnkiHubImporter()
-            second_anki_did = ankihub_importer._import_ankihub_deck_inner(
+            import_result = ankihub_importer._import_ankihub_deck_inner(
                 ankihub_did=ah_did,
                 notes_data=notes_data,
                 deck_name="test",
@@ -1014,7 +1020,8 @@ class TestAnkiHubImporter:
                 protected_tags=[],
                 local_did=anki_did,
                 subdecks=True,
-            ).anki_did
+            )
+            second_anki_did = import_result.anki_did
             new_dids = all_dids() - dids_before_import
 
             # assert that two new decks were created
@@ -1023,8 +1030,8 @@ class TestAnkiHubImporter:
             assert mw.col.decks.by_name("Testdeck::A::B") is not None
 
             # one note should be updated
-            assert len(ankihub_importer.created_nids) == 0
-            assert len(ankihub_importer.updated_nids) == 1
+            assert len(import_result.created_nids) == 0
+            assert len(import_result.updated_nids) == 1
 
             assert_that_only_ankihub_sample_deck_info_in_database(
                 ankihub_deck_uuid=ah_did


### PR DESCRIPTION
When multiple decks are synced, the tooltip that is shown after sync only shows the number of notes synced for the last deck that was synced instead of the total amount. The bug was introduced in https://github.com/ankipalace/ankihub_addon/commit/3d37b199aa9f7a7586cc109aaf0c4a75a0e8c204.

This PR fixes this.