### PR TITLE
fix: Check feature flag before media download on deck install

### DIFF
--- a/ankihub/gui/decks.py
+++ b/ankihub/gui/decks.py
@@ -533,7 +533,8 @@ def install_deck(
         creator=is_creator,
     )
 
-    media_sync.start_media_download()
+    if AnkiHubClient().is_feature_flag_enabled("image_support_enabled"):
+        media_sync.start_media_download()
 
     LOGGER.info("Importing deck was succesful.")
 


### PR DESCRIPTION
Currently the add-on starts downloading media after install a deck, even if the image support feature flag is not enabled. This PR fixes that.