### PR TITLE
fix: Add sleep to fix flaky test

### DIFF
--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1775,6 +1775,10 @@ class TestCustomSearchNodes:
 
             record_review(mw, cid)
 
+            # sleep to make sure the timestamp of the review entry is different from the
+            # timestamp of the note
+            sleep(1.1)
+
             # import the deck again, this counts as an update
             import_sample_ankihub_deck(
                 mw, ankihub_did=ah_did, assert_created_deck=False
@@ -1786,6 +1790,8 @@ class TestCustomSearchNodes:
                     all_nids
                 ) == [nid]
 
+            # sleep to make sure the timestamp of the review entry is different from the
+            # timestamp of the note
             sleep(1.1)
 
             # add another review entry for the card to the database


### PR DESCRIPTION
The test for the `UpdatedSinceLastReviewSearchNode` sometimes fails in CI despite no changes to the code. This PR adds an additional sleep to make sure that the compared timestamps are different.