### PR TITLE
fix: Make Deck Management dialog be always on top of main window on Windows

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -47,7 +47,7 @@ class DeckManagementDialog(QDialog):
     silentlyClose = True
 
     def __init__(self):
-        super(DeckManagementDialog, self).__init__()
+        super(DeckManagementDialog, self).__init__(aqt.mw)
         self.client = AnkiHubClient()
         self._setup_ui()
         self._refresh_decks_list()
@@ -59,6 +59,7 @@ class DeckManagementDialog(QDialog):
             self.show()
 
     def _setup_ui(self):
+        self.setWindowModality(Qt.WindowModality.WindowModal)
         self.setWindowTitle("AnkiHub | Deck Management")
         self.setMinimumWidth(640)
         self.setMinimumHeight(550)


### PR DESCRIPTION
The Deck Management dialog should always be on top of the main Anki window. Otherwise it will hide behind the main Anki window when you click on the main window, which is annoying and confusing. Our other dialogs do stay on top of the main Anki window as well.

The dialog is already on top of the main Anki window on Linux and probably MacOs, but not on Windows.

## Proposed changes
- Make the Deck Management Dialog always be on top of the main Anki window.
