### PR TITLE
fix: Dont show error to user when failing to send review data because of `DBError`

### DIFF
--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -48,13 +48,15 @@ def sync_with_ankihub(on_done: Callable[[Future], None]) -> None:
 
         try:
             send_review_data()
-        except DBError:
+        except DBError:  # pragma: no cover
             # TODO Attaching the ankihub db to the main db sometimes fails with a DBError
             # for some users. See:
             # https://ankihub.sentry.io/issues/4574509733/?project=6546414
             # This prevents the error from being shown to the user, until we find a fix.
             # The exception is sent to Sentry because of the LoggingIntegration.
-            LOGGER.exception("Could not send review data to AnkiHub")
+            LOGGER.exception(
+                "Could not send review data to AnkiHub"
+            )  # pragma: no cover
 
         on_done(future_with_result(None))
 


### PR DESCRIPTION
`review_data.send_review_data` is sometimes failing for some users with a `DBError`. The function is called after every AnkiHub sync and when this happens the error dialog is shown to the user.
It would be better to catch the exception and not show it to the user, until we create a fix for the exception.
Sending the review data is not essential for the operation of the add-on, so we can just ignore the exception in the add-on and send the exception information to Sentry.

## Related issues
https://ankihub.sentry.io/issues/4574509733/?project=6546414&referrer=issue-stream&sort=freq&statsPeriod=1h&stream_index=0

## Proposed changes
- Catch the `DBError` when sending review data and send it to Sentry. Don't re-raise the exception.

## Comments
The error is only happening for Windows users according to Sentry.
I tried to reproduce it on Windows without success.