### PR TITLE
[BUILD-741] fix: Filter out deleted notes in db queries, speed up resetting local changes

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -289,10 +289,10 @@ class AnkiHubClient:
         return token
 
     def signout(self) -> None:
-        self.token = None
         response = self._send_request("POST", API.ANKIHUB, "/logout/")
         if response.status_code not in [204, 401]:
             raise AnkiHubHTTPError(response)
+        self.token = None
 
     def upload_deck(
         self,

--- a/ankihub/db/__init__.py
+++ b/ankihub/db/__init__.py
@@ -1,1 +1,6 @@
-from .db import ankihub_db, execute_list_query_in_chunks, flat  # noqa: F401
+from .db import (  # noqa: F401
+    NOTE_NOT_DELETED_CONDITION,
+    ankihub_db,
+    execute_list_query_in_chunks,
+    flat,
+)

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -500,6 +500,7 @@ class _AnkiHubDB:
     def media_names_for_ankihub_deck(self, ah_did: uuid.UUID) -> Set[str]:
         """Returns the names of all media files which are referenced on notes in the given deck."""
         notes = AnkiHubNote.select(AnkiHubNote.fields).filter(
+            NOTE_NOT_DELETED_CONDITION,
             (DQ(fields__ilike="%<img%") | DQ(fields__ilike="%[sound:%")),
             ankihub_deck_id=ah_did,
         )

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -385,18 +385,12 @@ class _AnkiHubDB:
                     AnkiHubNote.select(
                         AnkiHubNote.anki_note_id, AnkiHubNote.ankihub_deck_id
                     )
-                    .filter(anki_note_id__in=anki_nids)
+                    .filter(NOTE_NOT_DELETED_CONDITION, anki_note_id__in=anki_nids)
                     .tuples()
                 ),
                 ids=list(anki_nids),
             )
         )
-
-    def are_ankihub_notes(self, anki_nids: List[NoteId]) -> bool:
-        notes_count = execute_count_query_in_chunks(
-            lambda nids: AnkiHubNote.filter(anki_note_id__in=nids).count(), anki_nids
-        )
-        return notes_count == len(set(anki_nids))
 
     def ankihub_nid_for_anki_nid(self, anki_note_id: NoteId) -> Optional[uuid.UUID]:
         return (

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -351,7 +351,7 @@ class _AnkiHubDB:
     def anki_nids_for_ankihub_deck(self, ankihub_did: uuid.UUID) -> List[NoteId]:
         return (
             AnkiHubNote.select(AnkiHubNote.anki_note_id)
-            .filter(ankihub_deck_id=ankihub_did)
+            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ankihub_did)
             .objects(flat)
         )
 
@@ -361,7 +361,7 @@ class _AnkiHubDB:
     def ankihub_did_for_anki_nid(self, anki_nid: NoteId) -> Optional[uuid.UUID]:
         return (
             AnkiHubNote.select(AnkiHubNote.ankihub_deck_id)
-            .filter(anki_note_id=anki_nid)
+            .filter(NOTE_NOT_DELETED_CONDITION, anki_note_id=anki_nid)
             .scalar()
         )
 
@@ -371,7 +371,7 @@ class _AnkiHubDB:
         return execute_list_query_in_chunks(
             lambda anki_nids: (
                 AnkiHubNote.select(AnkiHubNote.ankihub_deck_id)
-                .filter(anki_note_id__in=anki_nids)
+                .filter(NOTE_NOT_DELETED_CONDITION, anki_note_id__in=anki_nids)
                 .distinct()
                 .objects(flat)
             ),
@@ -399,7 +399,7 @@ class _AnkiHubDB:
     def ankihub_nid_for_anki_nid(self, anki_note_id: NoteId) -> Optional[uuid.UUID]:
         return (
             AnkiHubNote.select(AnkiHubNote.ankihub_note_id)
-            .filter(anki_note_id=anki_note_id)
+            .filter(NOTE_NOT_DELETED_CONDITION, anki_note_id=anki_note_id)
             .scalar()
         )
 
@@ -428,7 +428,7 @@ class _AnkiHubDB:
     def anki_nid_for_ankihub_nid(self, ankihub_id: uuid.UUID) -> Optional[NoteId]:
         return (
             AnkiHubNote.select(AnkiHubNote.anki_note_id)
-            .filter(ankihub_note_id=ankihub_id)
+            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_note_id=ankihub_id)
             .scalar()
         )
 
