### PR TITLE
chore: bump dependencies in GHA for AnkiWeb upload

### DIFF
--- a/.github/workflows/upload_to_ankiweb.yml
+++ b/.github/workflows/upload_to_ankiweb.yml
@@ -34,6 +34,8 @@ jobs:
           python -m pip install webdriver_manager==3.7.1
           python -m pip uninstall -y selenium
           python -m pip install selenium==3.141.0
+          python -m pip uninstall urllib3
+          python -m pip install urllib3==1.26.14
 
       - name: Run upload script
         run: |


### PR DESCRIPTION
This should fix the `Upload to AnkiWeb` GHA.

See https://github.com/ankipalace/ankihub_addon/actions/runs/5002001652/jobs/8961508922.