### PR TITLE
chore: Log `DeckDownloadAndInstallError`s

### DIFF
--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -138,6 +138,7 @@ def _download_and_install_decks_inner(
                     ankihub_did=ah_did,
                 )
             )
+            LOGGER.warning(f"Failed to download and install deck {ah_did}.", exc_info=e)
 
     if exceptions:
         # Raise the first exception that occurred


### PR DESCRIPTION
Previously the log didn't contain the traceback for `DeckDownloadAndInstallError`s. This PR changes this.