@@ -458,7 +458,10 @@ class _AnkiHubDB:
         return (
             AnkiHubNote.select(AnkiHubNote.ankihub_deck_id)
             .distinct()
-            .filter(DQ(guid__is=None) | DQ(fields__is=None) | DQ(tags__is=None))
+            .filter(
+                NOTE_NOT_DELETED_CONDITION,
+                DQ(guid__is=None) | DQ(fields__is=None) | DQ(tags__is=None),
+            )
             .objects(flat)
         )
 

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -443,9 +443,6 @@ class _AnkiHubDB:
             ).execute()
             DeckMedia.delete().where(DeckMedia.ankihub_deck_id == ankihub_did).execute()
 
-    def ankihub_deck_ids(self) -> List[uuid.UUID]:
-        return AnkiHubNote.select(AnkiHubNote.ankihub_deck_id).distinct().objects(flat)
-
     def last_sync(self, ankihub_note_id: uuid.UUID) -> Optional[int]:
         return (
             AnkiHubNote.select(AnkiHubNote.mod)

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -281,10 +281,14 @@ class _AnkiHubDB:
         # It's possible that an AnkiHub nid does not exists after calling insert_or_update_notes_data
         # with a NoteInfo that has the AnkkiHub nid if a note with the same Anki nid already exists
         # in the AnkiHub DB but in different deck.
-        return AnkiHubNote.filter(ankihub_note_id=ankihub_nid).exists()
+        return AnkiHubNote.filter(
+            NOTE_NOT_DELETED_CONDITION, ankihub_note_id=ankihub_nid
+        ).exists()
 
     def note_data(self, anki_note_id: int) -> Optional[NoteInfo]:
-        note = AnkiHubNote.filter(anki_note_id=anki_note_id).get_or_none()
+        note = AnkiHubNote.filter(
+            NOTE_NOT_DELETED_CONDITION, anki_note_id=anki_note_id
+        ).get_or_none()
 
         if not note:
             return None

--- a/ankihub/gui/browser/custom_search_nodes.py
+++ b/ankihub/gui/browser/custom_search_nodes.py
@@ -10,10 +10,9 @@ import aqt
 from anki.notes import NoteId
 from anki.utils import ids2str
 from aqt.browser import Browser, ItemId
-from peewee import DQ
 
-from ...ankihub_client import SuggestionType, suggestion_type_from_str
-from ...db import execute_list_query_in_chunks, flat
+from ...ankihub_client import suggestion_type_from_str
+from ...db import NOTE_NOT_DELETED_CONDITION, execute_list_query_in_chunks, flat
 from ...db.models import AnkiHubNote
 
 
@@ -94,10 +93,7 @@ class ModifiedAfterSyncSearchNode(CustomSearchNode):
                 lambda nids: (
                     AnkiHubNote.select(AnkiHubNote.anki_note_id, AnkiHubNote.mod)
                     .filter(
-                        (
-                            DQ(last_update_type__is=None)
-                            | DQ(last_update_type__ne=SuggestionType.DELETE.value[0])
-                        ),
+                        NOTE_NOT_DELETED_CONDITION,
                         anki_note_id__in=nids,
                     )
                     .tuples()

--- a/ankihub/gui/operations/db_check/ah_db_check.py
+++ b/ankihub/gui/operations/db_check/ah_db_check.py
@@ -4,7 +4,7 @@ from typing import Callable, List, Optional
 
 from .... import LOGGER
 from ....addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
-from ....db import ankihub_db, flat
+from ....db import NOTE_NOT_DELETED_CONDITION, ankihub_db, flat
 from ....db.models import AnkiHubNote
 from ....main.deck_unsubscribtion import uninstall_deck
 from ....settings import config
@@ -31,7 +31,7 @@ def _fetch_missing_note_types() -> None:
         mids_of_notes_of_deck = (
             AnkiHubNote.select(AnkiHubNote.anki_note_type_id)
             .distinct()
-            .filter(ankihub_deck_id=ah_did)
+            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ah_did)
             .objects(flat)
         )
         mids_of_missing_note_types = [

--- a/ankihub/gui/operations/db_check/ah_db_check.py
+++ b/ankihub/gui/operations/db_check/ah_db_check.py
@@ -27,7 +27,7 @@ def _fetch_missing_note_types() -> None:
     This is necessary because in a previous version of the add-on, note types were not saved in the database.
     """
     client = AnkiHubClient()
-    for ah_did in ankihub_db.ankihub_deck_ids():
+    for ah_did in ankihub_db.ankihub_dids():
         mids_of_notes_of_deck = (
             AnkiHubNote.select(AnkiHubNote.anki_note_type_id)
             .distinct()
@@ -129,6 +129,6 @@ def _try_reinstall_decks_with_something_missing(
 
 
 def _decks_missing_from_config() -> List[uuid.UUID]:
-    ah_dids_from_ankihub_db = ankihub_db.ankihub_deck_ids()
+    ah_dids_from_ankihub_db = ankihub_db.ankihub_dids()
     ah_dids_from_config = config.deck_ids()
     return list(set(ah_dids_from_ankihub_db) - set(ah_dids_from_config))

--- a/ankihub/gui/operations/db_check/anki_db_check.py
+++ b/ankihub/gui/operations/db_check/anki_db_check.py
@@ -7,8 +7,7 @@ from anki.utils import ids2str
 from aqt.utils import showInfo
 
 from .... import LOGGER
-from ....ankihub_client.models import SuggestionType
-from ....db import ankihub_db, flat
+from ....db import NOTE_NOT_DELETED_CONDITION, ankihub_db, flat
 from ....db.models import AnkiHubNote
 from ....main.reset_local_changes import reset_local_changes_to_notes
 from ....settings import ANKIHUB_NOTE_TYPE_FIELD_NAME, config
@@ -97,8 +96,8 @@ def _decks_with_missing_ankihub_nids() -> List[uuid.UUID]:
             nids = (
                 AnkiHubNote.select(AnkiHubNote.anki_note_id)
                 .filter(
+                    NOTE_NOT_DELETED_CONDITION,
                     ankihub_deck_id=ah_did,
-                    last_update_type__ne=SuggestionType.DELETE.value[0],
                 )
                 .objects(flat)
             )

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -1,6 +1,7 @@
 """Code for resetting notes to the state they have in the AnkiHub database.
 (This is the state that the notes had on AnkiHub when the add-on synced with AnkiHub last time.)
 """
+
 import uuid
 from typing import Sequence
 
@@ -24,11 +25,7 @@ def reset_local_changes_to_notes(
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
 
-    notes_data = [
-        note_data
-        for nid in nids
-        if (note_data := ankihub_db.note_data(nid)) is not None
-    ]
+    notes_data = ankihub_db.notes_data_for_anki_nids(nids)
     note_types = {
         mid: ankihub_db.note_type_dict(ankihub_did=ah_did, note_type_id=mid)
         for mid in ankihub_db.note_types_for_ankihub_deck(ah_did)

--- a/ankihub/main/subdecks.py
+++ b/ankihub/main/subdecks.py
@@ -15,6 +15,7 @@ from anki.notes import NoteId
 
 from .. import LOGGER
 from ..db import ankihub_db
+from ..db.db import NOTE_NOT_DELETED_CONDITION
 from ..db.models import AnkiHubNote
 from ..settings import config
 from .utils import (
@@ -29,6 +30,7 @@ SUBDECK_TAG = "AnkiHub_Subdeck"
 def deck_contains_subdeck_tags(ah_did: uuid.UUID) -> bool:
     """Return whether the given deck contains any notes which have subdeck tags in the AnkiHub database."""
     return AnkiHubNote.filter(
+        NOTE_NOT_DELETED_CONDITION,
         ankihub_deck_id=ah_did,
         tags__ilike=f"%{SUBDECK_TAG}::%::%",
     ).exists()

--- a/tests/addon/performance/test_ankihub_importer.py
+++ b/tests/addon/performance/test_ankihub_importer.py
@@ -41,7 +41,7 @@ def import_anking_notes(
     def import_anking_notes_inner(
         anking_notes_data: List[NoteInfo],
     ) -> None:
-        first_import = ah_did not in ankihub_db.ankihub_deck_ids()
+        first_import = ah_did not in ankihub_db.ankihub_dids()
         importer = AnkiHubImporter()
         importer.import_ankihub_deck(
             ankihub_did=ah_did,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -979,7 +979,7 @@ class TestDownloadAndInstallDecks:
             assert aqt.mw.col.get_note(NoteId(notes_data[0].anki_nid)) is not None
 
             # ... in the AnkiHub database
-            ankihub_db.ankihub_deck_ids() == [deck.ah_did]
+            ankihub_db.ankihub_dids() == [deck.ah_did]
             assert ankihub_db.note_data(NoteId(notes_data[0].anki_nid)) == notes_data[0]
 
             # ... in the config
@@ -2487,7 +2487,7 @@ class TestAnkiHubImporter:
 
 
 def assert_that_only_ankihub_sample_deck_info_in_database(ah_did: uuid.UUID):
-    assert ankihub_db.ankihub_deck_ids() == [ah_did]
+    assert ankihub_db.ankihub_dids() == [ah_did]
     assert len(ankihub_db.anki_nids_for_ankihub_deck(ah_did)) == 3
 
 
@@ -4126,7 +4126,7 @@ def test_profile_swap(
         install_sample_ah_deck()
 
         # the database should contain the imported deck
-        assert len(ankihub_db.ankihub_deck_ids()) == 1
+        assert len(ankihub_db.ankihub_dids()) == 1
         # the config should contain the deck subscription
         assert len(config.deck_ids()) == 1
 
@@ -4140,7 +4140,7 @@ def test_profile_swap(
     with anki_session.profile_loaded():
         assert profile_files_path() == ankihub_base_path() / str(PROFILE_2_ID)
         # the database should be empty
-        assert len(ankihub_db.ankihub_deck_ids()) == 0
+        assert len(ankihub_db.ankihub_dids()) == 0
         # the config should not conatin any deck subscriptions
         assert len(config.deck_ids()) == 0
 
@@ -4149,7 +4149,7 @@ def test_profile_swap(
     with anki_session.profile_loaded():
         assert profile_files_path() == ankihub_base_path() / str(PROFILE_1_ID)
         # the database should contain the imported deck
-        assert len(ankihub_db.ankihub_deck_ids()) == 1
+        assert len(ankihub_db.ankihub_dids()) == 1
         # the config should contain the deck subscription
         assert len(config.deck_ids()) == 1
 
@@ -4431,9 +4431,7 @@ class TestSyncWithAnkiHub:
             # Assert that the deck was uninstalled if the user is not subscribed to it,
             # else assert that it was not uninstalled
             assert config.deck_ids() == ([ah_did] if subscribed_to_deck else [])
-            assert ankihub_db.ankihub_deck_ids() == (
-                [ah_did] if subscribed_to_deck else []
-            )
+            assert ankihub_db.ankihub_dids() == ([ah_did] if subscribed_to_deck else [])
 
             mids = [
                 mw.col.get_note(nid).mid for nid in mw.col.find_notes(f"did:{anki_did}")
@@ -5996,7 +5994,7 @@ class TestAHDBCheck:
                 assert config.deck_ids() == [ah_did]
             elif user_confirms and not deck_exists_on_ankihub:
                 # The deck could't be installed because it doesn't exist, was uninstalled completely
-                assert ankihub_db.ankihub_deck_ids() == []
+                assert ankihub_db.ankihub_dids() == []
             else:
                 # User didn't confirm, nothing to do
                 assert mocks["get_deck_by_id"].call_count == 0

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1285,55 +1285,6 @@ class TestAnkiHubDBAnkiHubNidsToAnkiIds:
         }
 
 
-class TestAnkiHubDBAreAnkiHubNotes:
-    def test_with_one_ankihub_note(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        ankihub_db: _AnkiHubDB,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            note_info = import_ah_note()
-            assert ankihub_db.are_ankihub_notes(anki_nids=[NoteId(note_info.anki_nid)])
-
-    def test_with_multiple_ankihub_notes(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        ankihub_db: _AnkiHubDB,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            note_info_1 = import_ah_note()
-            note_info_2 = import_ah_note()
-            assert ankihub_db.are_ankihub_notes(
-                anki_nids=[NoteId(note_info_1.anki_nid), NoteId(note_info_2.anki_nid)]
-            )
-
-    def test_with_one_non_ankihub_note(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        ankihub_db: _AnkiHubDB,
-        add_anki_note: AddAnkiNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            anki_note = add_anki_note()
-            assert not ankihub_db.are_ankihub_notes(anki_nids=[anki_note.id])
-
-    def test_with_mixed_notes(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        ankihub_db: _AnkiHubDB,
-        import_ah_note: ImportAHNote,
-        add_anki_note: AddAnkiNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            anki_note = add_anki_note()
-            note_info = import_ah_note()
-            assert not ankihub_db.are_ankihub_notes(
-                anki_nids=[anki_note.id, NoteId(note_info.anki_nid)]
-            )
-
-
 class TestAnkiHubDBRemoveNotes:
     def test_remove_notes(
         self,


### PR DESCRIPTION
We are currently not filtering out deleted notes in some DB queries where they should be filtered out.

This leads to issues such as the one reported here: https://community.ankihub.net/t/i-am-not-able-to-reset-the-local-changes-made-to-tha-anki-hub-deck/323705/16 

This task fixes this.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-741

Community report: https://community.ankihub.net/t/i-am-not-able-to-reset-the-local-changes-made-to-tha-anki-hub-deck/323705/18

Sentry: https://ankihub.sentry.io/issues/5592235372/?project=6546414&query=id%3A88e49e2126f14c1eb809372a9b4cae4f&referrer=issue-stream&statsPeriod=90d&stream_index=0.

## Proposed changes
- [Speed up resetting local changes, skip deleted notes](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1020/commits/8aad50c9de9bd1902f37d7ffd997b7cdc04139dd)
  - We are currently calling `ankihub_db.note_data` in a loop when resetting local changes for the deck. Every call requires a DB query. This is very slow when a lot of notes are involved.
  - With this PR the note data will be queried in bulk instead
  - Also, deleted notes won't be reset anymore. This fixes the reported issue mentioned above
- [Ignore non ankihub notes when resetting notes or suggesting optional tag](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1020/commits/fe617a1aae3f3233457e313a74cd659728d40e63)
  - Currently, when you select some notes in the browser and some of them are AnkiHub notes and some are not, you get this message: "Please only select notes with AnkiHub ids to reset local changes.". 
  - With this PR non-AnkiHub notes will be ignored while AnkiHub notes will be reset.
  - This change was made to keep the behavior consistent - it should work when selecting a mix of deleted and not-deleted notes.
- Deleted notes are now filtered out from queries in `AnkiHubDB` methods
- Deleted notes are now filtered out from selected queries outside `AnkiHubDB` methods
  - [Use NOTE_NOT_DELETED_CONDITION outside db.py](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1020/commits/2b1a1372fc2f14eba172f29cd3942914cde61d6f)

## How to reproduce
You can reproduce the [error](https://ankihub.sentry.io/issues/5592235372/?project=6546414&query=id%3A88e49e2126f14c1eb809372a9b4cae4f&referrer=issue-stream&statsPeriod=90d&stream_index=0.) like this:
- Subscribe to https://app.ankihub.net/decks/136f5006-e2b4-4a37-a5cd-3c3bd5c542a4 on production
- Install the deck
- Go to the Anki browser -> AnkiHub -> Reset local changes for deck
  - This takes very long without the changes in the PR

With the changes in the PR the error doesn't occur.