### PR TITLE
feat: Show detail message for AnkiHub http errors

### DIFF
--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -1,4 +1,5 @@
 """Error handling and reporting."""
+
 import dataclasses
 import os
 import re
@@ -325,16 +326,17 @@ def _maybe_handle_ankihub_http_error(error: AnkiHubHTTPError) -> bool:
         ):
             check_and_prompt_for_updates_on_main_window()
         return True
-    elif response.status_code == 403:
-        try:
-            response_data = response.json()
-        except JSONDecodeError:
-            return False
-        else:
-            error_message = response_data.get("detail")
-            if error_message:
-                show_error_dialog(error_message, title="Oh no!")
-                return True
+
+    try:
+        response_data = response.json()
+    except JSONDecodeError:
+        return False
+
+    error_message = response_data.get("detail")
+    if error_message:
+        LOGGER.info(f"AnkiHubRequestError was handled: {error_message}")
+        show_error_dialog(error_message, title="Oh no!")
+        return True
 
     return False
 


### PR DESCRIPTION
Previously we were only showing the detail message of responses from the AnkiHub web app if the status code was 401. With this PR, we will show the detail message for all responses that have it, if they are not handled otherwise. 

Previously we were showing the general error dialog for these error responses:
<image src="https://github.com/ankipalace/ankihub_addon/assets/31575114/368e964a-52da-424a-9dcb-878911a17d86" width=600>


Now the detail message is shown (here for a disallowed deck name, see https://github.com/ankipalace/ankihub/pull/2099):
<image src="https://github.com/ankipalace/ankihub_addon/assets/31575114/f36e79e8-8c66-4507-ace5-4e6eef177a40" width=600>