### PR TITLE
[BUILD-720] chore: Show chatbot for notes with AnkiHub note id, note type or deck

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -22,7 +22,7 @@ from ..feature_flags import feature_flags
 from ..gui.menu import AnkiHubLogin
 from ..settings import config
 from .js_message_handling import VIEW_NOTE_PYCMD
-from .utils import using_qt5
+from .utils import get_ah_did_of_deck_or_ancestor_deck, using_qt5
 
 VIEW_NOTE_BUTTON_ID = "ankihub-view-note-button"
 
@@ -116,7 +116,14 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
         return
 
     reviewer: Reviewer = context
-    ah_dids = ankihub_db.ankihub_dids_for_note_type(reviewer.card.note().mid)
+    ah_did_of_note = ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid)
+    ah_dids_of_note_type = ankihub_db.ankihub_dids_for_note_type(
+        reviewer.card.note().mid
+    )
+    ah_did_of_deck = get_ah_did_of_deck_or_ancestor_deck(
+        aqt.mw.col.decks.current()["id"]
+    )
+    ah_dids = (set([ah_did_of_note, ah_did_of_deck]) | ah_dids_of_note_type) - {None}
     if not any(
         (
             (deck_config := config.deck_config(ah_did))

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -155,8 +155,7 @@ def _notify_ankihub_ai_of_card_change(card: Card) -> None:
         return
 
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(card.nid)
-    ah_nid_str = str(ah_nid) if ah_nid else ""
-    js = _wrap_with_ankihubAI_check(f"ankihubAI.cardChanged('{ah_nid_str}');")
+    js = _wrap_with_ankihubAI_check(f"ankihubAI.cardChanged('{ah_nid}');")
     aqt.mw.reviewer.web.eval(js)
 
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -123,7 +123,7 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
     ah_did_of_deck = get_ah_did_of_deck_or_ancestor_deck(
         aqt.mw.col.decks.current()["id"]
     )
-    ah_dids = (set([ah_did_of_note, ah_did_of_deck]) | ah_dids_of_note_type) - {None}
+    ah_dids = {ah_did_of_note, ah_did_of_deck, *ah_dids_of_note_type} - {None}
     if not any(
         (
             (deck_config := config.deck_config(ah_did))

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -6,7 +6,10 @@ class AnkiHubAI {
         this.queryParameters = "{{ QUERY_PARAMETERS }}"
         this.embeddedAuthPath = "common/embedded-auth";
 
-        this.noteIdOfReviewerCard = null; // The note ID for which the card is currently being reviewed.
+        // The note ID for which the card is currently being reviewed.
+        // An empty string means that the card has no AnkiHub note ID.
+        this.noteIdOfReviewerCard = null;
+
         this.noteIdOfChatbot = null; // The note ID for which the chatbot page is currently loaded.
         this.authenticated = false;
         this.knoxToken = "{{ KNOX_TOKEN }}";
@@ -211,7 +214,10 @@ class AnkiHubAI {
             return;
         }
 
-        const targetUrl = `${this.appUrl}/${this.endpointPath}/${this.noteIdOfReviewerCard}/?${this.queryParameters}`;
+        const targetUrl = this.noteIdOfReviewerCard !== ""
+            ? `${this.appUrl}/${this.endpointPath}/${this.noteIdOfReviewerCard}/?${this.queryParameters}`
+            : `${this.appUrl}/${this.endpointPath}/?${this.queryParameters}`;
+
         if (!this.authenticated) {
             this.iframe.src = `${this.appUrl}/${this.embeddedAuthPath}/?next=${encodeURIComponent(targetUrl)}`;
             this.authenticated = true;

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -6,10 +6,7 @@ class AnkiHubAI {
         this.queryParameters = "{{ QUERY_PARAMETERS }}"
         this.embeddedAuthPath = "common/embedded-auth";
 
-        // The note ID for which the card is currently being reviewed.
-        // An empty string means that the card has no AnkiHub note ID.
-        this.noteIdOfReviewerCard = null;
-
+        this.noteIdOfReviewerCard = null; // The note ID for which the card is currently being reviewed.
         this.noteIdOfChatbot = null; // The note ID for which the chatbot page is currently loaded.
         this.authenticated = false;
         this.knoxToken = "{{ KNOX_TOKEN }}";
@@ -214,10 +211,7 @@ class AnkiHubAI {
             return;
         }
 
-        const targetUrl = this.noteIdOfReviewerCard !== ""
-            ? `${this.appUrl}/${this.endpointPath}/${this.noteIdOfReviewerCard}/?${this.queryParameters}`
-            : `${this.appUrl}/${this.endpointPath}/?${this.queryParameters}`;
-
+        const targetUrl = `${this.appUrl}/${this.endpointPath}/${this.noteIdOfReviewerCard}/?${this.queryParameters}`;
         if (!this.authenticated) {
             this.iframe.src = `${this.appUrl}/${this.embeddedAuthPath}/?next=${encodeURIComponent(targetUrl)}`;
             this.authenticated = true;


### PR DESCRIPTION
We want to show the chatbot icon on AnkiHub notes which were not suggested/accepted yet.
Currently, we only show it for notes which are accepted and have an AnkiHub note id.

<img src="https://github.com/user-attachments/assets/71e8275c-f63e-427d-a58d-dd399ead480b" width="400" />

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-720


## Proposed changes
- Show the chatbot icon in the reviewer for all notes that have an AnkiHub id, note type or are in an AnkiHub deck