### PR TITLE
chore: change waffle_status endpoint to feature-flags

### DIFF
--- a/ankihub/ankihub_client.py
+++ b/ankihub/ankihub_client.py
@@ -43,7 +43,7 @@ S3_BUCKET_URL = (
 )
 
 API_URL_BASE = "https://app.ankihub.net/api"
-API_VERSION = 6.0
+API_VERSION = 7.0
 
 DECK_UPDATE_PAGE_SIZE = 2000  # seems to work well in terms of speed
 DECK_EXTENSION_UPDATE_PAGE_SIZE = 2000
@@ -902,15 +902,15 @@ class AnkiHubClient:
 
     def is_feature_flag_enabled(self, flag_name: str) -> bool:
         return (
-            self._get_waffle_status()["flags"]
+            self._get_feature_flags_status()["flags"]
             .get(flag_name, {})
             .get("is_active", False)
         )
 
-    def _get_waffle_status(self):
+    def _get_feature_flags_status(self):
         response = self._send_request(
             "GET",
-            "/waffle/waffle_status",
+            "/feature-flags",
         )
         if response.status_code != 200:
             raise AnkiHubRequestError(response)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -41,7 +41,7 @@ def enable_image_support_feature_flag(requests_mock: Mocker) -> None:
     from ankihub.ankihub_client import API_URL_BASE
 
     requests_mock.get(
-        f"{API_URL_BASE}/waffle/waffle_status",
+        f"{API_URL_BASE}/feature-flags",
         status_code=200,
         json={"flags": {"image_support_enabled": {"is_active": True}}},
     )
@@ -52,7 +52,7 @@ def disable_image_support_feature_flag(requests_mock: Mocker) -> None:
     from ankihub.ankihub_client import API_URL_BASE
 
     requests_mock.get(
-        f"{API_URL_BASE}/waffle/waffle_status",
+        f"{API_URL_BASE}/feature-flags",
         status_code=200,
         json={"flags": {"image_support_enabled": {"is_active": False}}},
     )


### PR DESCRIPTION
## Description

Has to be merged together with:
- ankipalace/ankihub#1164

This PR changes the `waffle/waffle_status` requests to `/feature-flags`. This change was needed because the default implementation of waffle_status didn't consider the token of the logged user (it uses cookies instead, which worked for insomnia and the browser but not the addon). Without this it is impossible to use flags for groups (only global).