### PR TITLE
Chore/add additional setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The devcontainer doesn't include the AnkiHub web app yet, so you have to use it 
 You only have to do this once.
 
 #### Setup pre-commit hooks
-`pre-commit`
+`pre-commit install`
 
 This will ensure linters and code auto-formatters are run before each commit.
 


### PR DESCRIPTION
This adds some additional setup steps I found I needed. I didn't have pre-commit hooks setup initially, so my pull requests occasionally had linting errors. I also didn't have Xvfb installed, so the addon tests were not running in the background. 

## Proposed changes

This adds instructions for setting up pre-commit hooks with git (`pre-commit` should already be installed thanks to earlier steps for setting up a virtual environment and installing dependencies).

This also adds optional instructions for installing Xvfb. I looked into the Mac and Windows situation for pytest-xvfb. It looks like the tests would need to be run through XQuartz on Mac to use Xvfb. I couldn't tell what would be needed for Windows.
It seems like running through Docker would be preferable on Mac and Windows anyway.