### PR TITLE
fix: Disable browser context menu actions if no notes selected

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -140,7 +140,7 @@ def _on_browser_will_show_context_menu(browser: Browser, context_menu: QMenu) ->
         if not selected_nids or not at_least_one_note_has_ah_note_type:
             action.setDisabled(True)
 
-    # Set copy ankihub id to clipboard action
+    # Set up copy ankihub id to clipboard action
     copy_ankihub_id_action = context_menu.addAction(
         "AnkiHub: Copy AnkiHub ID to clipboard",
         lambda: aqt.mw.app.clipboard().setText(str(ah_nid)),


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->
It makes no sense to use actions like `AnkiHub: Reset Protect fields` with no notes selected and it results in an error. To fix this, the actions are now disabled when no notes are selected. The actions are also disabled if none of the selected notes has an AnkiHub note type.

## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
Fixes https://ankihub.sentry.io/issues/4367873672/?project=6546414.

## How to reproduce
<!--
If it's a bug would be nice if you explain how to also reproduce the bug for us to make sure this does whats needed.
For instance:
1. Sign in using a Regular user
2. Go to the Explore page (https://app.ankihub.net/explore/)
3. Click on any Deck card
4. Click on the Copy and Paste Icon down below the Deck Name
5. Make sure the Copy and Paste feature works.
-->
Open the Anki browser, right click somewhere (not on a note or card) while not having any notes selected. AnkiHub actions in the context menu should be greyed out (disabled).