### PR TITLE
fix: `AttributeError` during media sync

### DIFF
--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -101,7 +101,7 @@ class _AnkiHubMediaSync:
         self._client.media_upload_finished(ankihub_deck_id)
 
     def _update_deck_media_and_download_missing_media(self) -> None:
-        for ah_did in ankihub_db.ankihub_deck_ids():
+        for ah_did in config.deck_ids():
             self._update_deck_media(ankihub_did=ah_did)
             missing_media_names = self._missing_media_for_ah_deck(ah_did)
             if not missing_media_names:


### PR DESCRIPTION
This PR fixes an error that occurs for some some users during media sync.

## Related issues
https://ankihub.sentry.io/issues/4459310625/?project=6546414&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0
https://community.ankihub.net/t/browse-button-error/8335/10

## Proposed changes
Get deck ids from config instead of from database.
For the affected users, they have more deck ids in the database, than in the config. Probably because a previous version of the add-on wasn't removing the data from the db when a deck was removed.
Getting the deck ids from the config will fix the error. We are using the deck ids from the config as the source of truth about installed decks in other places in the add-on.