### PR TITLE
chore: Fix release action

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+
       - name: Check status of the last run of the test workflow
         run: |
           gh auth login --with-token <<< "${{ secrets.GH_BOT_ACCESS_TOKEN }}"
@@ -28,13 +35,6 @@ jobs:
             echo "The last run of the test workflow on the main branch was not successful. Aborting..."
             exit 1
           fi
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
 
       - name: Setup git config
         run: |


### PR DESCRIPTION
The release action currently fails:
https://github.com/ankipalace/ankihub_addon/actions/runs/6353910467/job/17259416559

To fix it, the step for checking out the repo needs to be run before the step for checking the last run of the test workflow.