### PR TITLE
[BUILD-194] fix: Send review data in background instead of blocking UI

### DIFF
--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -73,7 +73,9 @@ def sync_with_ankihub(on_done: Callable[[Future], None]) -> None:
 
 def _on_send_review_data_done(future: Future) -> None:
     if future.exception():
-        LOGGER.error(f"Failed to send review data: {future.exception()}")
+        LOGGER.error(  # pragma: no cover
+            f"Failed to send review data: {future.exception()}"
+        )
     else:
         LOGGER.info("Review data sent successfully")
 


### PR DESCRIPTION
Anki is currently freezing after syncing with AnkiHub if you have many notes in your collection.
This happens because we are querying Anki’s DB for review data and sending it to AnkiHub right after the sync. This should be done in the background to not block the main UI.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-194

## Proposed changes
- Run `send_review_data()` in a background thread.


## Screenshots and videos
How it looks when it freezes (on Windows):

https://github.com/ankipalace/ankihub_addon/assets/31575114/d137f96b-32c9-4593-b4de-c632f9109ad2