### PR TITLE
chore: Fix Anki 23.12 incompatibility 2

### DIFF
--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -201,7 +201,7 @@ def _install_deck(
         latest_udpate=latest_update,
     )
 
-    media_sync.start_media_download()
+    aqt.mw.taskman.run_on_main(media_sync.start_media_download)
 
     LOGGER.info("Importing deck was succesful.")
 


### PR DESCRIPTION
This PR makes the same change as [this PR](https://github.com/ankipalace/ankihub_addon/pull/830#issue-2037464102). The other PR prevents this dialog from being shown when syncing with AnkiHub:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/0e9e1dde-a25a-41a4-bd79-f828a42c6197" width="500" />

This PR prevents the dialog from being shown when installing an AnkiHub deck.

## Proposed changes
- Use `aqt.mw.taskman.run_on_main(media_sync.start_media_download)` instead of calling `media_sync.start_media_download()` directly from a background thread.

## How to reproduce
- Create a new virtual python environment
- Change the anki and aqt version to 23.12b2 in `requirements/base.txt`
- Install the requirements: `pip install -r requirements/dev.txt`
- Launch Anki with the add-on
- Subscribe to an AnkiHub deck on the website
- Sync with AnkiHbu and confirm the deck installation
- The warning dialog is shown
With the changes in this PR the warning dialog is not shown and the media sync is run.