### PR TITLE
fix: Upload to AnkiWeb script

### DIFF
--- a/scripts/upload_to_ankiweb.py
+++ b/scripts/upload_to_ankiweb.py
@@ -9,18 +9,17 @@ from selenium.webdriver.common.by import By
 from webbot import Browser
 from webdriver_manager.chrome import ChromeDriverManager
 
-webdriver_path = Path(ChromeDriverManager(driver_version="94.0.4606.41").install())
+webdriver_path = Path(ChromeDriverManager().install())
 
 
 def upload(
-    ankiweb_username,
-    ankiweb_password,
-    build_file_path,
-    description_file_path,
-    support_url,
-    show_window=False,
-):
-
+    ankiweb_username: str,
+    ankiweb_password: str,
+    build_file_path: str,
+    description_file_path: str,
+    support_url: str,
+    show_window: bool = False,
+) -> None:
     with ZipFile(build_file_path) as zipf:
         zipf.extract("manifest.json")
 
@@ -30,12 +29,15 @@ def upload(
 
     # use webbot to upload the add-on
     web = Browser(showWindow=show_window, driverPath=webdriver_path)
-    web.go_to("https://ankiweb.net/shared/upload")
+
+    web.go_to("https://ankiweb.net/account/login")
+    time.sleep(2)
+
     web.type(ankiweb_username, into="Email")
     web.type(ankiweb_password, into="Password")
     web.press(web.Key.ENTER)
-
     time.sleep(2)
+
     print("Url after login:", web.get_current_url())
 
     if manifest_dict["ankiweb_id"]:
@@ -45,11 +47,13 @@ def upload(
         # upload new addon
         web.go_to("https://ankiweb.net/shared/upload")
 
+    time.sleep(2)
+
     web.type(manifest_dict["name"], into="title")
-    web.type(support_url, into="support url")
+    web.type(support_url, into="Support Page")
     web.type(
         str(Path(build_file_path).absolute()),
-        id="v21file0",
+        xpath="//input[@type='file']",
     )
 
     with open(description_file_path) as f:
@@ -57,24 +61,31 @@ def upload(
 
     # web.type doesn't handle unicode characters correctly, so we use javascript
     driver = web.driver
-    description_field = driver.find_element(By.ID, "desc")
+    description_field = driver.find_element(By.TAG_NAME, "textarea")
     escaped_description = json.dumps(description)
     driver.execute_script(
-        "arguments[0].value = " + escaped_description, description_field
+        # the event is needed, otherwise the description change will be ignored
+        f"""
+        arguments[0].value = {escaped_description}
+        arguments[0].dispatchEvent(new Event('input'));
+        """,
+        description_field,
+        escaped_description,
     )
 
-    # optional values
-    def enter_optional_value(dict_, key, into="", id=""):
-        if dict_.get(key) is not None:
-            web.type(dict_[key], into=into, id=id)
+    if min_point_version := manifest_dict["min_point_version"]:
+        xpath = '//div[@class="form-inline"]//input[1]'
+        web.type("", xpath=xpath)
+        time.sleep(0.3)
+        web.type(f"2.1.{min_point_version}", xpath=xpath)
 
-    enter_optional_value(manifest_dict, "min_point_version", id="minVer0")
-    enter_optional_value(manifest_dict, "max_point_version", id="maxVer0")
+    if max_point_version := manifest_dict["max_point_version"]:
+        xpath = '//div[@class="form-inline"]//input[2]'
+        web.type("", xpath=xpath)
+        time.sleep(0.3)
+        web.type(f"2.1.{max_point_version}", xpath=xpath)
 
-    if manifest_dict["ankiweb_id"]:
-        web.click("Update")
-    else:
-        web.click("Upload")
+    web.click("Save")
 
     # check if upload was successful
     for _ in range(5):


### PR DESCRIPTION
There were some changes to the AnkiWeb website and we need to change the upload script as well.

## Related issues
[fix: Upload to AnkiWeb script](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=ac8d88426e8a411ba2515fa655b8eb29&pm=s)


## Proposed changes
- Don't specify incompatible chrome driver version
- Update selectors for form fields
- Add sleeps, since AnkiWeb uses a front-end framework now and javascript needs some time to execute
- Dispatch an `input` event after updating description text using javascript

## How to reproduce
I tested the script with a throw-away AnkiWeb account and another add-on.