### PR TITLE
[BUILD-567] fix: Test crashing in GHA

### DIFF
--- a/.github/actions/setup-addon/action.yml
+++ b/.github/actions/setup-addon/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Install Qt
       if: ${{ inputs.install_qt == 'true' }}
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: "5.15.2"
         setup-python: false

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,25 +1,28 @@
 -r base.txt
 
-git+https://github.com/ankipalace/pytest-anki.git
+pyqt5==5.15.5
+pyqtwebengine==5.15.6
 black==22.6.0
 flake8==5.0.4
 mypy==0.971
 coverage==6.5.0
-pytest-cov==4.0.0
 pre-commit==2.20.0
 requests-mock==1.9.3
 types-requests==2.28.9
 urllib3==1.26.14
-pytest-env==0.6.2
 typeguard==2.13.3
 pdbpp==0.10.3
 vcrpy==4.2.0
+pytest==8.2.2
 pytest-vcr==1.0.2
 pytest-qt==4.2.0
-pytest-split==0.8.1
+pytest-split==0.9
 pytest-mock==3.12.0
+pytest-cov==4.0.0
+pytest-env==0.6.2
+pytest-xvfb==2.0.0
+git+https://github.com/ankipalace/pytest-anki.git
 factory-boy==3.2.1
 types-factory-boy==0.3.1
-pytest-xvfb==2.0.0
 faker==19.12.0
 approvaltests==12.2.0


### PR DESCRIPTION
Tests were crashing in GHAs with this message:
```
running the test CRASHED with signal 6
```
See https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/10273257966/job/28427314731?pr=996

This PR fixes the problem by specifying version of these libraries in `dev.txt`:
```
pyqt5==5.15.5
pyqtwebengine==5.15.6
```

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-567