### PR TITLE
fix: Catch AnkiHubRequestError when fetching feature flag during menu setup

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -591,7 +591,7 @@ def media_download_status_setup(parent: QMenu):
             "image_support_enabled"
         )
     except (ConnectionError, AnkiHubRequestError):
-        # It's ok to not setup the menu when the feature flag status can't be retrieved.
+        # If we can't get the feature flags, we assume that the feature is disabled.
         return
 
     if not image_support_enabled:


### PR DESCRIPTION
The setup shouldn't raise an exception if fetching the feature flag fails. By raising the exception it also aborted the rest of the general setup (in `entrypoint.py`).