### PR TITLE
ref: Filter remote media in media regexes

### DIFF
--- a/ankihub/common_utils.py
+++ b/ankihub/common_utils.py
@@ -2,19 +2,18 @@
 import re
 from typing import Set
 
-IMG_NAME_IN_IMG_TAG_REGEX = re.compile(r"<img.*?src=[\"'](.*?)[\"']")
-SOUND_NAME_IN_SOUND_TAG_REGEX = re.compile(r"\[sound:(.*?)\]")
+# Regex to find the name of image files inside an <img> tag in HTML
+# excluding the ones that start with http:// or https://
+IMG_NAME_IN_IMG_TAG_REGEX = re.compile(
+    r"<img.*?src=[\"'](?!http://|https://)(.+?)[\"']"
+)
+# Regex to find the name of sound files inside a [sound] tag (specific to Anki)
+# excluding the ones that start with http:// or https://
+SOUND_NAME_IN_SOUND_TAG_REGEX = re.compile(r"\[sound:(?!http://|https://)(.+?)\]")
 
 
 def local_media_names_from_html(html_content: str) -> Set[str]:
     image_names = re.findall(IMG_NAME_IN_IMG_TAG_REGEX, html_content)
     sound_names = re.findall(SOUND_NAME_IN_SOUND_TAG_REGEX, html_content)
-    all_names = image_names + sound_names
-
-    # Filter out links to media hosted on the web
-    result = {
-        name
-        for name in all_names
-        if not any([http_prefix in name for http_prefix in ["http://", "https://"]])
-    }
-    return result
+    all_names = set(image_names + sound_names)
+    return all_names


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->
Introduces the same changes as this web app PR:
https://github.com/ankipalace/ankihub/pull/1675

his PR improves the regexes for extracting media references from the fields of notes and suggestions.
Previously we first used the regexes and then had to filter out references to remote media (ones starting with `http://` or `https://`) using python.
Now the regexes don't match remote media references anymore. This should make the code easier and more performant.