### PR TITLE
[BUILD-593] feat: Tweak flashcard selector to not hide behind parent window

### DIFF
--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -27,7 +27,7 @@ from .utils import using_qt5
 
 class AlwaysOnTopOfParentDialog(QDialog):
     """A dialog that is always on top of its parent window. This is useful on MacOS, where we had issues
-    with dialogs hding behind the parent window."""
+    with dialogs hiding behind the parent window."""
 
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -4,13 +4,17 @@ from typing import Any, Optional, cast
 from anki.utils import is_mac
 from aqt.gui_hooks import theme_did_change
 from aqt.qt import (
+    QCloseEvent,
     QColor,
     QDialog,
+    QEvent,
     QHBoxLayout,
+    QObject,
     QPushButton,
     QUrl,
     QVBoxLayout,
     QWebEngineUrlRequestInterceptor,
+    QWidget,
     qconnect,
 )
 from aqt.utils import openLink
@@ -21,7 +25,28 @@ from ..settings import config
 from .utils import using_qt5
 
 
-class AnkiHubWebViewDialog(QDialog):
+class AlwaysOnTopOfParentDialog(QDialog):
+    """A dialog that is always on top of its parent window. This is useful on MacOS, where we had issues
+    with dialogs hding behind the parent window."""
+
+    def __init__(self, parent: QWidget = None) -> None:
+        super().__init__(parent)
+        if parent:
+            parent.installEventFilter(self)
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if watched == self.parent() and event.type() == QEvent.Type.WindowActivate:
+            self.raise_()
+            self.activateWindow()
+        return super().eventFilter(watched, event)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        if self.parent():
+            self.parent().removeEventFilter(self)
+        super().closeEvent(event)
+
+
+class AnkiHubWebViewDialog(AlwaysOnTopOfParentDialog):
     """A dialog that displays a web view. The purpose is to show an AnkiHub web app page.
     This class handles setting up the web view, loading the page, styling and authentication.
     """


### PR DESCRIPTION
On MacOs, the flashcard selector dialog was sometimes hiding behind the main Anki window. This task fixes this.

Addresses this QA feedback: https://ankihub.atlassian.net/browse/BUILD-477?focusedCommentId=11355

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-593


## Proposed changes
- Raise and activate the flashcard selector dialog when its parent window (main Anki dialog) gets activated.
  - I tried other solutions, but this is tricky to solve on MacOs (see e.g. https://bugreports.qt.io/browse/QTBUG-56829) and this solution works well enough according to QA feedback. 
