### PR TITLE
chore: Use bot account to push to protected branch in GHA

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup git config
         run: |
           git config user.name "ankihub-addon-bot"
-          git config user.email "jakub.fidler@proton.me"
+          git config user.email "gh@users.noreply.github.com"
 
       - name: Setup Python
         uses: actions/setup-python@v2.2.1


### PR DESCRIPTION
Now that we have branch protection rules enabled, the `Create Release` GHA needs to be able to bypass the branch protection rules to be able to create the version bump commit.

I followed these instructions to make this work: https://stackoverflow.com/a/72515781