### PR TITLE
[BUILD-575] feat: Show open-in-browser button in card preview of flashcard selector

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -10,7 +10,7 @@ from aqt.gui_hooks import profile_did_open, profile_will_close
 from . import LOGGER
 from .db import ankihub_db
 from .feature_flags import setup_feature_flags_in_background
-from .gui import browser, deckbrowser, editor, progress, reviewer
+from .gui import browser, deckbrowser, editor, js_message_handling, progress, reviewer
 from .gui.addons import setup_addons
 from .gui.auto_sync import setup_auto_sync
 from .gui.config_dialog import setup_config_dialog_manager
@@ -130,6 +130,9 @@ def _general_setup():
 
     setup_addons()
     LOGGER.info("Set up addons.")
+
+    js_message_handling.setup()
+    LOGGER.info("Set up JavaScript message handling.")
 
     setup_config_dialog_manager()
     LOGGER.info("Set up config.")

--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -1,0 +1,133 @@
+"""Handles messages sent from JavaScript code which are useful in multiple places
+(instead of being specific to a single module)."""
+import json
+import uuid
+from typing import Any, Dict, List, Tuple
+
+import aqt
+from anki.consts import QUEUE_TYPE_SUSPENDED
+from anki.utils import ids2str
+from aqt.browser import Browser
+from aqt.gui_hooks import webview_did_receive_js_message
+from aqt.utils import openLink, tooltip
+
+from ..db import ankihub_db
+from ..settings import url_plans_page, url_view_note
+from .operations.scheduling import suspend_notes, unsuspend_notes
+from .utils import show_dialog
+
+VIEW_NOTE_PYCMD = "ankihub_view_note"
+VIEW_NOTE_BUTTON_ID = "ankihub-view-note-button"
+
+OPEN_BROWSER_PYCMD = "ankihub_open_browser"
+UNSUSPEND_NOTES_PYCMD = "ankihub_unsuspend_notes"
+SUSPEND_NOTES_PYCMD = "ankihub_suspend_notes"
+GET_NOTE_SUSPENSION_STATES_PYCMD = "ankihub_get_note_suspension_states"
+ANKIHUB_UPSELL = "ankihub_ai_upsell"
+
+
+def setup():
+    webview_did_receive_js_message.append(_on_js_message)
+
+
+def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any:
+    """Handles messages sent from JavaScript code."""
+    if message == VIEW_NOTE_PYCMD:
+        anki_nid = context.reviewer.card.nid
+        ankihub_nid = ankihub_db.ankihub_nid_for_anki_nid(anki_nid)
+        view_note_url = f"{url_view_note()}{ankihub_nid}"
+        openLink(view_note_url)
+
+        return (True, None)
+    elif message.startswith(OPEN_BROWSER_PYCMD):
+        kwargs = _parse_js_message_kwargs(message)
+        ah_nids = kwargs.get("noteIds", [])
+
+        browser: Browser = aqt.dialogs.open("Browser", aqt.mw)
+
+        if ah_nids:
+            search_string = f"ankihub_id:{' or ankihub_id:'.join(ah_nids)}"
+            browser.search_for(search_string)
+
+        return (True, None)
+    elif message.startswith(SUSPEND_NOTES_PYCMD):
+        kwargs = _parse_js_message_kwargs(message)
+        ah_nids = kwargs.get("noteIds")
+        if ah_nids:
+            suspend_notes(
+                ah_nids,
+                on_done=lambda: tooltip("AnkiHub: Note(s) suspended", parent=aqt.mw),
+            )
+
+        return (True, None)
+    elif message.startswith(UNSUSPEND_NOTES_PYCMD):
+        kwargs = _parse_js_message_kwargs(message)
+        ah_nids = kwargs.get("noteIds")
+        if ah_nids:
+            unsuspend_notes(
+                ah_nids,
+                on_done=lambda: tooltip("AnkiHub: Note(s) unsuspended", parent=aqt.mw),
+            )
+    elif message.startswith(GET_NOTE_SUSPENSION_STATES_PYCMD):
+        kwargs = _parse_js_message_kwargs(message)
+        ah_nids = kwargs.get("noteIds")
+        note_suspension_states = _get_note_suspension_states(ah_nids)
+        context.web.eval(
+            f"ankihubAI.sendNoteSuspensionStates({json.dumps(note_suspension_states)})"
+        )
+
+        return (True, None)
+    elif message == ANKIHUB_UPSELL:
+
+        def on_button_clicked(button_index: int) -> None:
+            if button_index == 1:
+                openLink(url_plans_page())
+
+        show_dialog(
+            text="Upgrade your membership to <b>Premium</b> to access this feature 🌟",
+            title="Your trial has ended!",
+            buttons=[
+                ("Cancel", aqt.QDialogButtonBox.ButtonRole.RejectRole),
+                ("Upgrade", aqt.QDialogButtonBox.ButtonRole.ActionRole),
+            ],
+            default_button_idx=1,
+            callback=on_button_clicked,
+        )
+    return handled
+
+
+def _parse_js_message_kwargs(message: str) -> Dict[str, Any]:
+    if " " in message:
+        _, kwargs_json = message.split(" ", maxsplit=1)
+        return json.loads(kwargs_json)
+    else:
+        return {}
+
+
+def _get_note_suspension_states(ah_nids: List[str]) -> Dict[str, bool]:
+    """Returns a mapping of AnkiHub note IDs (as strings) to whether they are suspended or not.
+    A note is considered unsuspended if at least one of its cards is unsuspended.
+    If the note is not found in Anki, it will be missing from the returned mapping."""
+    ah_nids_to_anki_nids = ankihub_db.ankihub_nids_to_anki_nids(
+        [uuid.UUID(ah_nid) for ah_nid in ah_nids]
+    )
+    ah_nids_to_anki_nids = {
+        ah_nid: anki_nid
+        for ah_nid, anki_nid in ah_nids_to_anki_nids.items()
+        if anki_nid
+    }
+    if not ah_nids_to_anki_nids:
+        return {}
+
+    unsuspended_anki_nids = set(
+        aqt.mw.col.db.list(
+            f"""
+            SELECT DISTINCT nid FROM cards
+            WHERE nid IN {ids2str(ah_nids_to_anki_nids.values())} AND queue != {QUEUE_TYPE_SUSPENDED}
+            """
+        )
+    )
+    return {
+        str(ah_nid): anki_nid not in unsuspended_anki_nids
+        for ah_nid, anki_nid in ah_nids_to_anki_nids.items()
+    }

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -1,48 +1,36 @@
 """Modifies Anki's reviewer UI (aqt.reviewer)."""
 
