### PR TITLE
feat: Increase bulk suggestion limit to 2000

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -68,6 +68,9 @@ from .custom_search_nodes import (
     UpdatedSinceLastReviewSearchNode,
 )
 
+# Maximum number of notes that can be selected for bulk suggestions.
+BULK_SUGGESTION_LIMIT = 2000
+
 browser: Optional[Browser] = None
 ankihub_tree_item: Optional[SidebarItem] = None
 
@@ -240,8 +243,8 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
 
 
 def _on_bulk_notes_suggest_action(browser: Browser, nids: Sequence[NoteId]) -> None:
-    if len(nids) > 500:
-        msg = "Please select at most 500 notes at a time for bulk suggestions.<br>"
+    if len(nids) > BULK_SUGGESTION_LIMIT:
+        msg = f"Please select at most {BULK_SUGGESTION_LIMIT} notes at a time for bulk suggestions.<br>"
         showInfo(msg, parent=browser)
         return
 


### PR DESCRIPTION
We currently have a limit how many notes / note changes you can suggest at notes from the add-on. This limit is 500 notes. This limit is inconvenient when users / deck maintainers want to push many updates at once.

This PR increases the limit from 500 to 2000.

## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
[Increase limit for bulk suggestions](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=ebb729aa168f491bad549a524763acd3&pm=s)

This issue was brought for example here:
[https://community.ankihub.net/t/auto-bulk-suggest/2316/12](https://community.ankihub.net/t/auto-bulk-suggest/2316/12?u=jakub.f)