### PR TITLE
[BUILD-99] ref: Remove usages of DBConnection class in db_migrations.py and db.py

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -56,16 +56,14 @@ class _AnkiHubDB:
 
         set_peewee_database(db_path)
 
-        journal_mode = (
-            get_peewee_database().execute_sql("pragma journal_mode=wal").fetchone()[0]
-        )
+        journal_mode = get_peewee_database().pragma("journal_mode", "wal")
         if journal_mode != "wal":
             LOGGER.warning("Failed to set journal_mode=wal")  # pragma: no cover
 
         if self.schema_version() == 0:
             bind_peewee_models()
             create_tables()
-            get_peewee_database().execute_sql("PRAGMA user_version = 11")
+            get_peewee_database().pragma("user_version", 11)
         else:
             from .db_migrations import migrate_ankihub_db
 
@@ -73,7 +71,7 @@ class _AnkiHubDB:
             bind_peewee_models()
 
     def schema_version(self) -> int:
-        return get_peewee_database().execute_sql("PRAGMA user_version;").fetchone()[0]
+        return get_peewee_database().pragma("user_version")
 
     def connection(self) -> DBConnection:
         return DBConnection()

--- a/ankihub/db/db_migrations.py
+++ b/ankihub/db/db_migrations.py
@@ -29,14 +29,14 @@ def migrate_ankihub_db():
             peewee_db.execute_sql(
                 "CREATE INDEX anki_note_id_idx ON notes (anki_note_id)"
             )
-            peewee_db.execute_sql("PRAGMA user_version = 2;")
+            peewee_db.pragma("user_version", 2)
 
     if schema_version < 3:
         with peewee_db.atomic():
             peewee_db.execute_sql("ALTER TABLE notes ADD COLUMN guid TEXT")
             peewee_db.execute_sql("ALTER TABLE notes ADD COLUMN fields TEXT")
             peewee_db.execute_sql("ALTER TABLE notes ADD COLUMN tags TEXT")
-            peewee_db.execute_sql("PRAGMA user_version = 3;")
+            peewee_db.pragma("user_version", 3)
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
         )
@@ -44,7 +44,7 @@ def migrate_ankihub_db():
     if schema_version < 4:
         with peewee_db.atomic():
             peewee_db.execute_sql("ALTER TABLE notes ADD COLUMN last_update_type TEXT")
-            peewee_db.execute_sql("PRAGMA user_version = 4;")
+            peewee_db.pragma("user_version", 4)
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
         )
@@ -54,7 +54,7 @@ def migrate_ankihub_db():
             peewee_db.execute_sql(
                 "CREATE INDEX anki_note_type_id ON notes (anki_note_type_id)"
             )
-            peewee_db.execute_sql("PRAGMA user_version = 5;")
+            peewee_db.pragma("user_version", 5)
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
         )
@@ -95,7 +95,7 @@ def migrate_ankihub_db():
                 "CREATE INDEX anki_note_type_id_idx ON notes (anki_note_type_id)"
             )
 
-            peewee_db.execute_sql("PRAGMA user_version = 6;")
+            peewee_db.pragma("user_version", 6)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
@@ -105,7 +105,7 @@ def migrate_ankihub_db():
         with peewee_db.atomic():
             # Remove newlines from tags
             peewee_db.execute_sql("UPDATE notes SET tags = REPLACE(tags, '\n', '')")
-            peewee_db.execute_sql("PRAGMA user_version = 7;")
+            peewee_db.pragma("user_version", 7)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
@@ -114,7 +114,7 @@ def migrate_ankihub_db():
     if schema_version < 8:
         with peewee_db.atomic():
             _setup_note_types_table(peewee_db=peewee_db)
-            peewee_db.execute_sql("PRAGMA user_version = 8;")
+            peewee_db.pragma("user_version", 8)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
@@ -123,7 +123,7 @@ def migrate_ankihub_db():
     if schema_version < 9:
         with peewee_db.atomic():
             _setup_deck_media_table(peewee_db=peewee_db)
-            peewee_db.execute_sql("PRAGMA user_version = 9;")
+            peewee_db.pragma("user_version", 9)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
@@ -147,7 +147,7 @@ def migrate_ankihub_db():
             )
             peewee_db.execute_sql("DROP TABLE temp_notetypes;")
 
-            peewee_db.execute_sql("PRAGMA user_version = 10;")
+            peewee_db.pragma("user_version", 10)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"
@@ -192,7 +192,7 @@ def migrate_ankihub_db():
                 # Drop the old table
                 get_peewee_database().execute_sql(f"DROP TABLE {temp_table_name}")
 
-            get_peewee_database().execute_sql("PRAGMA user_version = 11;")
+            peewee_db.pragma("user_version", 11)
 
         LOGGER.info(
             f"AnkiHub DB migrated to schema version {ankihub_db.schema_version()}"


### PR DESCRIPTION
We want to remove the DBConnection class. See #881. To do that, we first need to replace its usages in the `db_migrations.py` and `db.py` file.


## Related issues
https://ankihub.atlassian.net/browse/BUILD-99


## Proposed changes
- Replace raw sql queries done via the `DBConnection` class in `db_migrations.py` and `db.py` with raw sql queries done via `get_peewee_database.execute_sql()`.
- Use the [pragma](https://docs.peewee-orm.com/en/latest/peewee/api.html#SqliteDatabase.pragma) method for pragma queries