### PR TITLE
ref: Move error handling related files into own module

### DIFF
--- a/ankihub/__init__.py
+++ b/ankihub/__init__.py
@@ -25,7 +25,7 @@ def debug() -> None:
 
 
 if not SKIP_INIT:
-    from .error_reporting import report_exception_and_upload_logs
+    from .errors import report_exception_and_upload_logs
 
     try:
         from . import entry_point

--- a/ankihub/errors/__init__.py
+++ b/ankihub/errors/__init__.py
@@ -1,0 +1,5 @@
+from .error_reporting import (  # noqa: F401
+    report_exception_and_upload_logs,
+    upload_logs_in_background,
+)
+from .errors import setup_error_handler  # noqa: F401

--- a/ankihub/errors/error_reporting.py
+++ b/ankihub/errors/error_reporting.py
@@ -8,10 +8,10 @@ from typing import Callable, Optional
 import aqt
 from anki.utils import checksum
 
-from . import LOGGER
-from .addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
-from .ankihub_client import AnkiHubRequestError
-from .settings import ADDON_VERSION, ANKI_VERSION, config, log_file_path
+from .. import LOGGER
+from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
+from ..ankihub_client import AnkiHubRequestError
+from ..settings import ADDON_VERSION, ANKI_VERSION, config, log_file_path
 
 SENTRY_ENV = "anki_desktop"
 # This prevents Sentry from trying to run a git command to infer the version.
@@ -44,7 +44,7 @@ def report_exception(
         import sentry_sdk
         from sentry_sdk import capture_exception, configure_scope
 
-        from .settings import config
+        from ..settings import config
 
         sentry_sdk.init(
             dsn="https://715325d30fa44ecd939d12edda720f91@o1184291.ingest.sentry.io/6546414",

--- a/ankihub/errors/errors.py
+++ b/ankihub/errors/errors.py
@@ -10,14 +10,14 @@ from anki.errors import BackendIOError, DBError, SyncError
 from aqt.utils import askUser, showText, showWarning, tooltip
 from requests import exceptions
 
-from . import LOGGER
-from .addon_ankihub_client import AnkiHubRequestError
+from .. import LOGGER
+from ..addon_ankihub_client import AnkiHubRequestError
+from ..gui.error_feedback import ErrorFeedbackDialog
+from ..gui.menu import AnkiHubLogin
+from ..gui.utils import check_and_prompt_for_updates_on_main_window
+from ..settings import ANKIWEB_ID, config
+from ..sync import NotLoggedInError
 from .error_reporting import report_exception_and_upload_logs
-from .gui.error_feedback import ErrorFeedbackDialog
-from .gui.menu import AnkiHubLogin
-from .gui.utils import check_and_prompt_for_updates_on_main_window
-from .settings import ANKIWEB_ID, config
-from .sync import NotLoggedInError
 
 
 def handle_exception(

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -12,7 +12,7 @@ from aqt.utils import openLink, showInfo, showText, tooltip
 from .. import LOGGER, settings
 from ..ankihub_client import AnkiHubRequestError
 from ..db import ankihub_db
-from ..error_reporting import report_exception_and_upload_logs
+from ..errors import report_exception_and_upload_logs
 from ..settings import (
     ANKI_MINOR,
     ICONS_PATH,

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -26,7 +26,7 @@ from requests.exceptions import ConnectionError
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..ankihub_client import AnkiHubRequestError
-from ..error_reporting import upload_logs_in_background
+from ..errors import upload_logs_in_background
 from ..media_import.ui import open_import_dialog
 from ..register_decks import create_collaborative_deck
 from ..settings import ADDON_VERSION, config, url_view_deck

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -9,7 +9,7 @@ from pytest_anki import AnkiSession
 os.environ["SKIP_INIT"] = "1"
 
 from ankihub import suggestions
-from ankihub.error_reporting import normalize_url
+from ankihub.errors.error_reporting import normalize_url
 from ankihub.exporting import _prepared_field_html
 from ankihub.importing import updated_tags
 from ankihub.note_conversion import ADDON_INTERNAL_TAGS, TAG_FOR_OPTIONAL_TAGS


### PR DESCRIPTION
Moves error handling related files into the new `error` module to encapsulate this functionality.

Similar to https://github.com/ankipalace/ankihub_addon/pull/495.