### PR TITLE
fix: Change construction of `ICONS_PATH`

### DIFF
--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -572,7 +572,7 @@ ANKIHUB_TEMPLATE_END_COMMENT = (
     "-->"
 )
 ADDON_PACKAGE = __name__.split(".")[0]
-ICONS_PATH = ADDON_PATH / "gui/icons"
+ICONS_PATH = ADDON_PATH / "gui" / "icons"
 
 TOKEN_SLUG = "token"
 USER_EMAIL_SLUG = "user_email"


### PR DESCRIPTION
This PR attempts to fix a `FileNotFoundError` which occurs when Anki can't find the ankihub icon which is shown in the editor.

## Related issues
https://ankihub.sentry.io/issues/4253358830/?project=6546414&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=1

## Proposed changes
See the comment below.