### PR TITLE
[BUILD-300] fix: `QtGridLayout` was deleted with `ConfigureDeletedNotesDialog`

### DIFF
--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -62,7 +62,7 @@ def _on_deck_infos_fetched(
     # Ask the user how to handle deleted notes
     deck_id_name_tuples = [(deck.ah_did, deck.name) for deck in decks]
     dialog = ConfigureDeletedNotesDialog(
-        parent=aqt.mw.app.activeWindow(),
+        parent=aqt.mw,
         deck_id_and_name_tuples=deck_id_name_tuples,
     )
     dialog.exec()


### PR DESCRIPTION
## Related issues
https://ankihub.sentry.io/issues/5092776604/?project=6546414&query=id%3A2e05cd5ba1564bafbec29074ec87e4d0&referrer=issue-stream&statsPeriod=14d&stream_index=0

## Proposed changes
- Set `aqt.mw` as the parent of `instead of the result of `aqt.mw.app.activeWindow()` for the `ConfigureDeletedNotesDialog`. The problem was that `activeWindow()` returned the progress dialog, which was closed shortly after. This caused the `ConfigureDeletedNotesDialog` to be closed as well.
