### PR TITLE
feat: update addon login window

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -134,9 +134,11 @@ class AnkiHubLogin(QWidget):
         self.sign_up_help_text = QLabel(
             'Don\'t have a AnkiHub account? <a href="https://app.ankihub.net/accounts/signup/">Register now</a>'
         )
+        self.sign_up_help_text.setOpenExternalLinks(True)
         self.recover_password_help_text = QLabel(
             '<a href="https://app.ankihub.net/accounts/password/reset/">Forgot password?</a>'
         )
+        self.recover_password_help_text.setOpenExternalLinks(True)
         self.sign_up_and_recover_password_container.addWidget(self.sign_up_help_text)
         self.sign_up_and_recover_password_container.addWidget(
             self.recover_password_help_text

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -619,6 +619,26 @@ class TestAnkiHubLoginDialog:
         assert window.password_box_text.echoMode() == QLineEdit.EchoMode.Password
         assert window.toggle_button.isChecked() is False
 
+    @patch("ankihub.gui.menu.AnkiHubClient.login")
+    def test_forgot_password_and_sign_up_links_are_present(
+        self, login_mock, qtbot: QtBot
+    ):
+        AnkiHubLogin.display_login()
+
+        window: AnkiHubLogin = AnkiHubLogin._window
+
+        assert window.sign_up_help_text.openExternalLinks() is True
+        assert (
+            window.sign_up_help_text.text()
+            == 'Don\'t have a AnkiHub account? <a href="https://app.ankihub.net/accounts/signup/">Register now</a>'
+        )
+
+        assert window.recover_password_help_text.openExternalLinks() is True
+        assert (
+            window.recover_password_help_text.text()
+            == '<a href="https://app.ankihub.net/accounts/password/reset/">Forgot password?</a>'
+        )
+
 
 class TestSuggestionDialog:
     @pytest.mark.parametrize(


### PR DESCRIPTION
# [ANKI-568](https://www.notion.so/ankihub/Improve-the-add-on-log-in-Add-on-c3aa6cb48cb445e1b548e73c2c44d96d?pvs=4)


## Proposed changes
This PR:
- adds a show/hide button at the right of the password input, allowing users to toggle the visibility of the password while they are filling the login form.
- Updates overall layout of the login window
- Add forgot password/sign up links at the bottom of the login window

## How to reproduce
- Open anki, try to log in
- Check that the login window is updated
- Check that the password field has a "show" button on the right
- Type something in the password field, check that it is hidden
- Click the "show" button, it should change to "hide" and now the content of the password field should be readable
- Click the "hide" button, it should change back to "show" and the content of the password field should be hidden again
- Try to open the links at the bottom (forgot password and sign up) and check that they open the correct pages

## Screenshots and videos
![image](https://github.com/ankipalace/ankihub_addon/assets/24229855/db58c356-bcd6-4910-904f-f1de4644f79e)
![image](https://github.com/ankipalace/ankihub_addon/assets/24229855/27f56c58-b781-4588-9304-1596c3dd1c2b)


## Further comments
This does not solve the ANKI-568 completely. It is just one of the requirements.
