### PR TITLE
fix: view note too large clickable area on ios

### DIFF
--- a/ankihub/utils.py
+++ b/ankihub/utils.py
@@ -256,6 +256,11 @@ def add_ankihub_snippet_to_template(template: Dict) -> None:
             display: block;
         }}
 
+        .ipad .ankihub-view-note, .iphone .ankihub-view-note {{
+            width: fit-content;
+            margin: 0 auto;
+        }}
+
         .android .ankihub-view-note {{
             text-decoration: none;
             position: fixed;


### PR DESCRIPTION
Error report: https://community.ankihub.net/t/view-note-on-ankihub-link-ipad/1639/4

The clickable area of the "View Note on AnkiHub" link was too large on iOS devices. This PR fixes this.