### PR TITLE
Fix non_field_errors not being reported for new note suggestions

### DIFF
--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -226,14 +226,17 @@ def _on_suggestion_dialog_for_single_suggestion_closed(
                 f"Unknown suggestion result: {suggestion_result}"
             )
     else:
-        suggest_new_note(
-            note=note,
-            ankihub_did=ah_did,
-            comment=suggestion_meta.comment,
-            media_upload_cb=media_sync.start_media_upload,
-            auto_accept=suggestion_meta.auto_accept,
-        )
-        show_tooltip("Submitted suggestion to AnkiHub.", parent=parent)
+        try:
+            suggest_new_note(
+                note=note,
+                ankihub_did=ah_did,
+                comment=suggestion_meta.comment,
+                media_upload_cb=media_sync.start_media_upload,
+                auto_accept=suggestion_meta.auto_accept,
+            )
+            show_tooltip("Submitted suggestion to AnkiHub.", parent=parent)
+        except AnkiHubHTTPError as e:
+            _handle_suggestion_error(e, parent)
 
 
 def open_suggestion_dialog_for_bulk_suggestion(


### PR DESCRIPTION
## Proposed changes

New note suggestion errors such as "A deck can't contain multiple notes with the same anki_id" are not being reported. We fixed the issue for change note suggestions in #956 but [we ended up only handling the suggest_note_update call](https://github.com/AnkiHubSoftware/ankihub_addon/pull/956#discussion_r1607065022).

