### PR TITLE
fix: Increase sync rate limit duration to 2 seconds

### DIFF
--- a/ankihub/auto_sync.py
+++ b/ankihub/auto_sync.py
@@ -72,7 +72,7 @@ def _rate_limit_syncincg() -> None:
     )
 
 
-@rate_limited(1, "after_sync")
+@rate_limited(2, "after_sync")
 def _rate_limited(*args, **kwargs) -> None:
     """Wrapper for AnkiQt._sync_collection_and_media that is rate limited to 1 sync per second.
     The `after_sync` callable passed to the _sync_collection_and_media function is called immediately


### PR DESCRIPTION
The sync rate limit was introduced here: https://ankihub.sentry.io/issues/3801328076/events/a4392e6e99074164b054554e986aec17/?project=6546414.

There are cases in which 1 second is not enough, that's apparent from the logs of these events:
https://ankihub.sentry.io/issues/3801328076/events/190aedefc83940bfab5c34f1bb1b3367/?project=6546414
https://ankihub.sentry.io/issues/3801328076/events/a4392e6e99074164b054554e986aec17/?project=6546414
The calls to `mw._sync_collection_and_media` are just barely more than 1 second apart. Not sure how this happens, because the progress dialog should open when the first sync is triggered, preventing the user from starting concurrent syncs.