### PR TITLE
fix: Use old css styling on ios for "view note on ankihub" link

### DIFF
--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -252,7 +252,7 @@ def add_ankihub_snippet_to_template(template: Dict) -> None:
             display: none;
         }}
 
-        .android .ankihub-view-note, .iphone .ankihub-view-note, .ipad .ankihub-view-note {{
+        .mobile .ankihub-view-note {{
             display: block;
         }}
 


### PR DESCRIPTION
This PR reverts the styling of the `View Note on AnkiHub` link on AnkiMobile, because it is not positioned properly. 
The new style was introduced in https://github.com/ankipalace/ankihub_addon/pull/498.

Screenshot that shows how it looks on AnkiMobile:
<img src="https://user-images.githubusercontent.com/31575114/232061894-cea3b755-a0ce-4787-bf3c-48a36e16a113.PNG" width="300" />
