### PR TITLE
[BUILD-439] perf: Prevent Anki being laggy while downloading media

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1282,7 +1282,7 @@ class ThreadLocalSession:
     def __init__(self):
         self.local = threading.local()
 
-    def get(self):
+    def get(self) -> Session:
         if not hasattr(self.local, "session"):
             self.local.session = Session()
         return self.local.session


### PR DESCRIPTION
Some users are experiencing Anki being laggy when the AnkiHub media sync is in progress. 

This PR addresses the problem by:
- re-using `requests.Session` objects
- reducing the `max_workers` argument of the `ThreadPoolExecutor` instances that download and upload media

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-439
https://theanking.slack.com/archives/C03S5DH9HH9/p1717080091231869

## Proposed changes
- Re-use a `requests.Session` thread-locally
- Use this `max_workers` value:
https://github.com/ankipalace/ankihub_addon/blob/bb1b2c9cc55a7aa06f14bfa25682f60a51e96788/ankihub/ankihub_client/ankihub_client.py#L115-L118
This reduces the number of `max_workers` by 3 for most devices when compared to the default setting.
The advantage of this is that the amount of workers is based on the device and the reduction will be relatively large on devices with low cpu counts, but relatively small on devices with high cpu counts.