### PR TITLE
[BUILD-725] fix: TypeError in reviewer

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -591,14 +591,13 @@ class _AnkiHubDB:
 
     def ankihub_dids_for_note_type(
         self, anki_note_type_id: NotetypeId
-    ) -> Optional[Set[uuid.UUID]]:
+    ) -> Set[uuid.UUID]:
         """Returns the AnkiHub deck ids that use the given note type."""
-        result = set(
+        return set(
             AnkiHubNoteType.select(AnkiHubNoteType.ankihub_deck_id)
             .filter(anki_note_type_id=anki_note_type_id)
             .objects(flat)
         )
-        return result if result else None
 
     def _note_type_field_names(
         self, ankihub_did: uuid.UUID, anki_note_type_id: NotetypeId

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1415,11 +1415,10 @@ class TestAnkiHubDBRemoveDeck:
             )
             is None
         )
-        assert (
+        assert not (
             ankihub_db.ankihub_dids_for_note_type(
                 anki_note_type_id=ankihub_basic_note_type["id"]
             )
-            is None
         )
 
         assert ankihub_db.downloadable_media_names_for_ankihub_deck(ah_did) == set()


### PR DESCRIPTION
Currently, when reviewing a note with a non-AnkiHub note type, this error occurs:
```
File "ankihub/gui/reviewer.py", line 126, in _add_ankihub_ai_js_to_reviewer_web_content
    ah_dids = {ah_did_of_note, ah_did_of_deck, *ah_dids_of_note_type} - {None}

TypeError: 'NoneType' object is not iterable
```

The reason is that the `ankihub_dids_for_note_type` function can return `None`.

To fix this, we can make it return an empty set instead of `None` when there are no AnkiHub deck ids for the note type.

## Related issues


## Proposed changes
- Return an empty set from the `ankihub_dids_for_note_type` function if there are no results instead of `None`
- Update test