### PR TITLE
[BUILD-692] [BUILD-694] chore: Enable smart search and ai chatbot for other decks

### DIFF
--- a/ankihub/ankihub_client/models.py
+++ b/ankihub/ankihub_client/models.py
@@ -117,6 +117,7 @@ class Deck(DataClassJSONMixinWithConfig):
             deserialize=lambda s: UserDeckRelation(s),
         )
     )
+    has_note_embeddings: bool
 
     @property
     def is_user_relation_owner_or_maintainer(self):

--- a/ankihub/ankihub_client/models.py
+++ b/ankihub/ankihub_client/models.py
@@ -117,7 +117,7 @@ class Deck(DataClassJSONMixinWithConfig):
             deserialize=lambda s: UserDeckRelation(s),
         )
     )
-    has_note_embeddings: bool
+    has_note_embeddings: bool = False
 
     @property
     def is_user_relation_owner_or_maintainer(self):

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -53,16 +53,8 @@ def _maybe_add_flashcard_selector_button() -> None:
     if not aqt.mw.state == "overview":
         return
 
-    # Only add the button if the currently open deck overview is for the Anking deck or a child of it
-    anking_deck_config = config.deck_config(config.anking_deck_id)
-    if (
-        not anking_deck_config
-        or not aqt.mw.col.decks.have(anking_deck_config.anki_id)
-        or (
-            aqt.mw.col.decks.current()["id"]
-            not in aqt.mw.col.decks.deck_and_child_ids(anking_deck_config.anki_id)
-        )
-    ):
+    deck_config = config.deck_config(aqt.mw.col.decks.current()["id"])
+    if not deck_config or not deck_config.has_note_embeddings:
         return
 
     if not feature_flags.show_flashcards_selector_button:

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -1,13 +1,14 @@
 """Modifies the Anki deck overview screen (aqt.overview)."""
 
+import json
+import uuid
 from concurrent.futures import Future
 from functools import partial
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional
 from uuid import UUID
 
 import aqt
-from anki.decks import DeckId
 from aqt.gui_hooks import overview_did_refresh, webview_did_receive_js_message
 from aqt.utils import tooltip
 from aqt.webview import AnkiWebView
@@ -19,6 +20,7 @@ from ..settings import config, url_flashcard_selector, url_flashcard_selector_em
 from .deck_updater import ah_deck_updater
 from .js_message_handling import parse_js_message_kwargs
 from .menu import AnkiHubLogin
