### PR TITLE
add handler for copy to clipboard pycmd JS-sent event

### DIFF
--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -28,6 +28,7 @@ UNSUSPEND_NOTES_PYCMD = "ankihub_unsuspend_notes"
 SUSPEND_NOTES_PYCMD = "ankihub_suspend_notes"
 GET_NOTE_SUSPENSION_STATES_PYCMD = "ankihub_get_note_suspension_states"
 ANKIHUB_UPSELL = "ankihub_ai_upsell"
+COPY_TO_CLIPBOARD_PYCMD = "ankihub_copy_to_clipboard"
 
 POST_MESSAGE_TO_ANKIHUB_JS_PATH = (
     Path(__file__).parent / "web/post_message_to_ankihub_js.js"
@@ -105,6 +106,14 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
             default_button_idx=1,
             callback=on_button_clicked,
         )
+    elif message.startswith(COPY_TO_CLIPBOARD_PYCMD):
+        kwargs = parse_js_message_kwargs(message)
+        content = kwargs.get("content")
+        if content:
+            aqt.mw.app.clipboard().setText(content)
+
+        return (True, None)
+
     return handled
 
 


### PR DESCRIPTION
## Related issues
This is necessary for the complete functionality of the chatbot changes introduced in:
- https://github.com/AnkiHubSoftware/ankihub/pull/2370


## Proposed changes
This PR adds a new conditional branch that handles the `ankihub_copy_to_clipboard` that will be sent by the chatbot iframe when the "copy link" button is clicked (see related PR).

This is because using the `navigator.clipboard.writeText(data)` inside an iframe is not allowed by default, and setting `allow="clipboard-write *"` (and inumerous other variants of this) didn't yield the desired result. Maybe this is a bug related to the specific browser that anki uses.

If you want to try your luck out there, It's dangerous to go alone, take [this](https://web.dev/articles/async-clipboard#permissions-policy-integration) and [this](https://hellodevworldblog.medium.com/error-when-copying-to-clipboard-from-iframe-dab0b5c5f310).


## How to reproduce
With the related ankihub PR checked out, open the chatbot with an user that has no available token quota.
When sending a message,this should trigger the warning:
![image](https://github.com/user-attachments/assets/e8c3c60d-7c74-43b0-8b3a-9b445e059ccf)

Ensure that you have something else in your clipboard. You can even copy this text, I wont' mind.

Then, click the "Copy email" button, it should change like this for 3 seconds and then go back to normal:
![image](https://github.com/user-attachments/assets/4bebf775-56ba-4fb4-8f0c-29147ae7d0b1)

Paste from your clipboard and you should see the email:
![image](https://github.com/user-attachments/assets/61eb4096-234b-450c-a2c7-a4ecfcea6a2f)



## Screenshots and videos
There are already a few screenshots above, that's all I've got.