### PR TITLE
[BUILD-144] fix: Use correct timestamp format for mod values in `AnkiHubDB.update_mod_values_based_on_anki_db`

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -155,8 +155,8 @@ class _AnkiHubDB:
                     "SELECT mod FROM notes WHERE id = ?", note_data.anki_nid
                 )
                 if not mod:
-                    # The format of mod is milliseconds since the epoch.
-                    mod = int(time.time() * 1000)
+                    # The format of mod is seconds since the epoch.
+                    mod = int(time.time())
 
                 AnkiHubNote.update(mod=mod).where(
                     AnkiHubNote.ankihub_note_id == note_data.ah_nid


### PR DESCRIPTION
We are currently using an incorrect format for the modifications timestamps in `AnkiHubDB.update_mod_values_based_on_anki_db`. The timestamp should be the seconds since the epoch and we are using milliseconds since the epoch.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-144


## Proposed changes
- Adjust the function to use the correct timestamp format which are seconds since the epoch. (See the comment for the `mod` column here: https://github.com/ankidroid/Anki-Android/wiki/Database-Structure#notes)