### PR TITLE
fix: Enable "View Note History" button for deleted notes

### DIFF
--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -333,7 +333,8 @@ def _refresh_buttons(editor: Editor) -> None:
 
         ah_note = cast(AnkiHubNote, ah_note)
         if ah_note.was_deleted():
-            _disable_buttons(editor, all_button_ids)
+            _enable_buttons(editor, [VIEW_NOTE_HISTORY_BTN_ID])
+            _disable_buttons(editor, [SUGGESTION_BTN_ID, VIEW_NOTE_BTN_ID])
             _set_suggestion_button_tooltip(
                 editor,
                 "This note has been deleted from AnkiHub. No new suggestions can be made.",
@@ -348,12 +349,11 @@ def _refresh_buttons(editor: Editor) -> None:
         command = AnkiHubCommands.NEW.value
 
         _enable_buttons(editor, [SUGGESTION_BTN_ID])
+        _disable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
         _set_suggestion_button_tooltip(
             editor,
             _default_suggestion_button_tooltip(),
         )
-
-        _disable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
 
     _set_suggestion_button_label(editor, command)
     editor.ankihub_command = command  # type: ignore


### PR DESCRIPTION
For deleted notes we need to disable the suggestion button and the **View on AnkiHub** button, we can enable the **View Note History** button. (The button links to the closed suggestions for the note on AnkiHub.)

## Related issues



## Proposed changes
- Enable the **View Note History** button for deleted notes


## How to reproduce
- Delete an AnkiHub note
- Sync the deletion
- Open the note in the Anki Browser
- Check that the **View Note History** button is enabled

## Screenshots and videos
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/d0d7e5be-1bb6-471f-9d3a-ee3b98b71446" width="500" />