### PR TITLE
[BUILD-621] chore: Make get_note_suspension_states available from flashcard selector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           install_qt: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Run coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_addon_${{ matrix.anki_package_version }}
-          path: .coverage
+          path: coverage.xml
 
 
   test-client:
@@ -110,6 +110,7 @@ jobs:
         with:
           name: coverage_client_${{ matrix.group }}
           path: .coverage
+          include-hidden-files: true
 
 
   coverage-and-static-checks:
@@ -133,7 +134,7 @@ jobs:
 
       - name: Run coverage
         run: |
-          coverage combine coverage*/.coverage*
+          coverage combine coverage_*/.coverage
           coverage html --fail-under=76
 
       - name: Install smokeshow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: coverage_addon_${{ matrix.anki_package_version }}
           path: coverage.xml
+          include-hidden-files: true
 
 
   test-client:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_addon_${{ matrix.anki_package_version }}
-          path: coverage.xml
+          path: .coverage
           include-hidden-files: true
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             --splits 2 --group ${{ matrix.group }} --durations-path=tests/.test_durations
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_client_${{ matrix.group }}
           path: .coverage
@@ -164,7 +164,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
       - name: Archive .ankiaddon
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ankihub_addon_${{ github.sha }}
           path: ankihub.ankiaddon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           pytest ./tests/addon -n 1 -m performance --cov-report=xml --cov-append
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_addon_${{ matrix.anki_package_version }}
           path: .coverage

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -120,13 +120,6 @@ class AnkiHubAI {
         this.knoxToken = token;
     }
 
-    sendNoteSuspensionStates(noteSuspensionStates) {
-        const message = {
-            noteSuspensionStates: noteSuspensionStates
-        }
-        this.iframe.contentWindow.postMessage(message, this.appUrl);
-    }
-
     maybeUpdateIframeSrc() {
         if (this.noteIdOfChatbot === this.noteIdOfReviewerCard) {
             // No need to reload the iframe.

--- a/ankihub/gui/web/post_message_to_ankihub_js.js
+++ b/ankihub/gui/web/post_message_to_ankihub_js.js
@@ -1,0 +1,11 @@
+(function () {
+    const appUrl = "{{ APP_URL }}";
+    const messageJson = `{{ MESSAGE_JSON }}`;
+
+    const message = JSON.parse(messageJson);
+    if (typeof window.ankihubAI !== 'undefined') {
+        window.ankihubAI.iframe.contentWindow.postMessage(message, appUrl);
+    } else {
+        window.postMessage(message, appUrl);
+    }
+})();

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -84,6 +84,10 @@ class AnkiHubWebViewDialog(AlwaysOnTopOfParentDialog):
         self.web.page().profile().setUrlRequestInterceptor(self.interceptor)
         self.web.page().setBackgroundColor(QColor("white"))
 
+        # Set the context to self so that self gets passed as context to the webview_did_receive_js_message hook
+        # when a pycmd is called from the web view.
+        self.web.set_bridge_command(func=self.web.defaultOnBridgeCmd, context=self)
+
         # Set the background color of the web view back to white when Anki's theme changes it to dark
         theme_did_change.append(
             lambda: self.web.page().setBackgroundColor(QColor("white"))

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -60,7 +60,9 @@ PRIVATE_CONFIG_FILENAME = ".private_config.json"
 PROFILE_ID_FIELD_NAME = "ankihub_id"
 
 # Id of the AnKing Overhaul deck
-ANKING_DECK_ID = uuid.UUID("e77aedfe-a636-40e2-8169-2fce2673187e")
+ANKING_DECK_ID = uuid.UUID(
+    os.environ.get("ANKING_DECK_ID", "e77aedfe-a636-40e2-8169-2fce2673187e")
+)
 TAG_FOR_INSTRUCTION_NOTES = "AnkiHub_Instructions"
 
 # Only used for configuring the logger, a structlog logger is used for logging.


### PR DESCRIPTION
Getting note suspension states from Anki when on an AnkiHub web page is currently only available from the AnkiHub AI chatbot iframe. This task makes it also available from the flashcard selector webview.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-621

## Proposed changes
- Post the note suspension states response message...
   - to the chatbot iframe if it exists in the context
   - to the current window otherwise
- Make `ANKING_DECK_ID` configurable using env var
- Bump GHA upload-artifact and download-artifact to version 4 because the previous version got deprecated

## How to reproduce
See the how-to-reproduce-section here: https://github.com/AnkiHubSoftware/ankihub/pull/2312
