### PR TITLE
[BUILD-146] fix: Stop deck media download when Anki is closed

### DIFF
--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -26,6 +26,7 @@ class _AnkiHubMediaSync:
         self._download_in_progress = False
         self._amount_uploads_in_progress = 0
         self._status_action: Optional[QAction] = None
+        self._stop_background_threads = False
         # Used to store the Anki profile ID when the media download is started.
         # If the Anki profile changes during the media download, the download is aborted.
         self._anki_profile_id_at_download_start: Optional[str] = None
@@ -85,10 +86,12 @@ class _AnkiHubMediaSync:
     def stop_background_threads(self):
         """Stop all media sync operations."""
         self._client.stop_background_threads()
+        self._stop_background_threads = True
 
     def allow_background_threads(self):
         """Allow background media sync operations to be started after they have been stopped."""
         self._client.allow_background_threads()
+        self._stop_background_threads = False
 
     def refresh_sync_status_text(self):
         """Refresh the status text on the status action."""
@@ -156,6 +159,12 @@ class _AnkiHubMediaSync:
                 if latest_update
                 else chunk.latest_update
             )
+
+            if self._stop_background_threads:
+                LOGGER.info(
+                    "Background threads stopped, aborting download of deck media objects..."
+                )
+                return
 
             if self._anki_profile_id_at_download_start != get_anki_profile_id():
                 LOGGER.info(


### PR DESCRIPTION
When the process of downloading deck media objects is in progress when Anki is closed, it doesn't stop  and goes on in the background. This is a problem because it prevents users from opening Anki until it is done (or they force quit Anki), because you can't have two instances of Anki running at the same time. On MacOs there is also an indication in the bar at the bottom of the screen that Anki is still running. The process of downloading deck media can take minutes if a deck has a lot of media.
This PR fixes this problem by aborting the deck media download when Anki is closed.

## Related issues
https://ankihub.atlassian.net/browse/BUILD-146


## Proposed changes
- Stop downloading deck media objects when Anki is closed. We are already stopping the download of the media files when Anki is closed. Now we will also break from the loop that makes requests to the `/decks/{ah_did}/media/list/` endpoint.


## How to reproduce
- Start the deck installation process for the AnKing deck on production
- When the success dialog for the installation shows up, look at the logs for requests like this:
`INFO 2024-02-01 19:41:51,264 addon_ankihub_client 378199 140355387233856 request: GET https://app.ankihub.net/api/decks/e77aedfe-a636-40e2-8169-2fce2673187e/media/list/?size=2000`
The ad-don will make multiple requests (more than 10) like this to get all the deck media objects.
- Close Anki
- Verify that the requests have stopped and Ankis process has stopped