### PR TITLE
fix: Hide "submit without review" checkbox initially

### DIFF
--- a/ankihub/gui/optional_tag_suggestion_dialog.py
+++ b/ankihub/gui/optional_tag_suggestion_dialog.py
@@ -77,6 +77,7 @@ class OptionalTagsSuggestionDialog(QDialog):
             "If checked, the suggestions will be automatically accepted. "
             "This option is only available for maintainers of the deck."
         )
+        self._refresh_auto_accept_check_box()
 
         self.setLayout(self.layout_)
         self.layout_.addLayout(self.hlayout)


### PR DESCRIPTION
Currently, when you open the optional tag suggestion dialog, the "Submit without review" checkbox is initially shown and then disappears after a moment when the validation is done:

https://github.com/ankipalace/ankihub_addon/assets/31575114/8d209831-7a19-4975-8173-133c3378a27a

This looks a bit weird. It's better to let the checkbox be hidden initially and only show it when needed:

https://github.com/ankipalace/ankihub_addon/assets/31575114/8bb03950-6a28-43a7-8838-1a5a08e11100

Note that the checkbox is only shown if only tag groups are selected for which the user is an owner or maintainer.

## Related issues


## Proposed changes
- Hide the checkbox initially when the dialog is set up


 
