### PR TITLE
fix: Retry backup if it raises error

### DIFF
--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -373,7 +373,8 @@ def create_backup() -> None:
 
 def _create_backup_with_retry_anki_50() -> bool:
     """Create a backup and retry once if it raises an exception."""
-    # The backup can fail with an exception when aqt.mw.autosave() is called while the backup is running.
+    # The backup can fail with DBError("Cannot start transaction within a transaction")
+    # when aqt.mw.autosave() is called while the backup is running.
     # This can happen for example when an aqt.operations.CollectionOp is executed in another thread. After the
     # CollectionOp is finished, autosave is called, which calls mw.db.begin().
     # When the backup is finished, it also calls mw.db.begin() which raises an exception


### PR DESCRIPTION
Addresses https://github.com/ankipalace/ankihub_addon/issues/550.
It does not solve the error completely, but I think it's unlikely that the backup fails two times one after another because of the "cannot start transaction within a transaction" error.

Related to https://github.com/ankipalace/ankihub_addon/pull/514.

https://github.com/ankipalace/ankihub_addon/blob/f980737d03ac8dee2e86fc228ca32ddffe64af4f/ankihub/utils.py#L374-L383