### PR TITLE
fix: Replace usage of signal.disconnect()

### DIFF
--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -297,7 +297,7 @@ class _Dialog(QDialog):
         self.scrollable = scrollable
         self.callback = callback
         self.icon = icon
-        self._was_closed = False
+        self._is_closing = False
 
         self._setup_ui()
 
@@ -379,10 +379,10 @@ class _Dialog(QDialog):
 
     def _on_btn_clicked_or_dialog_rejected(self, button_index: Optional[int]) -> None:
         # Prevent the callback from getting called recursively when it calls self.reject()
-        if self._was_closed:
+        if self._is_closing:
             return
 
-        self._was_closed = True
+        self._is_closing = True
 
         self.reject()
 


### PR DESCRIPTION
This is a fix for `QDialog.rejected.disconnect()` sometimes causing this error: `TypeError: disconnect() failed between 'rejected' and all its connections`. I'm not sure what causes this and I couldn't find any information about this.
 
`disconnect()` was used to prevent a callback from being called twice, and the same purpose can be achieved by using a boolean flag. The solution is straightforward and won't cause mysterious `TypeError`s.

## Related issues
https://ankihub.sentry.io/issues/4688651366/?project=6546414&query=is%3Aunresolved+release%3A2023-11-30.1&referrer=issue-stream&sort=freq&statsPeriod=30d&stream_index=8

## Proposed changes
- Use boolean `_QDialog._is_closing` flag to determine if the callback should be called