### PR TITLE
fix: Bug in `get_unique_deck_name`

### DIFF
--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -32,7 +32,7 @@ from .utils import (
     create_deck_with_id,
     create_note_type_with_id,
     dids_of_notes,
-    get_unique_deck_name,
+    get_unique_ankihub_deck_name,
     lowest_level_common_ancestor_did,
     modify_note_type_templates,
     reset_note_types_of_notes,
@@ -363,8 +363,10 @@ class AnkiHubImporter:
                 f"Moved new cards to common ancestor deck {common_ancestor_did=}"
             )
 
-            aqt.mw.col.decks.remove([created_did])
-            LOGGER.info(f"Removed created deck {created_did=}")
+            if created_did != common_ancestor_did:
+                aqt.mw.col.decks.remove([created_did])
+                LOGGER.info(f"Removed created deck {created_did=}")
+
             return common_ancestor_did
 
         return created_did
@@ -513,7 +515,6 @@ class AnkiHubImporter:
         fields: List[Field],
         protected_fields: Dict[int, List[str]],
     ) -> bool:
-
         if TAG_FOR_PROTECTING_ALL_FIELDS in note.tags:
             LOGGER.debug(
                 "Skipping preparing fields because they are protected by a tag."
@@ -568,7 +569,7 @@ class AnkiHubImporter:
 
 
 def _adjust_deck(deck_name: str, local_did: Optional[DeckId] = None) -> DeckId:
-    unique_name = get_unique_deck_name(deck_name)
+    unique_name = get_unique_ankihub_deck_name(deck_name)
     if local_did is None:
         local_did = DeckId(aqt.mw.col.decks.add_normal_deck_with_name(unique_name).id)
         LOGGER.info(f"Created deck {local_did=}")
@@ -583,7 +584,6 @@ def _adjust_deck(deck_name: str, local_did: Optional[DeckId] = None) -> DeckId:
 def _updated_tags(
     cur_tags: List[str], incoming_tags: List[str], protected_tags: List[str]
 ) -> List[str]:
-
     # get subset of cur_tags that are protected
     # by being equal to a protected tag or by containing a protected tag
     # protected_tags can't contain "::" (this is enforced when the user chooses them in the webapp)

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -32,9 +32,8 @@ if ANKI_INT_VERSION >= ANKI_VERSION_23_10_00:
 
 
 def create_deck_with_id(deck_name: str, deck_id: DeckId) -> None:
-
     source_did = aqt.mw.col.decks.add_normal_deck_with_name(
-        get_unique_deck_name(deck_name)
+        get_unique_ankihub_deck_name(deck_name)
     ).id
     aqt.mw.col.db.execute(f"UPDATE decks SET id={deck_id} WHERE id={source_did};")
     aqt.mw.col.db.execute(f"UPDATE cards SET did={deck_id} WHERE did={source_did};")
@@ -79,16 +78,16 @@ def dids_of_notes(notes: List[Note]) -> Set[DeckId]:
     return result
 
 
-def get_unique_deck_name(deck_name: str) -> str:
+def get_unique_ankihub_deck_name(deck_name: str) -> str:
+    """Returns the passed deck_name if it is unique, otherwise returns a unique version of it
+    by adding a suffix."""
     if not aqt.mw.col.decks.by_name(deck_name):
         return deck_name
 
-    suffix = " (AnkiHub)"
-    if suffix not in deck_name:
-        deck_name += suffix
-    else:
-        deck_name += f" {checksum(str(time.time()))[:5]}"
-    return deck_name
+    result = f"{deck_name} (AnkiHub)"
+    if aqt.mw.col.decks.by_name(result) is not None:
+        result += f" {checksum(str(time.time()))[:5]}"
+    return result
 
 
 def highest_level_did(dids: Iterable[DeckId]) -> DeckId:
@@ -172,7 +171,6 @@ def get_note_types_in_deck(did: DeckId) -> List[NotetypeId]:
 
 
 def reset_note_types_of_notes(nid_mid_pairs: List[Tuple[NoteId, NotetypeId]]) -> None:
-
     note_type_conflicts: Set[Tuple[NoteId, NotetypeId, NotetypeId]] = set()
     for nid, mid in nid_mid_pairs:
         try:
@@ -197,7 +195,6 @@ def reset_note_types_of_notes(nid_mid_pairs: List[Tuple[NoteId, NotetypeId]]) ->
 
 
 def change_note_type_of_note(nid: int, mid: int) -> None:
-
     current_schema: int = aqt.mw.col.db.scalar("select scm from col")
     note = aqt.mw.col.get_note(NoteId(nid))
     target_note_type = aqt.mw.col.models.get(NotetypeId(mid))


### PR DESCRIPTION
There is a bug in `ankihub.main.utils.get_unique_deck_name`. It can cause a deck getting deleted right after its installation in some circumstances.

## Related issues
- [Fix bug in get_unique_deck_name](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=9311db87ffc5424f84baee7137aa049e&pm=c)
- Sentry: https://ankihub.sentry.io/issues/4612134771/?project=6546414&query=is%3Aunresolved+Your+database+appears+to+be+in+an+inconsistent+state&referrer=issue-stream&statsPeriod=30d&stream_index=0


## Proposed changes
- Fix `ankihub.main.utils.get_unique_deck_name` and rename it to `get_unique_ankihub_deck_name`
- Change logic in `ankihub.main.importing.AnkiHubImporter._cleanup_first_time_deck_import` to make sure that it doesn't delete the deck were it just put the cards into

## How to reproduce
**Explanation of the bug which deleted the deck will all cards after an import**
You don't really need to understand this fully to review this PR. The problem will be solved by fixing the bug in `get_unique_ankihub_deck_name`.

https://github.com/ankipalace/ankihub_addon/blob/4e6ed5a536951cbeb02d4c2cd7f8713c0f2d811a/ankihub/main/utils.py#L81-L83
The bug was caused because passing in a deck name like `"my deck (AnkiHub)"` into `get_unique_deck_name` should return `my deck (AnkiHub) [<checksum>]`. Instead it just returned `my deck (AnkiHub)` - even if a deck with this name already existed.
The code in https://github.com/ankipalace/ankihub_addon/blob/4e6ed5a536951cbeb02d4c2cd7f8713c0f2d811a/ankihub/main/importing.py#L339 assumes that a new deck was created. It moved the cards to another deck and deleted the deck that was created at the start of the import process. However the deck wasn't really created now, it was an existing deck (this is caused by the bug in `get_unique_deck_name`). So the deck which contained all the imported cards was deleted and the cards too.