### PR TITLE
fix: Create-deck-action not working on qt6

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -230,6 +230,7 @@ def _create_collaborative_deck_action() -> None:
     if not confirm:
         return
 
+    LOGGER.info("Asking user to choose a deck to upload...")
     deck_chooser = StudyDeck(
         aqt.mw,
         title="AnkiHub",
@@ -243,6 +244,8 @@ def _create_collaborative_deck_action() -> None:
         ],
         parent=aqt.mw,
     )
+    LOGGER.info(f"Closed deck chooser dialog: {deck_chooser}")
+    LOGGER.info(f"Chosen deck name: {deck_chooser.name}")
     deck_name = deck_chooser.name
     if not deck_name:
         return


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->
Some users report that they can't create new AnkiHub decks from the add-on because nothing happens after they choose the deck they want to upload. This PR attempts to fix this.
@abdnh and I couldn't reproduce the issue ourselves.

## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
Report: https://community.ankihub.net/t/cant-upload-new-collaborative-decks-on-qt6/2340
Discussion: https://community.ankihub.net/t/cant-upload-new-collaborative-decks-on-qt6/2340/10

## Proposed changes
`aqt.mw` is passed to the `parent` argument of `StudyDeck`. This could fix the issue if `deck_choose.name` is getting destroyed  because of a missing parent element before we can access it.

<a href="https://gitpod.io/#https://github.com/ankipalace/ankihub_addon/pull/743"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

