### PR TITLE
[BUILD-296] Remove the unused tags and empty cards checkbox from the deck install dialog

### DIFF
--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -34,7 +34,6 @@ from .utils import future_with_result, pass_exceptions_to_on_done
 def download_and_install_decks(
     ankihub_dids: List[uuid.UUID],
     on_done: Callable[[Future], None],
-    cleanup: bool = True,
     recommended_deck_settings: bool = True,
 ) -> None:
     """Downloads and installs the given decks in the background."""
@@ -43,7 +42,6 @@ def download_and_install_decks(
         on_done=partial(
             _on_deck_infos_fetched,
             on_done=on_done,
-            cleanup=cleanup,
             recommended_deck_settings=recommended_deck_settings,
         ),
         label="Getting deck information...",
@@ -54,7 +52,6 @@ def download_and_install_decks(
 def _on_deck_infos_fetched(
     future: Future,
     on_done: Callable[[Future], None],
-    cleanup: bool,
     recommended_deck_settings: bool,
 ) -> None:
     decks = future.result()
@@ -78,17 +75,16 @@ def _on_deck_infos_fetched(
             ah_did_to_deletion_behavior=ah_did_to_deletion_behavior,
             recommended_deck_settings=recommended_deck_settings,
         ),
-        on_done=partial(_on_install_done, on_done=on_done, cleanup=cleanup),
+        on_done=partial(_on_install_done, on_done=on_done),
         label="Downloading decks from AnkiHub...",
     )
 
 
 @pass_exceptions_to_on_done
-def _on_install_done(future: Future, on_done: Callable[[Future], None], cleanup: bool):
+def _on_install_done(future: Future, on_done: Callable[[Future], None]):
     import_results: List[AnkiHubImportResult] = future.result()
 
-    if cleanup:
-        _cleanup_after_deck_install()
+    _cleanup_after_deck_install()
 
     # Reset the main window so that the decks are displayed
     aqt.mw.reset()

--- a/ankihub/gui/operations/new_deck_subscriptions.py
+++ b/ankihub/gui/operations/new_deck_subscriptions.py
@@ -25,9 +25,6 @@ def check_and_install_new_deck_subscriptions(
             on_done(future_with_result(None))
             return
 
-        cleanup_cb = QCheckBox("Remove unused tags and empty cards")
-        cleanup_cb.setChecked(True)
-
         recommended_deck_settings_cb = QCheckBox("Use recommended deck settings")
         recommended_deck_settings_cb.setChecked(True)
 
@@ -42,7 +39,6 @@ def check_and_install_new_deck_subscriptions(
             default_button_idx=1,
             callback=lambda button_index: _on_button_clicked(
                 button_index=button_index,
-                cleanup_cb=cleanup_cb,
                 recommended_deck_settings_cb=recommended_deck_settings_cb,
                 decks=decks,
                 on_done=on_done,
@@ -52,16 +48,12 @@ def check_and_install_new_deck_subscriptions(
         confirmation_dialog_layout = confirmation_dialog.content_layout
         confirmation_dialog_layout.insertWidget(
             confirmation_dialog_layout.count() - 2,
-            cleanup_cb,
-        )
-        confirmation_dialog_layout.insertWidget(
-            confirmation_dialog_layout.count() - 1,
             recommended_deck_settings_cb,
         )
         confirmation_dialog.open()
 
         # This prevents the checkbox from being garbage collected too early
-        confirmation_dialog.cleanup_cb = cleanup_cb  # type: ignore
+        confirmation_dialog.recommended_deck_settings_cb = recommended_deck_settings_cb  # type: ignore
     except Exception as e:
         # Using run_on_main prevents exceptions which occur in the callback to be backpropagated to the caller,
         # which is what we want.
@@ -70,7 +62,6 @@ def check_and_install_new_deck_subscriptions(
 
 def _on_button_clicked(
     button_index: Optional[int],
-    cleanup_cb: QCheckBox,
     recommended_deck_settings_cb: QCheckBox,
     decks: List[Deck],
     on_done: Callable[[Future], None],
@@ -86,7 +77,6 @@ def _on_button_clicked(
         download_and_install_decks(
             ah_dids,
             on_done=on_done,
-            cleanup=cleanup_cb.isChecked(),
             recommended_deck_settings=recommended_deck_settings_cb.isChecked(),
         )
     except Exception as e:


### PR DESCRIPTION

<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues

https://ankihub.atlassian.net/browse/BUILD-296

## Proposed changes

This removes the "Remove unused tags and empty cards" checkbox from the deck install dialog and executes its function unconditionally.


## How to reproduce

1. Add a note with a new tag not used in any existing note.
2. Remove the note.
3. Subscribe and install a new AnkiHub deck.
4. Notice the tag is gone from the browser sidebar

## Screenshots and videos

### Before
![image](https://github.com/ankipalace/ankihub_addon/assets/41397710/23f7d87f-2d4b-44a4-aef0-8d445e971f5d)

### After
![image](https://github.com/ankipalace/ankihub_addon/assets/41397710/fec80cba-290d-4b1d-89b0-1e0ffcb6876d)

