### PR TITLE
chore: Reduce log level for suspending cards in importer

### DIFF
--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -291,7 +291,7 @@ class AnkiHubImporter:
             if not (new_cards_ := new_cards()):
                 return
 
-            LOGGER.info(f"Suspending new cards of note {note.id}")
+            LOGGER.debug(f"Suspending new cards of note {note.id}")
             for card in new_cards_:
                 card.queue = QUEUE_TYPE_SUSPENDED
                 card.flush()


### PR DESCRIPTION
Now that we are often suspending a lot of notes during the import, logging every time the new cards of a note are suspended during an import is filling up the log file with mostly useless lines.

This PR just reduces the log level of a log statement from `info` to `debug`.

## Related issues
[chore: Reduce log level for suspending cards in importer](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=773f1c0451ae4219bb7c33cc1cfbfc51&pm=s)