### PR TITLE
[BUILD-474] Create a upsell dialog on chatbot in the addon

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -28,7 +28,7 @@ from ..feature_flags import feature_flags
 from ..gui.menu import AnkiHubLogin
 from ..settings import ANKING_DECK_ID, config, url_plans_page, url_view_note
 from .operations.scheduling import suspend_notes, unsuspend_notes
-from .utils import LinkButtonParam, show_dialog, using_qt5
+from .utils import show_dialog, using_qt5
 
 VIEW_NOTE_PYCMD = "ankihub_view_note"
 VIEW_NOTE_BUTTON_ID = "ankihub-view-note-button"
@@ -242,14 +242,20 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
         return (True, None)
 
     elif message == ANKIHUB_UPSELL:
+
+        def on_button_clicked(button_index: int) -> None:
+            if button_index == 1:
+                openLink(url_plans_page())
+
         show_dialog(
             text="Upgrade your membership to <b>Premium</b> to access this feature 🌟",
             title="Your trial has ended!",
             buttons=[
                 ("Cancel", aqt.QDialogButtonBox.ButtonRole.RejectRole),
-                LinkButtonParam("Upgrade", url_plans_page()),
+                ("Upgrade", aqt.QDialogButtonBox.ButtonRole.ActionRole),
             ],
             default_button_idx=1,
+            callback=on_button_clicked,
         )
     return handled
 

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -1,6 +1,5 @@
 import inspect
 import uuid
-from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -28,16 +27,10 @@ from aqt.qt import (
     qconnect,
 )
 from aqt.theme import theme_manager
-from aqt.utils import disable_help_button, openLink, tooltip
+from aqt.utils import disable_help_button, tooltip
 
 from .. import LOGGER
 from ..settings import config
-
-
-@dataclass
-class LinkButtonParam:
-    text: str
-    url: str
 
 
 def show_error_dialog(message: str, title: str, *args, **kwargs) -> None:
@@ -334,13 +327,6 @@ class _Dialog(QDialog):
                 button = button_box.addButton(button)
             elif isinstance(button, tuple):
                 button = button_box.addButton(*button)
-            elif isinstance(button, LinkButtonParam):
-                custom_button = QPushButton(button.text)
-                custom_button.clicked.connect(lambda _, url=button.url: openLink(url))
-                button_box.addButton(
-                    custom_button, QDialogButtonBox.ButtonRole.ActionRole
-                )
-                button = custom_button
 
             qconnect(
                 button.clicked,


### PR DESCRIPTION
## Related issues
[BUILD-474](https://ankihub.atlassian.net/browse/BUILD-474)


## Proposed changes
Show up a dialog for users who does not have access to chatbot feature to redirect them to the plans page on webapp.


## How to reproduce

- Turn the `chatbot` feature flag on (addon and webapp)
- Turn the `new_pricing_tier` feature flag on

### User with no access

1. Select any user with a plan lower than Premium
2. Check if the user is not in trial period (user.is_trialing)
3. Go to the addon
4. Select the ANKING deck
5. Click on the robot icon
6. An upsell dialog should appear
7. Click upgrade
8. Check if you were redirected to the plans page

### User with access
1. Select any user with a Premium plan
2. Do the same process above
3. The upsell dialog should not appear and the user should be able to use the chatbot

## Screenshots and videos
![image (12)](https://github.com/ankipalace/ankihub_addon/assets/69124522/96494326-560b-40c0-9596-d649f66c55e1)



[BUILD-474]: https://ankihub.atlassian.net/browse/BUILD-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