### PR TITLE
chore: dont report collection is None errors

### DIFF
--- a/ankihub/errors.py
+++ b/ankihub/errors.py
@@ -187,7 +187,7 @@ def _try_handle_exception(
         and aqt.mw.col is None
     ):
         # Ignore errors that occur when the collection is None.
-        # This can e.g happen when a background task is running
+        # This can e.g. happen when a background task is running
         # and the user switches to a different Anki profile.
         LOGGER.warning("Collection is None was handled")
         return True


### PR DESCRIPTION
In general it's not necessary to report errors caused by the `aqt.mw.col` being `None` and (probably) all of the reported errors caused by this are just noise. If there was an issue caused by the collection being `None` we can still ask people to upload logs manually.