-import json
-import uuid
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List, Tuple
+from typing import Any, Tuple
 
 import aqt
 from anki.cards import Card
-from anki.consts import QUEUE_TYPE_SUSPENDED
-from anki.utils import ids2str
-from aqt.browser import Browser
 from aqt.gui_hooks import (
     reviewer_did_show_answer,
     reviewer_did_show_question,
     webview_did_receive_js_message,
     webview_will_set_content,
 )
-from aqt.reviewer import Reviewer, ReviewerBottomBar
+from aqt.reviewer import Reviewer
 from aqt.theme import theme_manager
-from aqt.utils import openLink, tooltip
 from aqt.webview import WebContent
 from jinja2 import Template
 
 from ..db import ankihub_db
 from ..feature_flags import feature_flags
 from ..gui.menu import AnkiHubLogin
-from ..settings import ANKING_DECK_ID, config, url_plans_page, url_view_note
-from .operations.scheduling import suspend_notes, unsuspend_notes
-from .utils import show_dialog, using_qt5
+from ..settings import ANKING_DECK_ID, config
+from .js_message_handling import VIEW_NOTE_PYCMD
+from .utils import using_qt5
 
-VIEW_NOTE_PYCMD = "ankihub_view_note"
 VIEW_NOTE_BUTTON_ID = "ankihub-view-note-button"
 
 ANKIHUB_AI_JS_PATH = Path(__file__).parent / "web/ankihub_ai.js"
 REMOVE_ANKING_BUTTON_JS_PATH = Path(__file__).parent / "web/remove_anking_button.js"
 
 AI_INVALID_AUTH_TOKEN_PYCMD = "ankihub_ai_invalid_auth_token"
-OPEN_BROWSER_PYCMD = "ankihub_open_browser"
-UNSUSPEND_NOTES_PYCMD = "ankihub_unsuspend_notes"
-SUSPEND_NOTES_PYCMD = "ankihub_suspend_notes"
-GET_NOTE_SUSPENSION_STATES_PYCMD = "ankihub_get_note_suspension_states"
 CLOSE_ANKIHUB_CHATBOT_PYCMD = "ankihub_close_chatbot"
