### PR TITLE
fix: don't hide too many fields in the editor

### DIFF
--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -262,6 +262,7 @@ def _refresh_editor_fields_for_anki_v50_and_up_js(hide_last_field: bool) -> str:
             }
         """
     else:
+        # We don't expect this condition to occur, but adding this here to be sure we are notified if it does.
         raise RuntimeError("Function should not be called for Anki < 2.1.50")
 
     # This is the common part of the JS code for refreshing the fields.


### PR DESCRIPTION
**Problem**
When you switch the focus between different notes in the browser too many fields are hidden in the editor sometimes.

**Expected behavior**
Only the `ankihub_id` field should be hidden in the editor if it exists on the note type of the shown note.

**How this PR fixes the problem**
It changes the javascript code that is added to the editors own javascript code. 

Anki doesn't reload the whole editor when switching between notes in the browser. That's why fields which were hidden previously potentially need to be made visible again.

The new code makes all fields visible each time you focus a new note and then hides the `ankihub_id` field if it is present on the note.

This change was only made to the javascript code for Anki versions higher than 2.1.50. The code for lower versions already works correctly.