### PR TITLE
chore: Disable peewe debug logging

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -11,6 +11,7 @@ Some differences between data stored in the AnkiHub database and the Anki databa
 - decks, notes and note types can be missing from the Anki database or be modified.
 """
 
+import logging
 import time
 import uuid
 from pathlib import Path
@@ -49,6 +50,11 @@ from .models import (
     set_peewee_database,
 )
 from .utils import TimedLock
+
+# Change the log level of the peewee logger to not show debug messges which show the sql queries.
+# These messages are bad for performance when e.g. inserting a lot entries into the database.
+peewee_logger = logging.getLogger("peewee")
+peewee_logger.setLevel(logging.INFO)
 
 # Chunk size for executing queries in chunks to avoid SQLite's "too many SQL variables" error.
 # The variable limit is 32_766, so the chunk size is set to 30_000 to be safe.


### PR DESCRIPTION
When using Anki 24.04 debug level peewee log messages are shown in the terminal. This is very bad for performance, for example when installing a deck. The logger logs all the queries for inserting notes into the database. I force-quit Anki when trying to install the AnKing deck because it was taking so long. I think that the log messages only cause performance problem when you run Anki in a terminal because the log output has to be shown somewhere when this is the case.

This PR changes the peewee logger level to `INFO` to avoid these performance issues.


## Proposed changes
- Change the log level of the peewee logger to `INFO`