-ANKIHUB_UPSELL = "ankihub_ai_upsell"
 
 
 def setup():
@@ -183,115 +171,15 @@ def _wrap_with_ankihubAI_check(js: str) -> str:
 
 def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any:
     """Handles messages sent from JavaScript code."""
-    if message == VIEW_NOTE_PYCMD:
-        assert isinstance(context, ReviewerBottomBar)
-        anki_nid = context.reviewer.card.nid
-        ankihub_nid = ankihub_db.ankihub_nid_for_anki_nid(anki_nid)
-        view_note_url = f"{url_view_note()}{ankihub_nid}"
-        openLink(view_note_url)
-
-        return (True, None)
-    elif message == AI_INVALID_AUTH_TOKEN_PYCMD:
+    if message == AI_INVALID_AUTH_TOKEN_PYCMD:
         assert isinstance(context, Reviewer)
         AnkiHubLogin.display_login()
 
         return (True, None)
-    elif message.startswith(OPEN_BROWSER_PYCMD):
-        kwargs = _parse_js_message_kwargs(message)
-        ah_nids = kwargs.get("noteIds", [])
-
-        browser: Browser = aqt.dialogs.open("Browser", aqt.mw)
-
-        if ah_nids:
-            search_string = f"ankihub_id:{' or ankihub_id:'.join(ah_nids)}"
-            browser.search_for(search_string)
-
-        return (True, None)
-    elif message.startswith(SUSPEND_NOTES_PYCMD):
-        kwargs = _parse_js_message_kwargs(message)
-        ah_nids = kwargs.get("noteIds")
-        if ah_nids:
-            suspend_notes(
-                ah_nids,
-                on_done=lambda: tooltip("AnkiHub: Note(s) suspended", parent=aqt.mw),
-            )
-
-        return (True, None)
-    elif message.startswith(UNSUSPEND_NOTES_PYCMD):
-        kwargs = _parse_js_message_kwargs(message)
-        ah_nids = kwargs.get("noteIds")
-        if ah_nids:
-            unsuspend_notes(
-                ah_nids,
-                on_done=lambda: tooltip("AnkiHub: Note(s) unsuspended", parent=aqt.mw),
-            )
     elif message == CLOSE_ANKIHUB_CHATBOT_PYCMD:
         assert isinstance(context, Reviewer), context
         js = _wrap_with_ankihubAI_check("ankihubAI.hideIframe();")
         context.web.eval(js)
 
         return (True, None)
-    elif message.startswith(GET_NOTE_SUSPENSION_STATES_PYCMD):
-        kwargs = _parse_js_message_kwargs(message)
-        ah_nids = kwargs.get("noteIds")
-        note_suspension_states = _get_note_suspension_states(ah_nids)
-        context.web.eval(
-            f"ankihubAI.sendNoteSuspensionStates({json.dumps(note_suspension_states)})"
-        )
-
-        return (True, None)
-
-    elif message == ANKIHUB_UPSELL:
-
-        def on_button_clicked(button_index: int) -> None:
-            if button_index == 1:
-                openLink(url_plans_page())
-
-        show_dialog(
-            text="Upgrade your membership to <b>Premium</b> to access this feature 🌟",
-            title="Your trial has ended!",
-            buttons=[
-                ("Cancel", aqt.QDialogButtonBox.ButtonRole.RejectRole),
-                ("Upgrade", aqt.QDialogButtonBox.ButtonRole.ActionRole),
-            ],
-            default_button_idx=1,
-            callback=on_button_clicked,
-        )
     return handled
