### PR TITLE
fix: handle some connection errors better

### DIFF
--- a/ankihub/errors.py
+++ b/ankihub/errors.py
@@ -51,7 +51,7 @@ def handle_exception(
         if details:
             showText(f"Error while communicating with AnkiHub:\n{details}")
 
-    if isinstance(exc, exceptions.ConnectionError, ConnectionError):
+    if isinstance(exc, (exceptions.ConnectionError, ConnectionError)):
         tooltip(
             "Could not connect to AnkiHub (no internet or the site is down for maintenance)",
             parent=aqt.mw,


### PR DESCRIPTION
Just show an `Could not connect to AnkiHub (no internet or the site is down for maintenance)` error message when there is a `ConnectionError` (built-in) instead of showing showing the error report dialog and sending report to sentry.