### PR TITLE
chore: Don't capture log events from other add-ons in sentry

### DIFF
--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -412,7 +412,19 @@ def _initialize_sentry():
         ],
         # This disable the AtexitIntegration because it causes a RuntimeError when Anki is closed.
         shutdown_timeout=0,
+        before_send=_before_send,
     )
+
+
+def _before_send(
+    event: Dict[str, Any], hint: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Filter out events created by the LoggingIntegration that are not related to this add-on."""
+    if "log_record" in hint:
+        logger_name = hint["log_record"].name
+        if logger_name != LOGGER.name:
+            return None
+    return event
 
 
 def _report_exception(


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->
We are not capturing errors to Sentry from other add-ons in the exception handler, but Sentry's `LoggingIntegration` causes `ERROR` or `EXCEPTION` level logs to be captured.
See for example this one: https://ankihub.sentry.io/issues/4093933044/?project=6546414&query=logger%3Anotion_sync.worker_%3C336d851-2f12-64c7-a97a-3496785596d3e%3E
This is a problem because it causes many irrelevant events getting captured by Sentry.

This PR configures a [`before_send`](https://docs.sentry.io/platforms/python/configuration/filtering/#using-platformidentifier-namebefore-send-) function that filters out events caused by loggers other than our logger.

## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
Discussion: https://theanking.slack.com/archives/C05DW3AKF63/p1693889363676079.

## Comments
Tested this manually by setting a breakpoint in `_before_send`:
https://github.com/ankipalace/ankihub_addon/blob/6e75d6c5b47f7a00beb5e5c315755876d99e974a/ankihub/gui/errors.py#L423
and causing error level logs by our logger and another logger to confirm that events from our logger are captured and events from other loggers are filtered out.
Also checked that exceptions which were not caused by a logger (but by an exception) are captured.