### PR TITLE
chore: Don't log private config on every change

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -26,6 +26,7 @@ from aqt.studydeck import StudyDeck
 from aqt.theme import theme_manager
 from aqt.utils import openLink, showInfo, showText, tooltip
 
+from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..gui.operations.deck_creation import create_collaborative_deck
 from ..main.deck_unsubscribtion import unsubscribe_from_deck_and_uninstall
@@ -686,6 +687,9 @@ class DeckManagementDialog(QDialog):
 
     @classmethod
     def display_subscribe_window(cls):
+        LOGGER.info("Showing DeckManagementDialog")
+        config.log_private_config()
+
         if cls._window is None:
             cls._window = cls()
         else:
@@ -694,6 +698,10 @@ class DeckManagementDialog(QDialog):
             cls._window.raise_()
             cls._window.show()
         return cls._window
+
+    def closeEvent(self, event) -> None:
+        super().closeEvent(event)
+        config.log_private_config()
 
 
 class StudyDeckWithoutHelpButton(StudyDeck):

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -41,6 +41,7 @@ def sync_with_ankihub(on_done: Callable[[Future], None]) -> None:
     If a full AnkiWeb sync is already required, sync with AnkiWeb first.
     """
     LOGGER.info("Syncing with AnkiHub...")
+    config.log_private_config()
 
     @pass_exceptions_to_on_done
     def on_sync_status(out: SyncStatus, on_done: Callable[[Future], None]) -> None:
@@ -137,6 +138,7 @@ def _on_sync_done(future: Future, on_done: Callable[[Future], None]) -> None:
         on_done(future_with_result(None))
 
     LOGGER.info("Sync with AnkiHub done.")
+    config.log_private_config()
 
 
 def _on_clear_unused_tags_done(future: Future) -> None:

--- a/ankihub/gui/operations/deck_creation.py
+++ b/ankihub/gui/operations/deck_creation.py
@@ -26,6 +26,7 @@ def create_collaborative_deck() -> None:
     """
 
     LOGGER.info("Creating a new AnkiHub deck...")
+    config.log_private_config()
 
     confirm = DeckCreationConfirmationDialog().run()
     if not confirm:
@@ -141,6 +142,9 @@ def _on_deck_selected(study_deck: StudyDeck) -> None:
             "Link to the deck on AnkiHub:<br>"
             f"<a href={deck_url}>{deck_url}</a>"
         )
+
+        LOGGER.info("Deck creation successful.", deck_name=deck_name)
+        config.log_private_config()
 
     def on_failure(exc: Exception) -> None:
         aqt.mw.progress.finish()

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -230,7 +230,6 @@ class _Config:
                 self._private_config = PrivateConfig()
 
         self._update_private_config()
-        self._log_private_config()
 
     def _load_private_config(self) -> PrivateConfig:
         with open(self._private_config_path) as f:
@@ -248,7 +247,7 @@ class _Config:
         with open(self._private_config_path, "w") as f:
             config_json = self._private_config.to_json()
             f.write(json.dumps(json.loads(config_json), indent=4, sort_keys=True))
-        self._log_private_config()
+        self.log_private_config(log_level=logging.DEBUG)
 
     def load_public_config(self) -> None:
         """For loading the public config from its file (after it has been changed)."""
@@ -348,11 +347,11 @@ class _Config:
         if self.subscriptions_change_hook:
             self.subscriptions_change_hook()
 
-    def _log_private_config(self):
+    def log_private_config(self, log_level=logging.INFO):
         config_copy = deepcopy(self._private_config)
         if config_copy.token:
             config_copy.token = "REDACTED"
-        LOGGER.info("Private config", private_config=config_copy.to_dict())
+        LOGGER.log(log_level, "Private config", private_config=config_copy.to_dict())
 
     def set_home_deck(self, ankihub_did: uuid.UUID, anki_did: DeckId):
         self.deck_config(ankihub_did).anki_id = anki_did


### PR DESCRIPTION
Currently we are logging the private config every time there is a change to it (in `settings._Config._update_private_config()`). This results in a lot of logs. It's in the top 3 most frequent events for the last day (https://app.datadoghq.com/logs?query=service%3Aankihub_addon&cols=&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1716894511119&to_ts=1716980911119&live=true)
<img src="https://github.com/ankipalace/ankihub_addon/assets/31575114/a65df22e-b15d-41bd-a182-254cda38f135" width="400" />
(The second most frequent will get adjusted to log level `DEBUG` here: https://github.com/ankipalace/ankihub_addon/pull/966.)

This PR makes it so the private config is only logged at key moments, like when starting/ending a sync or deck creation and when opening and closing the `DeckManagementDialog`.   

## Related issues



## Proposed changes
