### PR TITLE
fix/update url_view_note_history to separate filters by comma

### DIFF
--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -454,7 +454,7 @@ except (FileNotFoundError, KeyError):
 
 url_view_note = lambda: f"{config.app_url}/decks/notes/"  # noqa: E731
 url_view_note_history = (
-    lambda: f"{config.app_url}/decks/{{ankihub_did}}/suggestions/?search=note:{{ankihub_nid}} state:closed"
+    lambda: f"{config.app_url}/decks/{{ankihub_did}}/suggestions/?search=note:{{ankihub_nid}},state:closed"
 )  # noqa: E731
 url_view_deck = lambda: f"{config.app_url}/decks/"  # noqa: E731
 url_help = lambda: f"{config.app_url}/help"  # noqa: E731


### PR DESCRIPTION
Related to: https://community.ankihub.net/t/clicking-on-author-then-open-suggestion-goes-back-to-main-menu/1261/6

Update `url_view_note_history` to separate filters by comma instead of space.