### PR TITLE
[BUILD-683] chore: Use correct anking deck id for staging

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -53,7 +53,7 @@ WEB_MEDIA_PATH = Path(__file__).parent / "gui/web/media"
 def run():
     """Call this function in __init__.py when Anki starts."""
 
-    config.setup_public_config_and_urls()
+    config.setup_public_config_and_other_settings()
 
     setup_logger()
     LOGGER.info("Set up logger.")

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -18,7 +18,7 @@ from ..main.importing import AnkiHubImporter, AnkiHubImportResult
 from ..main.note_conversion import is_tag_for_group
 from ..main.note_types import fetch_note_types_based_on_notes
 from ..main.utils import create_backup
-from ..settings import ANKING_DECK_ID, config
+from ..settings import config
 from .media_sync import media_sync
 from .operations.scheduling import unsuspend_notes
 from .utils import deck_download_progress_cb, show_error_dialog
@@ -103,7 +103,7 @@ class _AnkiHubDeckUpdater:
         if not result:
             return False
 
-        if ankihub_did == ANKING_DECK_ID:
+        if ankihub_did == config.anking_deck_id:
             self.fetch_and_apply_pending_notes_actions_for_deck(ankihub_did)
 
         return True

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -14,12 +14,7 @@ from jinja2 import Template
 
 from .. import LOGGER
 from ..feature_flags import add_feature_flags_update_callback, feature_flags
-from ..settings import (
-    ANKING_DECK_ID,
-    config,
-    url_flashcard_selector,
-    url_flashcard_selector_embed,
-)
+from ..settings import config, url_flashcard_selector, url_flashcard_selector_embed
 from .deck_updater import ah_deck_updater
 from .js_message_handling import parse_js_message_kwargs
 from .menu import AnkiHubLogin
@@ -59,7 +54,7 @@ def _maybe_add_flashcard_selector_button() -> None:
         return
 
     # Only add the button if the currently open deck overview is for the Anking deck or a child of it
-    anking_deck_config = config.deck_config(ANKING_DECK_ID)
+    anking_deck_config = config.deck_config(config.anking_deck_id)
     if (
         not anking_deck_config
         or not aqt.mw.col.decks.have(anking_deck_config.anki_id)
@@ -139,10 +134,10 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
         super()._setup_ui()
 
     def _get_embed_url(self) -> str:
-        return url_flashcard_selector_embed(ANKING_DECK_ID)
+        return url_flashcard_selector_embed(config.anking_deck_id)
 
     def _get_non_embed_url(self) -> str:
-        return url_flashcard_selector(ANKING_DECK_ID)
+        return url_flashcard_selector(config.anking_deck_id)
 
     @classmethod
     def _handle_auth_failure(cls) -> None:

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -20,7 +20,7 @@ from jinja2 import Template
 from ..db import ankihub_db
 from ..feature_flags import feature_flags
 from ..gui.menu import AnkiHubLogin
-from ..settings import ANKING_DECK_ID, config
+from ..settings import config
 from .js_message_handling import VIEW_NOTE_PYCMD
 from .utils import using_qt5
 
@@ -116,7 +116,10 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
         return
 
     reviewer: Reviewer = context
-    if not ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid) == ANKING_DECK_ID:
+    if (
+        not ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid)
+        == config.anking_deck_id
+    ):
         # Only show the AI chatbot for cards in the AnKing deck
         return
 

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -47,7 +47,7 @@ from ..main.suggestions import (
     suggest_note_update,
     suggest_notes_in_bulk,
 )
