### PR TITLE
chore: Remove unused workaround in gui.auto_sync

### DIFF
--- a/ankihub/gui/auto_sync.py
+++ b/ankihub/gui/auto_sync.py
@@ -2,14 +2,13 @@
 Depends on the auto_sync setting in the public config."""
 from concurrent.futures import Future
 from dataclasses import dataclass
-from time import sleep
 from typing import Callable
 
 from anki.hooks import wrap
 from aqt import AnkiQt
 
 from .. import LOGGER
-from ..settings import ANKI_INT_VERSION, config
+from ..settings import config
 from .operations.ankihub_sync import sync_with_ankihub
 from .operations.utils import future_with_exception, future_with_result
 from .threading_utils import rate_limited
@@ -81,9 +80,6 @@ def _on_ankiweb_sync(*args, **kwargs) -> None:
 
         future.result()
 
-    if not auto_sync_state.attempted_startup_sync:
-        _workaround_for_addon_compatibility_on_startup_sync()
-
     try:
         _maybe_sync_with_ankihub(on_done=sync_with_ankiweb)
     except Exception as e:
@@ -109,20 +105,3 @@ def _maybe_sync_with_ankihub(on_done: Callable[[Future], None]) -> None:
     else:
         LOGGER.info("Not syncing with AnkiHub")
         on_done(future_with_result(None))
-
-
-def _workaround_for_addon_compatibility_on_startup_sync() -> None:
-    # AnkiHubSync creates a backup before syncing and creating a backup requires to close
-    # the collection in Anki versions lower than 2.1.50.
-    # When other add-ons try to access the collection while it is closed they will get an error.
-    # Many add-ons are added to the profile_did_open hook so we can wait until they are probably finished
-    # and sync then.
-    # Another way to deal with that is to tell users to set the auto_sync option to "never" and
-    # to sync manually.
-    LOGGER.info("Running _workaround_for_addon_compatibility_on_startup_sync")
-    if ANKI_INT_VERSION < 50:
-        sleep(3)
-
-    LOGGER.info(
-        f"Finished _workaround_for_addon_compatibility_on_startup_sync {ANKI_INT_VERSION=}"
-    )


### PR DESCRIPTION
There is a workaround which is only used on Anki versions below 2.1.50 and we don't support these versions anymore. (Currently the oldest version we support is 2.1.56, see https://github.com/ankipalace/ankihub_addon/blob/7ad2168174fcc87887ec8de680543815f1c0f95c/addon.json#L15
The workaround is not used anymore and we can remove it to make the code cleaner.


## Related issues
[chore: Remove unused workaround in gui.auto_sync](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=369b9c34ce8f428193ab64d52b156c5f&pm=c)

## Proposed changes
- Remove the code for the workaround from `ankihub.gui.autosync`