### PR TITLE
fix: rare crashes in taskmanager code

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -6,7 +6,7 @@ import aqt
 from anki.errors import CardTypeError
 from aqt.gui_hooks import profile_did_open
 
-from . import LOGGER
+from . import LOGGER, taskman
 from .addons import setup_addons
 from .auto_sync import setup_ankihub_sync_on_ankiweb_sync
 from .db import ankihub_db
@@ -117,6 +117,9 @@ def _general_setup():
 
     progress.setup()
     LOGGER.info("Set up progress manager.")
+
+    taskman.setup()
+    LOGGER.info("Set up task manager.")
 
     _trigger_addon_update_check()
     LOGGER.info("Triggered add-on update check.")

--- a/ankihub/taskman.py
+++ b/ankihub/taskman.py
@@ -1,0 +1,35 @@
+"""Modifies Anki's task manager (aqt.taskman). """
+from threading import current_thread, main_thread
+
+from anki.hooks import wrap
+from aqt.taskman import TaskManager
+
+from . import LOGGER
+
+
+def setup():
+    """Modifies TaskManager._on_closures_pending() to only run in the main thread.
+    This prevents Anki from crashing when a background thread calls it and
+    a closure tries to call a function that tries to change the Qt GUI.
+    This workaround is made necessary because we are nesting TaskManager.run_in_background calls
+    in the add-on code. (_on_closures_pending() is called in run_in_background,
+    run_in_background expects to be called from the main thread, but when the run_in_background_calls are nested,
+    it is called from a background thread. Then any waiting closures are also called from a background thread.)
+    The crashes caused by this are very rare even without this workaround."""
+    TaskManager._on_closures_pending = wrap(  # type: ignore
+        TaskManager._on_closures_pending,
+        _only_run_in_main_thread,
+        "around",
+    )
+
+
+def _only_run_in_main_thread(*args, **kwargs):
+    _old = kwargs["_old"]
+    del kwargs["_old"]
+
+    if current_thread() == main_thread():
+        _old(*args, **kwargs)
+    else:
+        LOGGER.warning(
+            "TaskManager._on_closures_pending() skipped, because it was called from a background thread."
+        )


### PR DESCRIPTION
While working on something else I noticed that Anki was consistently crashing on startup.
I found out that the reason was a call to a qt gui function from a background thread. (Qt functions that modify the gui should only be called for the main thread to prevent crashes.)

This PR adds a fix for this problem, by changing Anki's task manager code to call closures passed to `run_on_main` really only on the main thread. 
https://github.com/ankipalace/ankihub_addon/blob/04a356ac191548a4810b4ca560a09059034679d0/ankihub/taskman.py#L10-L36

This is probably something that should ideally be changed in Anki itself. 