### PR TITLE
chore: Simplify requirements a bit

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,2 @@
 anki==23.10
-aqt==23.10
-
-PyQt5==5.15.5
-PyQtWebEngine==5.15.6
-PyQtWebEngine-Qt5==5.15.2
+aqt[qt5]==23.10


### PR DESCRIPTION
This just simplifies the requirements a bit.

We don't have to specify the versions of `PyQt5`, `PyQtWebEngine` and `PyQtWebEngine` if we just specify a version for `aqt[qt5]` which depends on the required versions for the aforementioned packages.

## Related issues


## Proposed changes


## How to reproduce
