### PR TITLE
[BUILD-693] fix: Update feature flags when auth token changes

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -12,7 +12,7 @@ from aqt.main import AnkiQt
 
 from . import LOGGER
 from .db import ankihub_db
-from .feature_flags import setup_feature_flags_in_background
+from .feature_flags import update_feature_flags_in_background
 from .gui import (
     browser,
     deckbrowser,
@@ -230,7 +230,10 @@ def _general_setup():
     # This is because other setup functions can add callbacks which react to the feature flags getting fetched.
     # If this function is called earlier, the feature flags might be fetched before the callbacks are added,
     # which would cause the callbacks to not be called.
-    setup_feature_flags_in_background()
+    update_feature_flags_in_background()
+
+    config.token_change_hook.append(update_feature_flags_in_background)
+
     LOGGER.info(
         "Set up feature flag fetching (flags will be fetched in the background)."
     )

--- a/ankihub/feature_flags.py
+++ b/ankihub/feature_flags.py
@@ -25,7 +25,7 @@ feature_flags = _FeatureFlags()
 _feature_flags_update_callbacks: List[Callable[[], None]] = []
 
 
-def setup_feature_flags_in_background() -> None:
+def update_feature_flags_in_background() -> None:
     def on_done(_: None) -> None:
         LOGGER.info("Set up feature flags.")
 


### PR DESCRIPTION
Currently feature flags are only fetched when Anki is started. 

This leads to issues, for example the AnkiHub AI features are not appearing on the add-on sometimes because the auth token is outdated when Anki starts and because of this the feature flags can not be fetched.
When this is the case, the user will be asked to login when syncing. However, we are currently not updating the feature flags after they login, leaving them without the feature-flat protected features.

This PR fixes this by fetching feature flags after the user logs in.

## Related issues
https://ankihub.atlassian.net/browse/BUILD-693

## Proposed changes
- Update feature flags when user logs in