### PR TITLE
chore: Fix client tests not working without web app docker container

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -106,7 +106,6 @@ def client_with_server_setup(vcr: VCR, marks: List[str], request: FixtureRequest
         # Restore DB from dump
         result = subprocess.run(
             [
-                "sudo",
                 "docker",
                 "exec",
                 "-i",
@@ -152,7 +151,6 @@ def create_db_dump_if_not_exists() -> None:
     # Check if DB dump exists
     result = subprocess.run(
         [
-            "sudo",
             "docker",
             "exec",
             "-i",
@@ -178,7 +176,6 @@ def create_db_dump_if_not_exists() -> None:
     # Prepare the DB state
     result = subprocess.run(
         [
-            "sudo",
             "docker",
             "exec",
             DJANGO_CONTAINER_NAME,
@@ -199,7 +196,6 @@ def create_db_dump_if_not_exists() -> None:
     # Dump the DB to a file to be able to restore it before each test
     result = subprocess.run(
         [
-            "sudo",
             "docker",
             "exec",
             DB_CONTAINER_NAME,
@@ -223,7 +219,6 @@ def remove_db_dump() -> Generator:
     """Remove the db dump on the start of the session so that it is re-created for each session."""
     result = subprocess.run(
         [
-            "sudo",
             "docker",
             "exec",
             DB_CONTAINER_NAME,


### PR DESCRIPTION
Currently you can't run the client tests (`pytest client`) when you don't have the AnkiHub web app docker container installed. This PR fixes this issue.


## Proposed changes
- Ignore "No such container" docker errors in the `remove_db_dump` pytest fixture
- Remove `sudo` from docker commands so that there is no prompt for providing your password when running tests