### PR TITLE
fix: Exclude entries for rescheduling cards when getting review data

### DIFF
--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Tuple
 
 import aqt
+from anki import consts as anki_consts
 
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
@@ -56,7 +57,9 @@ def _get_review_count_for_ah_deck_since(ah_did: uuid.UUID, since: datetime) -> i
         SELECT COUNT(*)
         FROM revlog as r
         JOIN cards as c ON r.cid = c.id
-        WHERE r.id > ? AND c.nid IN ({','.join(map(str, anki_nids))})
+        WHERE r.id > ?
+            AND r.type != {anki_consts.REVLOG_RESCHED}
+            AND c.nid IN ({','.join(map(str, anki_nids))})
         """,
         timestamp_ms,
     )
@@ -73,7 +76,8 @@ def _get_first_and_last_review_datetime_for_ah_deck(
         SELECT MIN(r.id), MAX(r.id)
         FROM revlog as r
         JOIN cards as c ON r.cid = c.id
-        WHERE c.nid IN ({','.join(map(str, anki_nids))})
+        WHERE r.type != {anki_consts.REVLOG_RESCHED}
+            AND c.nid IN ({','.join(map(str, anki_nids))})
         """,
     )
     if row[0] is None:


### PR DESCRIPTION
This PR is based on #788.

We are getting data about reviews the user did from Anki's review log table. The review log table contains an entry for each review the user does. However entries are also added to the table when the user uses the `Set Due Date` context menu action in the Anki browser to reschedule a card (https://docs.ankiweb.net/browsing.html?highlight=set%20due%20date#cards). These entries have a `type` value of `REVLOG_RESCHED` (https://github.com/ankitects/anki/blob/51a10f096940dbd9d86b7a434612e3b8b9469cc7/pylib/anki/consts.py#L92).
We should exclude these entries, because they don't represent reviews. This way the review counts we get will be more accurate.

## Related issues
[fix: Exclude entries for rescheduling cards when getting review data](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7)

## Proposed changes
- Exclude entries from the review log table which have the `REVLOG_RESCHED` type when querying review data.
