### PR TITLE
[BUILD-589] fix: Handle auth failure in flashcard selector

### DIFF
--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -141,11 +141,12 @@ class AnkiHubWebViewDialog(QDialog):
         qconnect(self.web.loadFinished, self._on_web_load_finished)
 
     def _on_web_load_finished(self, ok: bool) -> None:
+        self._handle_auth_failure_if_needed()
+
         if not ok:
             LOGGER.error("Failed to load page.")  # pragma: no cover
             return  # pragma: no cover
 
-        self._handle_auth_failure_if_needed()
         self._adjust_web_styling()
         self._on_successful_page_load()
 


### PR DESCRIPTION
When you open the flashcard selector and the token is not (longer) valid, the flashcard selector should close and the login dialog should open. 
However, currently this doesn't happen and this window stays open: 
<img src="https://github.com/user-attachments/assets/4a03fce0-6fc5-4c7a-915a-8113432f33c8" width="600" />

This PR fixes this.

## Related issues


## Proposed changes
- Move the `_handle_auth_failure_if_needed` call