### PR TITLE
fix: Media sync not working after Anki profile switch

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -541,6 +541,10 @@ class AnkiHubClient:
         """Can be called to stop all background threads started by this client."""
         self.should_stop_background_threads = True
 
+    def allow_background_threads(self) -> None:
+        """Can be called to allow background threads to run after they were stopped previously."""
+        self.should_stop_background_threads = False
+
     def get_deck_subscriptions(self) -> List[Deck]:
         response = self._send_request("GET", API.ANKIHUB, "/decks/subscriptions/")
         if response.status_code != 200:

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -59,9 +59,11 @@ def _on_profile_did_open():
         ATTEMPTED_GENERAL_SETUP = True
         _general_setup()
 
+    media_sync.allow_background_threads()
+
 
 def _on_profile_will_close():
-    media_sync.cleanup()
+    media_sync.stop_background_threads()
 
 
 def _profile_setup() -> bool:

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -67,9 +67,13 @@ class _AnkiHubMediaSync:
             ),
         )
 
-    def cleanup(self):
+    def stop_background_threads(self):
         """Stop all media sync operations."""
         self._client.stop_background_threads()
+
+    def allow_background_threads(self):
+        """Allow background media sync operations to be started after they have been stopped."""
+        self._client.allow_background_threads()
 
     def refresh_sync_status_text(self):
         """Refresh the status text on the status action."""


### PR DESCRIPTION
The media sync is currently not working at all after switching the Anki profile. This is caused by code that terminates background tasks when the profile is switched. The code is useful because otherwise the download would proceed even after the profile is changed or even if Anki is closed. However it also prevents the media sync from running at all after the profile was changed at least once.

This PR fixes this.

## Related issues
Community post about missing images in MCAT deck: https://community.ankihub.net/t/missing-images-in-anking-mcat-deck-despite-thorough-debugging/8466/21

## Proposed changes
The `AnkiHubClient` currently has a method called `stop_background_threads`.
This PR adds a method called `allow_background_threads`
https://github.com/ankipalace/ankihub_addon/blob/abfc4b8ef9095a9d56622d4012997ed934f7e839/ankihub/gui/media_sync.py#L70-L76

Analogous methods are now in `_AnkiHubMediaSync`:
https://github.com/ankipalace/ankihub_addon/blob/abfc4b8ef9095a9d56622d4012997ed934f7e839/ankihub/gui/media_sync.py#L70-L76

When an Anki profile is opened, `allow_background_threads` is called.
(When an Anki profile is closed, `stop_background_threads` is called.)

## How to reproduce
- Start Anki
- Switch the profile (File -> Switch profile)
- Sync with a deck with media
- Media should be downloaded

Without the changes in this PR the media would not get downloaded.