+from .utils import get_ah_did_of_deck_or_ancestor_deck
 from .webview import AnkiHubWebViewDialog
 
 ADD_FLASHCARD_SELECTOR_BUTTON_JS_PATH = (
@@ -54,7 +56,11 @@ def _maybe_add_flashcard_selector_button() -> None:
     if not aqt.mw.state == "overview":
         return
 
-    if not _deck_or_ancestor_has_note_embeddings(aqt.mw.col.decks.current()["id"]):
+    ah_did = get_ah_did_of_deck_or_ancestor_deck(aqt.mw.col.decks.current()["id"])
+    if (
+        not config.deck_config(ah_did)
+        or not config.deck_config(ah_did).has_note_embeddings
+    ):
         return
 
     if not feature_flags.show_flashcards_selector_button:
@@ -64,29 +70,25 @@ def _maybe_add_flashcard_selector_button() -> None:
         return
 
     overview_web: AnkiWebView = aqt.mw.overview.web
+    kwargs_json = json.dumps({"deck_id": str(ah_did)}).replace('"', '\\"')
     js = Template(ADD_FLASHCARD_SELECTOR_BUTTON_JS_PATH.read_text()).render(
         {
             "FLASHCARD_SELECTOR_OPEN_BUTTON_ID": FLASHCARD_SELECTOR_OPEN_BUTTON_ID,
-            "FLASHCARD_SELECTOR_OPEN_PYCMD": FLASHCARD_SELECTOR_OPEN_PYCMD,
+            "FLASHCARD_SELECTOR_OPEN_PYCMD": f"{FLASHCARD_SELECTOR_OPEN_PYCMD} {kwargs_json}",
         }
     )
     overview_web.eval(js)
 
 
-def _deck_or_ancestor_has_note_embeddings(anki_did: DeckId) -> bool:
-    anki_dids = [anki_did] + [deck["id"] for deck in aqt.mw.col.decks.parents(anki_did)]
-    return any(
-        (deck_config := config.deck_config_by_anki_did(anki_did))
-        and deck_config.has_note_embeddings
-        for anki_did in anki_dids
-    )
-
-
 def _handle_flashcard_selector_py_commands(
     handled: tuple[bool, Any], message: str, context: Any
 ) -> tuple[bool, Any]:
-    if message == FLASHCARD_SELECTOR_OPEN_PYCMD:
-        FlashCardSelectorDialog.display(aqt.mw)
+    if message.startswith(FLASHCARD_SELECTOR_OPEN_PYCMD):
+        kwargs = parse_js_message_kwargs(message)
+        ah_did = UUID(kwargs.get("deck_id"))
+
+        FlashCardSelectorDialog.display_for_ah_did(ah_did=ah_did, parent=aqt.mw)
+
         LOGGER.info("Opened flashcard selector dialog.")
         return (True, None)
     elif message.startswith(FLASHCARD_SELECTOR_SYNC_NOTES_ACTIONS_PYCMD):
@@ -125,8 +127,32 @@ def _on_fetch_and_apply_pending_notes_actions_done(
 
 
 class FlashCardSelectorDialog(AnkiHubWebViewDialog):
-    def __init__(self, parent: Any) -> None:
+
+    dialog: Optional["FlashCardSelectorDialog"] = None
+
+    def __init__(self, ah_did: uuid.UUID, parent) -> None:
         super().__init__(parent)
+
+        self.ah_did = ah_did
+
+    @classmethod
+    def display_for_ah_did(
+        cls, ah_did: uuid.UUID, parent: Any
+    ) -> "FlashCardSelectorDialog":
+        """Display the flashcard selector dialog for the given deck.
+        Reuses the dialog if it is already open for the same deck.
+        Otherwise, closes the existing dialog and opens a new one."""
+        if cls.dialog and cls.dialog.ah_did != ah_did:
+            cls.dialog.close()
+            cls.dialog = None
+
+        if not cls.dialog:
+            cls.dialog = cls(ah_did=ah_did, parent=parent)
+
+        if not cls.dialog.display():
+            cls.dialog = None
+
+        return cls.dialog
 
     def _setup_ui(self) -> None:
         self.setWindowTitle("AnkiHub | Flashcard Selector")
@@ -135,18 +161,15 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
         super()._setup_ui()
 
     def _get_embed_url(self) -> str:
-        return url_flashcard_selector_embed(config.anking_deck_id)
+        return url_flashcard_selector_embed(self.ah_did)
 
     def _get_non_embed_url(self) -> str:
-        return url_flashcard_selector(config.anking_deck_id)
+        return url_flashcard_selector(self.ah_did)
 
-    @classmethod
-    def _handle_auth_failure(cls) -> None:
+    def _handle_auth_failure(self) -> None:
         # Close the flashcard selector dialog and prompt them to log in,
         # then they can open the dialog again
-        if cls.dialog:
-            cls.dialog = cast(FlashCardSelectorDialog, cls.dialog)
-            cls.dialog.close()
+        self.close()
 
         AnkiHubLogin.display_login()
         LOGGER.info(

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -116,11 +116,11 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
         return
 
     reviewer: Reviewer = context
-    if (
-        not ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid)
-        == config.anking_deck_id
-    ):
-        # Only show the AI chatbot for cards in the AnKing deck
+    deck_config = config.deck_config(
+        ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid)
+    )
+    should_show_chatbot_button = deck_config and deck_config.has_note_embeddings
+    if not should_show_chatbot_button:
         return
 
     template_vars = {

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import aqt
+from anki.decks import DeckId
 from aqt import sync
 from aqt.addons import check_and_prompt_for_updates
 from aqt.progress import ProgressDialog
@@ -601,3 +602,15 @@ def sync_with_ankiweb(on_done: Callable[[], None]) -> None:
 
     aqt.gui_hooks.sync_will_start()
     sync.sync_collection(aqt.mw, on_done=on_collection_sync_finished)
+
+
+def get_ah_did_of_deck_or_ancestor_deck(anki_did: DeckId) -> Optional[uuid.UUID]:
+    anki_dids = [anki_did] + [deck["id"] for deck in aqt.mw.col.decks.parents(anki_did)]
+    return next(
+        (
+            ah_did
+            for anki_did in anki_dids
+            if (ah_did := config.get_deck_uuid_by_did(anki_did))
+        ),
+        None,
+    )

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional, cast
+from typing import Any
 
 from anki.utils import is_mac
 from aqt.gui_hooks import theme_did_change
@@ -51,30 +51,22 @@ class AnkiHubWebViewDialog(AlwaysOnTopOfParentDialog):
     This class handles setting up the web view, loading the page, styling and authentication.
     """
 
-    dialog: Optional["AnkiHubWebViewDialog"] = None
-
     def __init__(self, parent: Any) -> None:
         super().__init__(parent)
         self._setup_ui()
 
-    @classmethod
-    def display(cls, parent: Any) -> "Optional[AnkiHubWebViewDialog]":
-        """Display the dialog. If the dialog is already open, the existing dialog is activated and shown."""
+    def display(self) -> bool:
+        """Display the dialog. Return True if the initialization was successful, False otherwise."""
         if not config.token():
-            cls._handle_auth_failure()
-            return None
+            self._handle_auth_failure()
+            return False
 
-        if cls.dialog is None:
-            cls.dialog = cls(parent)
-        else:
-            cls.dialog = cast(AnkiHubWebViewDialog, cls.dialog)
+        self._load_page()
+        self.activateWindow()
+        self.raise_()
+        self.show()
 
-        cls.dialog._load_page()
-        cls.dialog.activateWindow()
-        cls.dialog.raise_()
-        cls.dialog.show()
-
-        return cls.dialog
+        return True
 
     def _setup_ui(self) -> None:
         self.web = AnkiWebView(parent=self)
@@ -156,9 +148,8 @@ class AnkiHubWebViewDialog(AlwaysOnTopOfParentDialog):
         """Return the URL to load in the default browser."""
         ...  # pragma: no cover
 
-    @classmethod
     @abstractmethod
-    def _handle_auth_failure(cls) -> None:
+    def _handle_auth_failure(self) -> None:
         """Handle an authentication failure, e.g. prompt the user to log in."""
         ...  # pragma: no cover
 

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -131,6 +131,7 @@ class DeckConfig(DataClassJSONMixin):
     suspend_new_cards_of_existing_notes: SuspendNewCardsOfExistingNotes = (
         SuspendNewCardsOfExistingNotes.IF_SIBLINGS_SUSPENDED
     )
+    has_note_embeddings: bool = False
 
     @staticmethod
     def suspend_new_cards_of_new_notes_default(ah_did: uuid.UUID) -> bool:
@@ -308,6 +309,7 @@ class _Config:
         behavior_on_remote_note_deleted: BehaviorOnRemoteNoteDeleted,
         latest_udpate: Optional[datetime] = None,
         subdecks_enabled: bool = False,
+        has_note_embeddings: bool = False,
     ) -> None:
         """Add deck to the list of installed decks."""
         self._private_config.decks[ankihub_did] = DeckConfig(
@@ -319,6 +321,7 @@ class _Config:
                 ankihub_did
             ),
             behavior_on_remote_note_deleted=behavior_on_remote_note_deleted,
+            has_note_embeddings=has_note_embeddings,
         )
         # remove duplicates
         self.save_latest_deck_update(ankihub_did, latest_udpate)
@@ -334,6 +337,7 @@ class _Config:
         # Only these fields are needed for the deck config
         deck_config.name = deck.name
         deck_config.user_relation = deck.user_relation
+        deck_config.has_note_embeddings = deck.has_note_embeddings
 
         self._update_private_config()
 

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -376,6 +376,13 @@ class _Config:
     def deck_config(self, ankihub_did: uuid.UUID) -> Optional[DeckConfig]:
         return self._private_config.decks.get(ankihub_did)
 
+    def deck_config_by_anki_did(self, anki_did: DeckId) -> Optional[DeckConfig]:
+        decks = self._private_config.decks
+        return next(
+            (deck for deck in decks.values() if deck.anki_id == anki_did),
+            None,
+        )
+
     def token(self) -> Optional[str]:
         # return aqt.mw.pm.ankihub_token()
         return aqt.mw.pm.profile.get("ankiHubToken")

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1255,6 +1255,7 @@ def test_get_deck_by_id(
         "csv_notes_filename": "test.csv",
         "media_upload_finished": False,
         "user_relation": "subscriber",
+        "has_note_embeddings": False,
     }
 
     requests_mock.get(f"{config.api_url}/decks/{ah_did}/", json=expected_data)
@@ -1267,6 +1268,7 @@ def test_get_deck_by_id(
         csv_notes_filename="test.csv",
         media_upload_finished=False,
         user_relation=UserDeckRelation.SUBSCRIBER,
+        has_note_embeddings=False,
     )
 
     # test get deck by id unauthenticated
@@ -2673,6 +2675,7 @@ def test_unsubscribe_from_deck(
                         "csv_notes_filename": "",
                         "media_upload_finished": True,
                         "user_relation": "subscriber",
+                        "has_note_embeddings": False,
                     }
                 }
             ],

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5570,7 +5570,7 @@ class TestFlashCardSelector:
             (False, True, False),
         ],
     )
-    def test_flashcard_selector_button_exists_for_anking_deck(
+    def test_flashcard_selector_button_exists_for_deck_with_note_embeddings(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
@@ -5588,7 +5588,6 @@ class TestFlashCardSelector:
         with anki_session_with_addon_data.profile_loaded():
             anki_did = DeckId(1)
             install_ah_deck(
-                ah_did=config.anking_deck_id if has_note_embeddings else uuid.uuid4(),
                 anki_did=anki_did,
                 has_note_embeddings=has_note_embeddings,
             )
@@ -5621,7 +5620,6 @@ class TestFlashCardSelector:
 
             anki_did = DeckId(1)
             install_ah_deck(
-                ah_did=config.anking_deck_id,
                 anki_did=anki_did,
                 has_note_embeddings=True,
             )
@@ -5661,7 +5659,7 @@ class TestFlashCardSelector:
             mocker.patch.object(config, "token")
 
             anki_did = DeckId(1)
-            install_ah_deck(ah_did=config.anking_deck_id, anki_did=anki_did)
+            install_ah_deck(anki_did=anki_did, has_note_embeddings=True)
             aqt.mw.deckBrowser.set_current_deck(anki_did)
 
             qtbot.wait(500)
@@ -5981,7 +5979,6 @@ class TestAnkiHubAIInReviewer:
         install_ah_deck: InstallAHDeck,
         qtbot: QtBot,
         set_feature_flag_state: SetFeatureFlagState,
-        next_deterministic_uuid: Callable[[], uuid.UUID],
         feature_flag_active: bool,
         has_note_embeddings: bool,
         expected_button_exists: bool,
@@ -5990,13 +5987,7 @@ class TestAnkiHubAIInReviewer:
 
         entry_point.run()
         with anki_session_with_addon_data.profile_loaded():
-            ah_did = (
-                config.anking_deck_id
-                if has_note_embeddings
-                else next_deterministic_uuid()
-            )
             self._setup_note_for_review(
-                ah_did,
                 install_ah_deck=install_ah_deck,
                 import_ah_note=import_ah_note,
                 has_note_embeddings=has_note_embeddings,
@@ -6033,7 +6024,9 @@ class TestAnkiHubAIInReviewer:
 
         with anki_session_with_addon_data.profile_loaded():
             self._setup_note_for_review(
-                config.anking_deck_id, install_ah_deck, import_ah_note
+                install_ah_deck,
+                import_ah_note,
+                has_note_embeddings=True,
             )
 
             aqt.mw.reviewer.show()
@@ -6218,7 +6211,9 @@ class TestAnkiHubAIInReviewer:
 
         with anki_session_with_addon_data.profile_loaded():
             self._setup_note_for_review(
-                config.anking_deck_id, install_ah_deck, import_ah_note
+                install_ah_deck,
+                import_ah_note,
+                has_note_embeddings=True,
             )
             aqt.mw.reviewer.show()
             qtbot.wait(100)
@@ -6250,7 +6245,9 @@ class TestAnkiHubAIInReviewer:
 
         with anki_session_with_addon_data.profile_loaded():
             self._setup_note_for_review(
-                config.anking_deck_id, install_ah_deck, import_ah_note
+                install_ah_deck,
+                import_ah_note,
+                has_note_embeddings=True,
             )
 
             aqt.mw.reviewer.show()
@@ -6277,18 +6274,18 @@ class TestAnkiHubAIInReviewer:
 
     def _setup_note_for_review(
         self,
-        ah_did: uuid.UUID,
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
         has_note_embeddings: bool = False,
     ) -> None:
+        ah_did = uuid.uuid4()
         install_ah_deck(ah_did=ah_did, has_note_embeddings=has_note_embeddings)
 
         # Changes the deck setting so that there are unsuspend cards ready for review
         config.set_suspend_new_cards_of_new_notes(ankihub_did=ah_did, suspend=False)
         deck_config = config.deck_config(ah_did)
         import_ah_note(
-            ah_did=config.anking_deck_id,
+            ah_did=ah_did,
             anki_did=deck_config.anki_id,
         )
         aqt.mw.col.decks.set_current(deck_config.anki_id)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -70,6 +70,7 @@ class DeckFactory(BaseFactory[Deck]):
     csv_notes_filename = "test.csv"
     media_upload_finished = False
     user_relation = UserDeckRelation.SUBSCRIBER
+    has_note_embeddings = False
 
 
 class DeckMediaFactory(BaseFactory[DeckMedia]):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -419,6 +419,7 @@ class InstallAHDeck(Protocol):
         ah_deck_name: Optional[str] = None,
         anki_did: Optional[DeckId] = None,
         anki_deck_name: Optional[str] = None,
+        has_note_embeddings: bool = False,
     ) -> uuid.UUID:
         ...
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -438,6 +438,7 @@ def install_ah_deck(
         ah_deck_name: Optional[str] = None,
         anki_did: Optional[DeckId] = None,
         anki_deck_name: Optional[str] = None,
+        has_note_embeddings: bool = False,
     ) -> uuid.UUID:
         if not ah_did:
             ah_did = next_deterministic_uuid()
@@ -455,6 +456,7 @@ def install_ah_deck(
             anki_did=anki_did,
             user_relation=UserDeckRelation.SUBSCRIBER,
             behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+            has_note_embeddings=has_note_embeddings,
         )
 
         # Create deck by importing a note for it


### PR DESCRIPTION
## Related issues
- [BUILD-692](https://ankihub.atlassian.net/browse/BUILD-692)
- [BUILD-694](https://ankihub.atlassian.net/browse/BUILD-694)


## Proposed changes
This PR updates the addon making sure that buttons of the "smart search" and the "chatbot" are available for other decks that have note embeddings.



[BUILD-692]: https://ankihub.atlassian.net/browse/BUILD-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-694]: https://ankihub.atlassian.net/browse/BUILD-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