### PR TITLE
[BUILD-145] fix: Don't copy `AnkiHub_Deleted` tag to the ankihub sidebar tree in the Anki browser

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -71,10 +71,10 @@ BULK_SUGGESTION_LIMIT = 2000
 
 # Various special tags used by AnkiHub have this prefix. The sidebar items of tags with this prefix
 # are copied to the AnkiHub tree in the sidebar.
-ANKIHUB_TAGS_PREFIX = "AnkiHub_"
+ANKIHUB_TAGS_PREFIX = "ankihub_"
 
 # These tags are not copied to the AnkiHub tree in the sidebar.
-ANKIHUB_TAGS_EXCLUDED_FROM_TAG_TREE = ["AnkiHub_Deleted"]
+ANKIHUB_TAGS_EXCLUDED_FROM_TAG_TREE = ["ankihub_deleted"]
 
 browser: Optional[Browser] = None
 ankihub_tree_item: Optional[SidebarItem] = None
@@ -722,8 +722,8 @@ def _build_tag_tree_and_copy_ah_tag_items_to_ah_tree(
     ankihub_tag_tree_items = [
         item
         for item in tag_tree.children
-        if item.name.startswith(ANKIHUB_TAGS_PREFIX)
-        and item.name not in ANKIHUB_TAGS_EXCLUDED_FROM_TAG_TREE
+        if item.name.lower().startswith(ANKIHUB_TAGS_PREFIX)
+        and item.name.lower() not in ANKIHUB_TAGS_EXCLUDED_FROM_TAG_TREE
     ]
 
     for ah_tag_tree_item in ankihub_tag_tree_items:


### PR DESCRIPTION
Currently, when there are notes with an `AnkiHub_Deleted` tag (the tag is used to mark notes which were deleted from AnkiHub), there will be an `AnkiHub_Deleted` item in the AnkiHub sidebar tree in the Anki browser:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/a2486218-e505-4b2c-b402-d67b81c3abef" width="400" />
This happens because sidebar tree items where the text starts with `AnkiHub_` are moved to the AnkiHub side bar tree by this function:
https://github.com/ankipalace/ankihub_addon/blob/6f82e757a6863dbbca23d8ca4aaecc951991a8e4/ankihub/gui/browser/browser.py#L689-L693

The `AnkiHub_Deleted` item is not needed, because we already have the `Deleted notes` sidebar tree item. It is better to exclude the `AnkiHub_Deleted` item:
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/5130b5bd-7078-4ffa-b472-8253ebc203dc" width="400" />

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-145

## Proposed changes
- Exclude the `AnkiHub_Deleted` item so that it isn't copied to the AnkiHub side bar tree.