### PR TITLE
feat: Add `send_review_times` method to client

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1108,6 +1108,26 @@ class AnkiHubClient:
         result = [uuid.UUID(deck["id"]) for deck in data["created_decks"]]
         return result
 
+    def send_review_times(
+        self, first_review_time: datetime, last_review_time: datetime
+    ) -> None:
+        """Sends the first and last review time of an AnkiHub note to AnkiHub."""
+        response = self._send_request(
+            "PATCH",
+            API.ANKIHUB,
+            "/users/review-times",
+            json={
+                "first_card_review_at": first_review_time.strftime(
+                    ANKIHUB_DATETIME_FORMAT_STR
+                ),
+                "last_card_review_at": last_review_time.strftime(
+                    ANKIHUB_DATETIME_FORMAT_STR
+                ),
+            },
+        )
+        if response.status_code != 200:
+            raise AnkiHubHTTPError(response)
+
 
 def _transform_notes_data(notes_data: List[Dict]) -> List[Dict]:
     # TODO Fix differences between csv (used when installing for the first time) vs.

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1566,3 +1566,12 @@ class TestGetFeatureFlags:
         client.get_feature_flags()
         # This test just makes sure that the method does not throw an exception
         # Feature flags can change so we don't want to assert anything
+
+
+class TestSendReviewTimes:
+    def test_basic(self, authorized_client_for_user_test1: AnkiHubClient):
+        client = authorized_client_for_user_test1
+        client.send_review_times(
+            first_review_time=datetime.now(timezone.utc),
+            last_review_time=datetime.now(timezone.utc),
+        )


### PR DESCRIPTION
## 🤔 Problem Statement

We need to send the time of the last review of an AnkiHub note to the server to use this data to determine active users.

## 💡Possible Solution

The URL route is:  `PATCH api/users/review-times/` 

The payload to be sent is like this one:

```
{
  "first_card_review_at": "2021-09-07T00:47:58.141428+0000",
  "last_card_review_at": "2023-10-06T13:29:11.141428+0000"
}
```

The response if everything is successful is `200 OK`


## Related issues
[Add client method for sending review times to AnkiHub](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=962777f725b74bd59597d4dd4af62fd2&pm=s)