### PR TITLE
fix: Add stretches to `DeckManagementDialog`

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -312,6 +312,7 @@ class DeckManagementDialog(QDialog):
         self.suspend_new_cards_of_existing_notes_row.addWidget(
             self.suspend_new_cards_of_existing_notes_cb_icon_label
         )
+        self.suspend_new_cards_of_existing_notes_row.addStretch()
 
         # Setup and configure the combo box for "Suspend new cards of existing notes"
         self.suspend_new_cards_of_existing_notes = QComboBox()
@@ -381,6 +382,7 @@ class DeckManagementDialog(QDialog):
         box = QHBoxLayout()
         box.addWidget(self.suspend_new_cards_of_new_notes_cb)
         box.addWidget(self.suspend_new_cards_of_new_notes_cb_icon_label)
+        box.addStretch()
 
         return box
 
@@ -404,6 +406,7 @@ class DeckManagementDialog(QDialog):
         self.subdecks_enabled_row = QHBoxLayout()
         self.subdecks_enabled_row.addWidget(self.subdecks_cb)
         self.subdecks_enabled_row.addWidget(self.subdeck_cb_icon_label)
+        self.subdecks_enabled_row.addStretch()
 
         # Initialize and set up the subdecks documentation link label
         self.subdecks_docs_link_label = QLabel(
@@ -425,7 +428,6 @@ class DeckManagementDialog(QDialog):
     def _setup_box_new_cards_destination(
         self, selected_ah_did: uuid.UUID
     ) -> QVBoxLayout:
-
         # Set up the destination tooltip message
         new_cards_destination_tooltip_message = (
             "Select the deck you want new cards to be saved to."
@@ -449,6 +451,7 @@ class DeckManagementDialog(QDialog):
         self.new_cards_destination_label_row.addWidget(
             self.new_cards_destination_icon_label
         )
+        self.new_cards_destination_label_row.addStretch()
 
         # Set up the destination details label
         self.new_cards_destination_details_label = QLabel()


### PR DESCRIPTION
This PR fixes a small issue with the look of the `DeckManagementDialog`. When the dialog is resized and its width is increased, the tooltip icons move away from their related text:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/ab2f5d87-1662-417f-993e-302312421678" width="500" />

With the changes in this PR, the dialog looks like this when resized:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/187912c9-9e7a-47b6-a5ae-7b4811ec33e9" width="500" />

For reference, this is how the dialog looks like when not resized:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/bf65eac5-5e9e-4292-839d-1f6c2fb23f23" width="500" />

## Related issues


## Proposed changes
- Add stretches to the hlayouts so that the labels and the icons stay near each other.