### PR TITLE
chore: Fix GHA hanging on codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,6 @@ jobs:
         run: |
           python -m pip install smokeshow
 
-      - uses: codecov/codecov-action@v1
-
       - name: Upload coverage report with smokeshow
         run: smokeshow upload coverage_html_report
         if: always()


### PR DESCRIPTION
This PR fixes a hanging GHA. 

Example run:
https://github.com/ankipalace/ankihub_addon/actions/runs/8893367152/job/24419744987?pr=943


## Proposed changes
- Remove unnecessary codecov-action usage