-
-
-def _parse_js_message_kwargs(message: str) -> Dict[str, Any]:
-    if " " in message:
-        _, kwargs_json = message.split(" ", maxsplit=1)
-        return json.loads(kwargs_json)
-    else:
-        return {}
-
-
-def _get_note_suspension_states(ah_nids: List[str]) -> Dict[str, bool]:
-    """Returns a mapping of AnkiHub note IDs (as strings) to whether they are suspended or not.
-    A note is considered unsuspended if at least one of its cards is unsuspended.
-    If the note is not found in Anki, it will be missing from the returned mapping."""
-    ah_nids_to_anki_nids = ankihub_db.ankihub_nids_to_anki_nids(
-        [uuid.UUID(ah_nid) for ah_nid in ah_nids]
-    )
-    ah_nids_to_anki_nids = {
-        ah_nid: anki_nid
-        for ah_nid, anki_nid in ah_nids_to_anki_nids.items()
-        if anki_nid
-    }
-    if not ah_nids_to_anki_nids:
-        return {}
-
-    unsuspended_anki_nids = set(
-        aqt.mw.col.db.list(
-            f"""
-            SELECT DISTINCT nid FROM cards
-            WHERE nid IN {ids2str(ah_nids_to_anki_nids.values())} AND queue != {QUEUE_TYPE_SUSPENDED}
-            """
-        )
-    )
-    return {
-        str(ah_nid): anki_nid not in unsuspended_anki_nids
-        for ah_nid, anki_nid in ah_nids_to_anki_nids.items()
-    }

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -841,7 +841,7 @@ url_flashcard_selector = (
     lambda deck_id: f"{config.app_url}/ai/{deck_id}/flashcard-selector"
 )  # noqa: E731
 url_flashcard_selector_embed = (
-    lambda deck_id: f"{config.app_url}/ai/{deck_id}/flashcard-selector-embed"
+    lambda deck_id: f"{config.app_url}/ai/{deck_id}/flashcard-selector-embed?is_on_anki=true"
 )  # noqa: E731
 url_plans_page = lambda: f"{config.app_url}/memberships/plans/"  # noqa: E731
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -152,6 +152,12 @@ from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import SUGGESTION_BTN_ID
 from ankihub.gui.errors import upload_logs_and_data_in_background
 from ankihub.gui.exceptions import DeckDownloadAndInstallError, RemoteDeckNotFoundError
+from ankihub.gui.js_message_handling import (
+    GET_NOTE_SUSPENSION_STATES_PYCMD,
+    OPEN_BROWSER_PYCMD,
+    SUSPEND_NOTES_PYCMD,
+    UNSUSPEND_NOTES_PYCMD,
+)
 from ankihub.gui.media_sync import media_sync
 from ankihub.gui.menu import AnkiHubLogin, menu_state
 from ankihub.gui.operations import ankihub_sync
@@ -163,13 +169,7 @@ from ankihub.gui.operations.new_deck_subscriptions import (
 )
 from ankihub.gui.operations.utils import future_with_result
 from ankihub.gui.optional_tag_suggestion_dialog import OptionalTagsSuggestionDialog
-from ankihub.gui.reviewer import (
-    CLOSE_ANKIHUB_CHATBOT_PYCMD,
-    GET_NOTE_SUSPENSION_STATES_PYCMD,
-    OPEN_BROWSER_PYCMD,
-    SUSPEND_NOTES_PYCMD,
-    UNSUSPEND_NOTES_PYCMD,
-)
+from ankihub.gui.reviewer import CLOSE_ANKIHUB_CHATBOT_PYCMD
 from ankihub.gui.suggestion_dialog import SuggestionDialog
 from ankihub.main.deck_creation import create_ankihub_deck, modify_note_type
 from ankihub.main.deck_unsubscribtion import uninstall_deck


### PR DESCRIPTION
In the card preview add a **Copy Note ID** button when shown on the AnkiHub Webapp and a **Open in browser** button when shown on Anki Desktop.

This is the addon-side of the task. This is the web app PR: https://github.com/AnkiHubSoftware/ankihub/pull/2260


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-575


## Proposed changes
- Add `is_on_anki=True` query argument to flashcard selector url in `settings.py`
- ref: Move js/pycmd message handling code from `reviewer.py` to `js_message_handling.py`
  - The reason is that the `OPEN_BROWSER_PYCMD` is now used for the flashcard selector as well, and not just in the reviewer. So it's better to move it to a separate module. Other pycmd code which could also be useful in multiple contexts was also moved to `js_message_handling.py`.


## How to reproduce
- Make sure that you have the `show_flashcards_selector_button` feature flag active
- Set up an AnkiHub deck with embeddings (generated using the `generate_vector_embeddings_for_decks.py` script) and a tag tree (generated using the `save_deck_tags_tree.py` script).
- Install the deck via the add-on
- Change `ANKING_DECK_ID` in `settings.py` to the deck id of the deck
- Open Anki, there should be a **Select flashcards** button next to the deck
- Open the flashcard selector, open the text search tab, search for something, open the card preview
- There should be a **Open in Browser** button on the card preview
- When you click the button the card should be opened in the Anki browser
- Also check for other search types

## Screenshots and videos
<img src="https://github.com/user-attachments/assets/80d841c7-654e-4421-afaf-36ef0d2778c0" width="700" />
