### PR TITLE
fix:  ensure existing hash-filenames are used when renaming files in suggestions

### DIFF
--- a/ankihub/ankihub_client.py
+++ b/ankihub/ankihub_client.py
@@ -454,7 +454,7 @@ class AnkiHubClient:
                 file_content_hash.hexdigest() + old_asset_path.suffix
             )
 
-            # If the file with the hashed name does not exist already, we 
+            # If the file with the hashed name does not exist already, we
             # try to create it.
             if not new_asset_path.is_file():
                 try:


### PR DESCRIPTION
## Description
This PR fixes a bug that happened in the specific scenario when the image was already hashed once and a version with the hash-filename was already present in the local media folder. Then, when using the old filename of the image on a new suggestion, due to the conditional `if new_asset_path.is_file()` evaluating to `True`, the creation of the new file with the hash-filename was skipped (intentional) but so does the mapping assignment that mapped the old filename to the new filename (not intentional, this is what was fixed). Without this mapping the renaming wouldn't happen.

This would impact when users try to reuse images from the local folder that were already hashed.