### PR TITLE
fix: Make media file suffix comparison case insensitive

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -398,8 +398,8 @@ class AnkiHubClient:
         """Whether the media file should be converted to webp once its uploaded to s3."""
         # We don't want to convert svgs, because they don't benefit from the conversion in most cases.
         result = (
-            media_path.suffix in IMAGE_FILE_EXTENSIONS
-            and media_path.suffix not in [".svg", ".webp"]
+            media_path.suffix.lower() in IMAGE_FILE_EXTENSIONS
+            and media_path.suffix.lower() not in [".svg", ".webp"]
         )
         return result
 


### PR DESCRIPTION
There is a bug in `ankihub_client.AnkiHubClient._media_file_should_be_converted_to_webp`: Media file suffixes are compared case-sensitively, with the consequence that the function will always return `False` if the file suffix is in upper case.

## Proposed changes
- Make the suffix comparison case-insensitive
