### PR TITLE
[BUILD-392] chore: Skip logging requests for downloading deck assets

### DIFF
--- a/ankihub/addon_ankihub_client.py
+++ b/ankihub/addon_ankihub_client.py
@@ -20,6 +20,11 @@ def logging_hook(response: Response, *args, **kwargs) -> Response:
     method = response.request.method
     body = response.request.body
 
+    if method == "GET" and "s3" in endpoint and "deck_assets" in endpoint:
+        # Don't log the request for downloading deck assets, as this would result in a lot of noise,
+        # because each asset is downloaded separately.
+        return response
+
     body_dict: Optional[Dict] = None
     try:
         body_dict = json.loads(body) if body else None


### PR DESCRIPTION
We are logging each request that the `AnkiHubClient` makes. This results in a huge amount of logs when a user install a deck which has a lot of media, because the download of each media file is logged separately.
This PR fixes that by not logging media downloads. 

The spike is from media downloads:
![image](https://github.com/ankipalace/ankihub_addon/assets/31575114/cc91b157-a9c8-4516-86ab-6decf16ebf31)
https://app.datadoghq.com/logs?query=service%3Aankihub_addon%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1716812411528&to_ts=1716898811528&live=true

# Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-392