### PR TITLE
[BUILD-673] chore: Fix upload-to-ankiweb GHA

### DIFF
--- a/.github/workflows/upload_to_ankiweb.yml
+++ b/.github/workflows/upload_to_ankiweb.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install git+https://github.com/nateshmbhat/webbot.git@333f51840cd5a1fcde0b014bd6ab401d51e62860
-          python -m pip install webdriver_manager==4.0.0
+          python -m pip install webdriver_manager==4.0.2
           python -m pip uninstall -y selenium
           python -m pip install selenium==3.141.0
           python -m pip uninstall -y urllib3


### PR DESCRIPTION
This fixes the upload-to-ankiweb GHA by bumping `webdriver_manager` to v4.0.2.

Currently, the GHA fails: https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/11105034314/job/30850355014
I reproduced this locally.
Installing `webdriver_manager==4.0.2` fixed it.
Also see https://github.com/SergeyPirogov/webdriver_manager/issues/670#issuecomment-2264755178


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-673