### PR TITLE
[BUILD-625] feat: Change ankihub AI icon and add tooltip

### DIFF
--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -88,9 +88,11 @@ class AnkiHubAI {
         document.body.appendChild(button);
 
         const tooltip = document.createElement("div");
+        tooltip.id = "ankihub-ai-tooltip";
         tooltip.innerHTML = "Learn more about this flashcard topic<br>or explore related cards.";
 
         const tooltipArrow = document.createElement("div");
+        tooltipArrow.id = "ankihub-ai-tooltip-arrow";
         tooltip.appendChild(tooltipArrow);
 
         this.setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow);
@@ -111,16 +113,11 @@ class AnkiHubAI {
     }
 
     setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
-        const tooltipBackgroundColor = "#d1d5db";
-        const tooltipColor = "black";
-
         tooltip.style.position = "absolute";
         tooltip.style.bottom = "13px";
         tooltip.style.right = "98px";
         tooltip.style.zIndex = "1000";
-        tooltip.style.backgroundColor = tooltipBackgroundColor;
         tooltip.style.fontSize = "medium";
-        tooltip.style.color = tooltipColor;
         tooltip.style.borderRadius = "5px";
         tooltip.style.textAlign = "center";
         tooltip.style.padding = "10px";
@@ -132,9 +129,38 @@ class AnkiHubAI {
         tooltipArrow.style.marginTop = "-4px";
         tooltipArrow.style.width = "0";
         tooltipArrow.style.height = "0";
-        tooltipArrow.style.borderLeft = `6px solid ${tooltipBackgroundColor}`;
+        tooltipArrow.style.borderLeft = "6px solid";
         tooltipArrow.style.borderTop = "6px solid transparent";
         tooltipArrow.style.borderBottom = "6px solid transparent";
+
+        const style = document.createElement("style");
+        style.innerHTML = `
+            :root {
+                --neutral-200: #e5e5e5;
+                --neutral-800: #1f2937;
+            }
+
+            #ankihub-ai-tooltip {
+                background-color: var(--neutral-800);
+                color: white;
+            }
+
+            .night-mode #ankihub-ai-tooltip {
+                background-color: var(--neutral-200);
+                color: black;
+            }
+
+            #ankihub-ai-tooltip-arrow {
+                border-color: var(--neutral-800);
+                color: var(--neutral-800);
+            }
+
+            .night-mode #ankihub-ai-tooltip-arrow {
+                border-color: var(--neutral-200);
+                color: var(--neutral-200);
+            }
+        `;
+        document.head.appendChild(style);
     }
 
     showTooltip() {

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -115,7 +115,7 @@ class AnkiHubAI {
     setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
         tooltip.style.position = "absolute";
         tooltip.style.bottom = "13px";
-        tooltip.style.right = "98px";
+        tooltip.style.right = "93px";
         tooltip.style.zIndex = "1000";
         tooltip.style.fontSize = "medium";
         tooltip.style.borderRadius = "5px";

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -225,9 +225,12 @@ class AnkiHubAI {
     setButtonStyles(button) {
         button.style.width = "40px";
         button.style.height = "40px";
+        button.style.boxSizing = "content-box";
+        button.style.padding = "8px 10px 8px 10px";
+        button.style.margin = "0px 4px 0px 4px";
 
         button.style.position = "fixed";
-        button.style.bottom = "0px";
+        button.style.bottom = "13px";
         button.style.right = "15px";
         button.style.zIndex = "9999";
 

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -18,7 +18,7 @@ class AnkiHubAI {
 
     setup() {
         this.iframe = this.setupIframe();
-        this.button = this.setupIFrameToggleButton();
+        [this.button, this.tooltip] = this.setupIFrameToggleButton();
 
         this.setupMessageListener();
         let updateIframeHeight = this.updateIframeHeight
@@ -79,8 +79,10 @@ class AnkiHubAI {
             if (!this.iframeVisible) {
                 this.maybeUpdateIframeSrc();
                 this.showIframe();
+                this.hideTooltip();
             } else {
                 this.hideIframe();
+                this.showTooltip();
             }
         };
         document.body.appendChild(button);
@@ -93,8 +95,10 @@ class AnkiHubAI {
 
         this.setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow);
 
-        button.addEventListener("mouseover", function () {
-            tooltip.style.display = "block";
+        button.addEventListener("mouseover", () => {
+            if (this.iframe.style.display === "none") {
+                tooltip.style.display = "block";
+            }
         });
 
         button.addEventListener("mouseout", function () {
@@ -103,7 +107,7 @@ class AnkiHubAI {
 
         document.body.appendChild(tooltip);
 
-        return button;
+        return [button, tooltip];
     }
 
     setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
@@ -133,6 +137,13 @@ class AnkiHubAI {
         tooltipArrow.style.borderBottom = "6px solid transparent";
     }
 
+    showTooltip() {
+        this.tooltip.style.display = "block";
+    }
+
+    hideTooltip() {
+        this.tooltip.style.display = "none";
+    }
 
     invalidateSessionAndPromptToLogin() {
         this.authenticated = false;

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -24,7 +24,7 @@ class AnkiHubAI {
         let updateIframeHeight = this.updateIframeHeight
         let updateIframeWidth = this.updateIframeWidth
         let iframe = this.iframe
-        window.parent.addEventListener('resize', function() {
+        window.parent.addEventListener('resize', function () {
             if (iframe.style.display !== "none") {
                 updateIframeHeight(iframe, window.parent.innerHeight)
                 updateIframeWidth(iframe, window.parent.innerWidth)
@@ -84,8 +84,55 @@ class AnkiHubAI {
             }
         };
         document.body.appendChild(button);
+
+        const tooltip = document.createElement("div");
+        tooltip.innerHTML = "Learn more about this flashcard topic<br>or explore related cards.";
+
+        const tooltipArrow = document.createElement("div");
+        tooltip.appendChild(tooltipArrow);
+
+        this.setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow);
+
+        button.addEventListener("mouseover", function () {
+            tooltip.style.display = "block";
+        });
+
+        button.addEventListener("mouseout", function () {
+            tooltip.style.display = "none";
+        });
+
+        document.body.appendChild(tooltip);
+
         return button;
     }
+
+    setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
+        const tooltipBackgroundColor = "#d1d5db";
+        const tooltipColor = "black";
+
+        tooltip.style.position = "absolute";
+        tooltip.style.bottom = "13px";
+        tooltip.style.right = "98px";
+        tooltip.style.zIndex = "1000";
+        tooltip.style.backgroundColor = tooltipBackgroundColor;
+        tooltip.style.fontSize = "medium";
+        tooltip.style.color = tooltipColor;
+        tooltip.style.borderRadius = "5px";
+        tooltip.style.textAlign = "center";
+        tooltip.style.padding = "10px";
+        tooltip.style.display = "none";
+
+        tooltipArrow.style.position = "absolute";
+        tooltipArrow.style.top = "50%";
+        tooltipArrow.style.right = "-6px";
+        tooltipArrow.style.marginTop = "-4px";
+        tooltipArrow.style.width = "0";
+        tooltipArrow.style.height = "0";
+        tooltipArrow.style.borderLeft = `6px solid ${tooltipBackgroundColor}`;
+        tooltipArrow.style.borderTop = "6px solid transparent";
+        tooltipArrow.style.borderBottom = "6px solid transparent";
+    }
+
 
     invalidateSessionAndPromptToLogin() {
         this.authenticated = false;
@@ -102,7 +149,7 @@ class AnkiHubAI {
     }
 
     hideIframe() {
-        this.button.style.backgroundImage = "url('_robotking.png')";
+        this.button.style.backgroundImage = "url('/_robot_icon.svg')";
         this.button.style.backgroundSize = "cover";
         this.iframe.style.display = "none";
         this.iframeVisible = false;
@@ -150,9 +197,7 @@ class AnkiHubAI {
         button.style.borderRadius = "100%";
         button.style.border = "none";
 
-        button.style.padding = "8px";
-
-        button.style.backgroundImage = "url('_robotking.png')";
+        button.style.backgroundImage = "url('/_robot_icon.svg')";
         button.style.backgroundSize = "cover";
         button.style.backgroundPosition = "center";
         button.style.backgroundRepeat = "no-repeat";
@@ -169,7 +214,7 @@ class AnkiHubAI {
         iframe.style.minWidth = "360px";
 
         iframe.style.height = "100%";
-        iframe.style.maxHeight = `${parentWindowHeight-95}px`;
+        iframe.style.maxHeight = `${parentWindowHeight - 95}px`;
 
         iframe.style.position = "fixed"
         iframe.style.bottom = "85px"
@@ -184,11 +229,11 @@ class AnkiHubAI {
     }
 
     updateIframeHeight(iframe, parentWindowHeight) {
-        iframe.style.maxHeight = `${parentWindowHeight-95}px`;
+        iframe.style.maxHeight = `${parentWindowHeight - 95}px`;
     }
 
     updateIframeWidth(iframe, parentWindowWidth) {
-        iframe.style.width = `${parentWindowWidth-36}px`;
+        iframe.style.width = `${parentWindowWidth - 36}px`;
     }
 
 }

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -89,7 +89,7 @@ class AnkiHubAI {
 
         const tooltip = document.createElement("div");
         tooltip.id = "ankihub-ai-tooltip";
-        tooltip.innerHTML = "Learn more about this flashcard topic<br>or explore related cards.";
+        tooltip.innerHTML = "Learn more about this flashcard<br>topic or explore related cards.";
 
         const tooltipArrow = document.createElement("div");
         tooltipArrow.id = "ankihub-ai-tooltip-arrow";


### PR DESCRIPTION
For the chatbot AI, we should update the icon as we did on the flashcard selector.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-625

## Proposed changes
- Change icon
- Add tooltip

## How to reproduce
- Open Anki
- Start a review session for the AnKing deck
- The AnkiHub AI icon should be there
  - If it's not there, make sure that the `chatbot` feature flag is active
  - Also make sure that the `ANKING_DECK_ID` env var for the add-on is set to the deck id of the deck

## Screenshots and videos
### Light mode
<img src="https://github.com/user-attachments/assets/97e1231d-d2e8-4912-92a1-328ec04b08b5" width="700" />

### Dark mode
<img src="https://github.com/user-attachments/assets/45ac7072-17b1-4673-a274-704e4e2f61d2" width="700" />