-from ..settings import ANKING_DECK_ID, RATIONALE_FOR_CHANGE_MAX_LENGTH, config
+from ..settings import RATIONALE_FOR_CHANGE_MAX_LENGTH, config
 from .errors import report_exception_and_upload_logs
 from .media_sync import media_sync
 from .utils import (
@@ -106,7 +106,7 @@ def open_suggestion_dialog_for_single_suggestion(
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(note.id)
     SuggestionDialog(
         is_new_note_suggestion=ah_nid is None,
-        is_for_anking_deck=ah_did == ANKING_DECK_ID,
+        is_for_anking_deck=ah_did == config.anking_deck_id,
         can_submit_without_review=_can_submit_without_review(ah_did=ah_did),
         added_new_media=_added_new_media(note),
         callback=lambda suggestion_meta: _on_suggestion_dialog_for_single_suggestion_closed(
@@ -263,7 +263,7 @@ def open_suggestion_dialog_for_bulk_suggestion(
 
     SuggestionDialog(
         is_new_note_suggestion=False,
-        is_for_anking_deck=ah_did == ANKING_DECK_ID,
+        is_for_anking_deck=ah_did == config.anking_deck_id,
         can_submit_without_review=_can_submit_without_review(ah_did=ah_did),
         # We currently have a limit of 500 notes per bulk suggestion, so we don't have to worry
         # about performance here.

--- a/ankihub/private_config_migrations.py
+++ b/ankihub/private_config_migrations.py
@@ -62,12 +62,12 @@ def _maybe_set_suspend_new_cards_of_new_notes_to_true_for_anking_deck(
 ) -> None:
     """Set suspend_new_cards_of_new_notes to True in the DeckConfig of the AnKing deck if the field
     doesn't exist yet."""
-    from .settings import ANKING_DECK_ID
+    from .settings import config
 
     field_name = "suspend_new_cards_of_new_notes"
     decks = private_config_dict["decks"]
     for ah_did, deck in decks.items():
-        if ah_did == ANKING_DECK_ID and deck.get(field_name) is None:
+        if ah_did == config.anking_deck_id and deck.get(field_name) is None:
             deck[field_name] = True
             LOGGER.info(
                 f"Set {field_name} to True for the previously installed AnKing deck."

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -59,10 +59,6 @@ PRIVATE_CONFIG_FILENAME = ".private_config.json"
 # (profile configs are stored by Anki in prefs21.db in the anki base directory)
 PROFILE_ID_FIELD_NAME = "ankihub_id"
 
-# Id of the AnKing Overhaul deck
-ANKING_DECK_ID = uuid.UUID(
-    os.environ.get("ANKING_DECK_ID", "e77aedfe-a636-40e2-8169-2fce2673187e")
-)
 TAG_FOR_INSTRUCTION_NOTES = "AnkiHub_Instructions"
 
 # Only used for configuring the logger, a structlog logger is used for logging.
@@ -138,7 +134,7 @@ class DeckConfig(DataClassJSONMixin):
 
     @staticmethod
     def suspend_new_cards_of_new_notes_default(ah_did: uuid.UUID) -> bool:
-        result = ah_did == ANKING_DECK_ID
+        result = ah_did == config.anking_deck_id
         return result
 
     @staticmethod
@@ -194,8 +190,9 @@ class _Config:
         self.subscriptions_change_hook: Optional[Callable[[], None]] = None
         self.app_url: Optional[str] = None
         self.s3_bucket_url: Optional[str] = None
+        self.anking_deck_id: Optional[uuid.UUID] = None
 
-    def setup_public_config_and_urls(self):
+    def setup_public_config_and_other_settings(self):
         migrate_public_config()
         self.load_public_config()
 
@@ -203,10 +200,12 @@ class _Config:
             self.app_url = STAGING_APP_URL
             self.api_url = STAGING_API_URL
             self.s3_bucket_url = STAGING_S3_BUCKET_URL
+            self.anking_deck_id = uuid.UUID("86652268-45a8-4832-bde1-8d9c48e9acc4")
         else:
             self.app_url = DEFAULT_APP_URL
             self.api_url = DEFAULT_API_URL
             self.s3_bucket_url = DEFAULT_S3_BUCKET_URL
+            self.anking_deck_id = uuid.UUID("e77aedfe-a636-40e2-8169-2fce2673187e")
 
         # Override urls with environment variables if they are set.
         if app_url_from_env_var := os.getenv("ANKIHUB_APP_URL"):
@@ -215,6 +214,9 @@ class _Config:
 
         if s3_url_from_env_var := os.getenv("S3_BUCKET_URL"):
             self.s3_bucket_url = s3_url_from_env_var
+
+        if anking_deck_id_from_env_var := os.getenv("ANKING_DECK_ID"):
+            self.anking_deck_id = uuid.UUID(anking_deck_id_from_env_var)
 
     def setup_private_config(self):
         # requires the profile setup to be completed unlike self.setup_pbulic_config

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -94,7 +94,7 @@ def anki_session_with_addon_data(
         # Change the ankihub base path to a temporary folder to isolate the tests
         os.environ["ANKIHUB_BASE_PATH"] = tmpdir
 
-        config.setup_public_config_and_urls()
+        config.setup_public_config_and_other_settings()
         setup_logger()
 
         mock_all_feature_flags_to_default_values()

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -214,7 +214,6 @@ from ankihub.settings import (
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
     ANKIHUB_NOTE_TYPE_MODIFICATION_STRING,
     ANKIHUB_TEMPLATE_END_COMMENT,
-    ANKING_DECK_ID,
     AnkiHubCommands,
     BehaviorOnRemoteNoteDeleted,
     DeckConfig,
@@ -4476,7 +4475,7 @@ class TestSyncWithAnkiHub:
         with anki_session_with_addon_data.profile_loaded():
             # Setup deck with a note that has a suspended card
             ah_did = install_ah_deck(
-                ah_did=ANKING_DECK_ID if is_for_anking_deck else None
+                ah_did=config.anking_deck_id if is_for_anking_deck else None
             )
             note_info = import_ah_note(
                 ah_did=ah_did,
@@ -5561,8 +5560,8 @@ class TestFlashCardSelector:
     @pytest.mark.parametrize(
         "deck_id, feature_flag_active, expected_button_exists",
         [
-            (ANKING_DECK_ID, True, True),
-            (ANKING_DECK_ID, False, False),
+            (config.anking_deck_id, True, True),
+            (config.anking_deck_id, False, False),
             (uuid.uuid4(), True, False),
         ],
     )
@@ -5612,7 +5611,7 @@ class TestFlashCardSelector:
             mocker.patch.object(config, "token")
 
             anki_did = DeckId(1)
-            install_ah_deck(ah_did=ANKING_DECK_ID, anki_did=anki_did)
+            install_ah_deck(ah_did=config.anking_deck_id, anki_did=anki_did)
             aqt.mw.deckBrowser.set_current_deck(anki_did)
 
             qtbot.wait(500)
@@ -5649,7 +5648,7 @@ class TestFlashCardSelector:
             mocker.patch.object(config, "token")
 
             anki_did = DeckId(1)
-            install_ah_deck(ah_did=ANKING_DECK_ID, anki_did=anki_did)
+            install_ah_deck(ah_did=config.anking_deck_id, anki_did=anki_did)
             aqt.mw.deckBrowser.set_current_deck(anki_did)
 
             qtbot.wait(500)
@@ -5731,7 +5730,7 @@ class TestFlashCardSelector:
             dialog.view_in_web_browser_button.click()
 
             openLink_mock.assert_called_once_with(
-                url_flashcard_selector(ANKING_DECK_ID)
+                url_flashcard_selector(config.anking_deck_id)
             )
             assert not dialog.isVisible()
 
@@ -5978,7 +5977,9 @@ class TestAnkiHubAIInReviewer:
 
         entry_point.run()
         with anki_session_with_addon_data.profile_loaded():
-            ah_did = ANKING_DECK_ID if for_anking_deck else next_deterministic_uuid()
+            ah_did = (
+                config.anking_deck_id if for_anking_deck else next_deterministic_uuid()
+            )
             self._setup_note_for_review(
                 ah_did, install_ah_deck=install_ah_deck, import_ah_note=import_ah_note
             )
@@ -6013,7 +6014,9 @@ class TestAnkiHubAIInReviewer:
         entry_point.run()
 
         with anki_session_with_addon_data.profile_loaded():
-            self._setup_note_for_review(ANKING_DECK_ID, install_ah_deck, import_ah_note)
+            self._setup_note_for_review(
+                config.anking_deck_id, install_ah_deck, import_ah_note
+            )
 
             aqt.mw.reviewer.show()
 
@@ -6196,7 +6199,9 @@ class TestAnkiHubAIInReviewer:
         entry_point.run()
 
         with anki_session_with_addon_data.profile_loaded():
-            self._setup_note_for_review(ANKING_DECK_ID, install_ah_deck, import_ah_note)
+            self._setup_note_for_review(
+                config.anking_deck_id, install_ah_deck, import_ah_note
+            )
             aqt.mw.reviewer.show()
             qtbot.wait(100)
 
@@ -6226,7 +6231,9 @@ class TestAnkiHubAIInReviewer:
         entry_point.run()
 
         with anki_session_with_addon_data.profile_loaded():
-            self._setup_note_for_review(ANKING_DECK_ID, install_ah_deck, import_ah_note)
+            self._setup_note_for_review(
+                config.anking_deck_id, install_ah_deck, import_ah_note
+            )
 
             aqt.mw.reviewer.show()
 
@@ -6262,7 +6269,7 @@ class TestAnkiHubAIInReviewer:
         config.set_suspend_new_cards_of_new_notes(ankihub_did=ah_did, suspend=False)
         deck_config = config.deck_config(ah_did)
         import_ah_note(
-            ah_did=ANKING_DECK_ID,
+            ah_did=config.anking_deck_id,
             anki_did=deck_config.anki_id,
         )
         aqt.mw.col.decks.set_current(deck_config.anki_id)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5558,11 +5558,11 @@ class TestConfigDialog:
 class TestFlashCardSelector:
     @pytest.mark.sequential
     @pytest.mark.parametrize(
-        "deck_id, feature_flag_active, expected_button_exists",
+        "is_anking_deck, feature_flag_active, expected_button_exists",
         [
-            (config.anking_deck_id, True, True),
-            (config.anking_deck_id, False, False),
-            (uuid.uuid4(), True, False),
+            (True, True, True),
+            (True, False, False),
+            (False, True, False),
         ],
     )
     def test_flashcard_selector_button_exists_for_anking_deck(
@@ -5570,7 +5570,7 @@ class TestFlashCardSelector:
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
         qtbot: QtBot,
-        deck_id: uuid.UUID,
+        is_anking_deck: bool,
         set_feature_flag_state: SetFeatureFlagState,
         feature_flag_active: bool,
         expected_button_exists: bool,
@@ -5582,7 +5582,10 @@ class TestFlashCardSelector:
         entry_point.run()
         with anki_session_with_addon_data.profile_loaded():
             anki_did = DeckId(1)
-            install_ah_deck(ah_did=deck_id, anki_did=anki_did)
+            install_ah_deck(
+                ah_did=config.anking_deck_id if is_anking_deck else uuid.uuid4(),
+                anki_did=anki_did,
+            )
             aqt.mw.deckBrowser.set_current_deck(anki_did)
 
             qtbot.wait(500)


### PR DESCRIPTION
Currently, when the "use_staging" setting is changed, this does not affect the `ANKING_DECK_ID` setting.
This causes some problems when "use_staging" is set to `true''. For example, the AnkiHub AI features do not show up for the AnKing deck on staging.

<img src="https://github.com/user-attachments/assets/573cfa06-e97d-46c9-a112-29aa7b0b3304" width="600" />


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-683
https://theanking.slack.com/archives/C01E9EJ1W2E/p1727791389645969?thread_ts=1727713744.955879&cid=C01E9EJ1W2E

## Proposed changes
- Move the `ANKING_DECK_ID` setting to the config
- Use the id of the AnKing deck on staging when "use_staging" is set to `true`