### PR TITLE
fix: error during AMBOSS add-on update

### DIFF
--- a/ankihub/db.py
+++ b/ankihub/db.py
@@ -27,6 +27,10 @@ def attach_ankihub_db_to_anki_db_connection() -> None:
 
 
 def detach_ankihub_db_from_anki_db_connection() -> None:
+    if aqt.mw.col is None:
+        LOGGER.info("The collection is not open. Not detaching AnkiHub DB.")
+        return
+
     if AnkiHubDB.database_name in [
         name for _, name, _ in aqt.mw.col.db.all("PRAGMA database_list")
     ]:


### PR DESCRIPTION
**Problem**
Nick encountered an error when updating the AMBOSS add-on while having the AnkiHub add-on installed. The AMBOSS add-on uses a custom update system and the add-on installation can be executed at other times than it is for other add-ons. In the error (see below) you can see that it was caused by the ankihub add-ons code trying to access a method of `aqt.mw.col` while `aqt.mw.col` was `None`.

**How this PR solves the problem**
The code that caused the problem tried to detach the AnkiHub database from the Anki database before the add-on update was run. (Usually this operation prevents errrors during the add-on update.) This code now checks if the collection is open and doesn't try to detach the database when it is not. There is no need to detach the AnkiHub database from the Anki database in this situation because the Anki database is not open.

**Error message**
```
An error occurred. Please start Anki while holding down the shift key, which will temporarily disable the add-ons you have installed.
If the issue only occurs when add-ons are enabled, please use the Tools > Add-ons menu item to disable some add-ons and restart Anki, repeating until you discover the add-on that is causing the problem.
When you’ve discovered the add-on that is causing the problem, please report the issue to the add-on author.
Debug info:
Anki 2.1.56 (07fd88dd) Python 3.9.15 Qt 6.3.2 PyQt 6.3.1
Platform: macOS-13.2.1-x86_64-i386-64bit
Flags: frz=True ao=True sv=?
Add-ons, last update check: 2023-02-28 18:47:10
Add-ons possibly involved: ⁨AnkiHub, AMBOSS add-on⁩Caught exception:
Traceback (most recent call last):
  File “/Users/Nick/Library/Application Support/Anki2/addons21/0amboss_addon/update_ui.py”, line 178, in on_download_done
    result = self._addon_installer.install(path)
  File “/Users/Nick/Library/Application Support/Anki2/addons21/0amboss_addon/update.py”, line 208, in install
    raw_result = self._addon_manager.install(addon_file_path)
  File “aqt.addons”, line 430, in install
  File “decorator”, line 232, in fun
  File “anki.hooks”, line 89, in decorator_wrapper
  File “anki.hooks”, line 84, in repl
  File “aqt.addons”, line 454, in _install
  File “decorator”, line 232, in fun
  File “anki.hooks”, line 89, in decorator_wrapper
  File “anki.hooks”, line 83, in repl
  File “/Users/Nick/Library/Application Support/Anki2/addons21/1322529746/addons.py”, line 44, in detach_ankihub_db
    detach_ankihub_db_from_anki_db_connection()
  File “/Users/Nick/Library/Application Support/Anki2/addons21/1322529746/db.py”, line 30, in detach_ankihub_db_from_anki_db_connection
    name for _, name, _ in mw.col.db.all(“PRAGMA database_list”)
AttributeError: ‘NoneType’ object has no attribute ‘db’
```