### PR TITLE
fix: Make scrolling possible in chatbot iframe

### DIFF
--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -155,9 +155,7 @@ class AnkiHubAI {
 
         iframe.style.boxShadow = "10px 10px 40px 0px rgba(0, 0, 0, 0.25)"
 
-        // Hide scrollbar of iframe
         iframe.style.overflow = "hidden"
-        iframe.scrolling = "no"
     }
 
 }


### PR DESCRIPTION
Currently you can't scroll in the chatbot iframe. This PR fixes this.