### PR TITLE
[BUILD-162] feat: Use a checkbox for the "behavior on remote note deleted" setting

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -446,36 +446,51 @@ class DeckManagementDialog(QDialog):
     ) -> QBoxLayout:
         deck_config = config.deck_config(selected_ah_did)
 
-        # Setup label
-        self.ankihub_deleted_notes_behavior_label = QLabel(
-            "Remove AnkiHub deleted notes from deck"
+        self.deleted_notes_behavior_tooltip_message = (
+            "Will automatically delete notes<br>"
+            "that you haven't reviewed when<br>"
+            "they are deleted from AnkiHub."
         )
 
-        # Setup and configure the combo box for "Remove AnkiHub deleted notes from deck"
-        self.ankihub_deleted_notes_behavior = QComboBox()
-        self.ankihub_deleted_notes_behavior.insertItems(
-            0, [option.value for option in BehaviorOnRemoteNoteDeleted]
+        # Setup and configure the check box
+        self.ankihub_deleted_notes_behavior_cb = QCheckBox(
+            "Remove notes without review history\nlocally when deleted on AnkiHub"
+        )
+        set_styled_tooltip(
+            self.ankihub_deleted_notes_behavior_cb,
+            self.deleted_notes_behavior_tooltip_message,
+        )
+        self.ankihub_deleted_notes_behavior_cb.setChecked(
+            deck_config.behavior_on_remote_note_deleted
+            == BehaviorOnRemoteNoteDeleted.DELETE_IF_NO_REVIEWS
         )
 
-        if deck_config.behavior_on_remote_note_deleted:
-            self.ankihub_deleted_notes_behavior.setCurrentText(
-                deck_config.behavior_on_remote_note_deleted.value
-            )
+        # Initialize and set up the icon label
+        self.ankihub_deleted_notes_behavior_icon_label = QLabel()
+        self.ankihub_deleted_notes_behavior_icon_label.setPixmap(
+            tooltip_icon().pixmap(16, 16)
+        )
+        set_styled_tooltip(
+            self.ankihub_deleted_notes_behavior_icon_label,
+            self.deleted_notes_behavior_tooltip_message,
+        )
 
         qconnect(
-            self.ankihub_deleted_notes_behavior.currentTextChanged,
+            self.ankihub_deleted_notes_behavior_cb.stateChanged,
             lambda: config.set_ankihub_deleted_notes_behavior(
                 selected_ah_did,
-                BehaviorOnRemoteNoteDeleted(
-                    self.ankihub_deleted_notes_behavior.currentText()
+                (
+                    BehaviorOnRemoteNoteDeleted.DELETE_IF_NO_REVIEWS
+                    if self.ankihub_deleted_notes_behavior_cb.isChecked()
+                    else BehaviorOnRemoteNoteDeleted.NEVER_DELETE
                 ),
             ),
         )
 
-        # Add the label and combo box to the result layout
-        box = QVBoxLayout()
-        box.addWidget(self.ankihub_deleted_notes_behavior_label)
-        box.addWidget(self.ankihub_deleted_notes_behavior)
+        # Add checkbox and icon label to the result layout
+        box = QHBoxLayout()
+        box.addWidget(self.ankihub_deleted_notes_behavior_cb)
+        box.addWidget(self.ankihub_deleted_notes_behavior_icon_label)
 
         return box
 


### PR DESCRIPTION
Currently we are using a combo box for the "behavior on remote note deleted" setting on the **Deck Management** dialog. However the design changed and we should use a checkbox instead. This task makes the necessary changes.

Figma Design: https://www.figma.com/file/xRV8um5NGKGZoXSzagyflK/%F0%9F%91%91--Tasks-2023?type=design&node-id=3671-1697&mode=design&t=OEdvA5Eg0CHIZu0J-0

## Related issues
https://ankihub.atlassian.net/browse/BUILD-162

## Proposed changes
- Use a checkbox instead of the combo box for the setting. Use the copy from the figma design.

## Screenshots
### Design
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/37f6095b-c558-426c-bb01-ab4864dbdabf" width="500" />

### After the changes in this task
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/c0d653e7-6d79-4915-ade8-4d0d948315fa" width="500" />

### Before the changes in this task
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/93f10890-677b-4a0c-a79e-586b357b176d" width="500" />