### PR TITLE
chore: Disable web debugging in `anki_session` fixture by default to avoid flaky tests

### DIFF
--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -61,6 +61,7 @@ def anki_session(
 ) -> Generator[AnkiSession, None, None]:
     """Overwrites the anki_session fixture from pytest-anki to disable web debugging by default.
     This is done because web debugging is not used in any tests and it sometimes leads to errors.
+    Otherwise the fixture is the same as the original.
     """
     default_parameters = {"enable_web_debugging": False}
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", {})


### PR DESCRIPTION
Tests which use the `pytest-qt` occasionally fail with `pytestqt.exceptions.TimeoutError: Signal match_found() not emitted after 5000`. See for example: https://github.com/ankipalace/ankihub_addon/actions/runs/7351084513/job/20013849472 or https://github.com/ankipalace/ankihub_addon/actions/runs/7360218864/job/20042750237?pr=849.
The error happens in the `anki_session` fixture when it's waiting for web debugging getting set up. We are not using the web debugging feature of `pytest-anki` in any of our tests. 
This PR overwrites the `anki_session` fixture to set `enable_web_debugging=False` by default. By doing this we omit the code which is causing the occasional test failures.

## Related issues
[chore: Disable web debugging in anki_session fixture by default to avoid flaky tests](https://www.notion.so/ankihub/AnkiHub-Planning-7d2bdb8e15034c559bef129adbe163b7?p=0343736d4ec34210b5ebf02a8fefb0c7&pm=c)


## Proposed changes
- Overwrite the `anki_session` fixture to set `enable_web_debugging=False` by default. By doing this we omit the code which is causing the occasional test failures.

## Comments
Here is the related code of `pytest-anki`:
https://github.com/ankipalace/pytest-anki/blob/dfacfecc6bf239c458175656da736826d18a76c5/pytest_anki/_launch.py#L229-L265
Note that by passing `enable_web_debugging=False` we are not waiting for the `match_found` signal anymore:
https://github.com/ankipalace/pytest-anki/blob/dfacfecc6bf239c458175656da736826d18a76c5/pytest_anki/_launch.py#L253-L255