### PR TITLE
fix: auto-sync not working after profile change

### DIFF
--- a/ankihub/debug.py
+++ b/ankihub/debug.py
@@ -8,6 +8,7 @@ import aqt
 from anki.hooks import wrap
 from anki.utils import is_win
 from aqt.addons import AddonManager
+from aqt.main import AnkiQt
 
 from . import LOGGER
 from .db import is_ankihub_db_attached_to_anki_db
@@ -72,8 +73,8 @@ def _setup_logging_for_sync_collection_and_media():
     # Log stack trace when mw._sync_collection_and_media is called to debug the
     # "Cannot start transaction within transaction" error that occurs when two syncs
     # are started at the same time.
-    aqt.mw._sync_collection_and_media = wrap(  # type: ignore
-        aqt.mw._sync_collection_and_media,
+    AnkiQt._sync_collection_and_media = wrap(  # type: ignore
+        AnkiQt._sync_collection_and_media,
         lambda *args, **kwargs: _log_stack("mw._sync_collection_and_media"),
         "before",
     )


### PR DESCRIPTION
Currently when you switch the Anki profile by clicking File -> Switch Profile when you already had a profile open, auto sync with AnkiHub doesn't work anymore. This means that when you sync with AnkiWeb it won't also automatically sync with AnkiHub.

The reason for the auto-sync not working is the way the monkeypatching of the `anki.AnkiQt.sync_collection` method is done:
```python
aqt.mw.col.sync_collection = wrap(  # type: ignore
    aqt.mw.col.sync_collection,
    _sync_with_ankihub_and_ankiweb,
    "around",
)
```

This PR changes this code to this:
```python
Collection.sync_collection = wrap(  # type: ignore
    Collection.sync_collection,
    _sync_with_ankihub_and_ankiweb,
    "around",
)
```

This is better because when a new profile is opened a new `Collection` instance is created. With the first method the monkeypatch will be lost, with the second method it will be kept.

The same change is applied to another place where monkeypatching is used.