### PR TITLE
feat: Protect autoopen tags by default

### DIFF
--- a/ankihub/note_conversion.py
+++ b/ankihub/note_conversion.py
@@ -15,6 +15,7 @@ TAG_FOR_OPTIONAL_TAGS = "AnkiHub_Optional"
 # top-level tags that are only used by the add-on, but not by the web app
 ADDON_INTERNAL_TAGS = [
     TAG_FOR_PROTECTING_FIELDS,
+    "autoopen",  # Used by AnKing note types
 ]
 
 # tags that are used internally by Anki and should not be deleted or appear in suggestions


### PR DESCRIPTION
The AnKing note types now use `autoopen` tags internally. This PR make it so that these tags are protected by default by the AnkiHub add-on.

See https://github.com/AnKing-Memberships/AnKing-Note-Types/pull/131#issuecomment-1556274434.