### PR TITLE
[BUILD-250] chore: Bump api version to 18.0

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -70,7 +70,7 @@ STAGING_APP_URL = "https://staging.ankihub.net"
 STAGING_API_URL = f"{STAGING_APP_URL}/api"
 STAGING_S3_BUCKET_URL = "https://ankihub-staging.s3.amazonaws.com"
 
-API_VERSION = 17.0
+API_VERSION = 18.0
 
 DECK_UPDATE_PAGE_SIZE = 2000  # seems to work well in terms of speed
 DECK_EXTENSION_UPDATE_PAGE_SIZE = 2000


### PR DESCRIPTION

## Related issues
https://ankihub.atlassian.net/browse/BUILD-250

## Proposed changes
- Bump the API version to 18.0