### PR TITLE
[BUILD-746] Create client method for storing review data

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -46,6 +46,7 @@ from .models import (
     ANKIHUB_DATETIME_FORMAT_STR,
     CardReviewData,
     ChangeNoteSuggestion,
+    DailyCardReviewSummary,
     Deck,
     DeckExtension,
     DeckExtensionUpdateChunk,
@@ -1273,6 +1274,18 @@ class AnkiHubClient:
             API.ANKIHUB,
             "/users/card-review-data/",
             json=[review.to_dict() for review in card_review_data],
+        )
+        if response.status_code != 200:
+            raise AnkiHubHTTPError(response)
+
+    def send_daily_card_review_summaries(
+        self, daily_card_review_summaries: List[DailyCardReviewSummary]
+    ) -> None:
+        response = self._send_request(
+            "POST",
+            API.ANKIHUB,
+            "/users/daily-card-review-summary/",
+            json=[summary.to_dict() for summary in daily_card_review_summaries],
         )
         if response.status_code != 200:
             raise AnkiHubHTTPError(response)

--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1281,14 +1281,15 @@ class AnkiHubClient:
     def send_daily_card_review_summaries(
         self, daily_card_review_summaries: List[DailyCardReviewSummary]
     ) -> None:
-        response = self._send_request(
-            "POST",
-            API.ANKIHUB,
-            "/users/daily-card-review-summary/",
-            json=[summary.to_dict() for summary in daily_card_review_summaries],
-        )
-        if response.status_code != 200:
-            raise AnkiHubHTTPError(response)
+        for summary in daily_card_review_summaries:
+            response = self._send_request(
+                "POST",
+                API.ANKIHUB,
+                "/users/daily-card-review-summary/",
+                json=summary.to_dict(),
+            )
+            if response.status_code != 201:
+                raise AnkiHubHTTPError(response)
 
 
 class ThreadLocalSession:

--- a/ankihub/ankihub_client/models.py
+++ b/ankihub/ankihub_client/models.py
@@ -323,7 +323,7 @@ class CardReviewData(DataClassJSONMixinWithConfig):
 
 
 @dataclass
-class DailyCardReviewSummaryData(DataClassJSONMixinWithConfig):
+class DailyCardReviewSummary(DataClassJSONMixinWithConfig):
     review_session_date: date
     total_cards_studied: int = 0
     total_time_reviewing: int = 0

--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -9,7 +9,7 @@ from anki import consts as anki_consts
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..ankihub_client import CardReviewData
-from ..ankihub_client.models import DailyCardReviewSummaryData
+from ..ankihub_client.models import DailyCardReviewSummary
 from ..db import ankihub_db
 from ..settings import config
 
@@ -95,9 +95,9 @@ def _ms_timestamp_to_datetime(timestamp: int) -> datetime:
     return datetime.fromtimestamp(timestamp / 1000)
 
 
-def get_daily_review_data_since_last_sync(
+def get_daily_review_summaries_since_last_sync(
     last_sync: datetime,
-) -> List[DailyCardReviewSummaryData]:
+) -> List[DailyCardReviewSummary]:
     """Filter revlog entries between the date of the last sync and the end of yesterday
     group by days, and compile the data."""
     end_of_yesterday = datetime.now().replace(
@@ -135,7 +135,7 @@ def get_daily_review_data_since_last_sync(
         total_cards_marked_as_easy = sum(1 for ease, _ in item if ease == 4)
 
         daily_card_review_data.append(
-            DailyCardReviewSummaryData(
+            DailyCardReviewSummary(
                 total_cards_studied=total_cards_studied,
                 total_time_reviewing=total_time_reviewing,
                 total_cards_marked_as_again=total_cards_marked_as_again,

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -31,12 +31,12 @@ from requests_mock import Mocker
 from ankihub.ankihub_client.ankihub_client import DEFAULT_API_URL
 from ankihub.ankihub_client.models import (  # type: ignore
     CardReviewData,
-    DailyCardReviewSummaryData,
+    DailyCardReviewSummary,
     UserDeckExtensionRelation,
 )
 from ankihub.gui import menu
 from ankihub.gui.config_dialog import setup_config_dialog_manager
-from ankihub.main.review_data import get_daily_review_data_since_last_sync
+from ankihub.main.review_data import get_daily_review_summaries_since_last_sync
 from ankihub.settings import ANKIHUB_TEMPLATE_END_COMMENT, DatadogLogHandler
 
 from ..factories import (
@@ -2925,10 +2925,10 @@ def test_get_daily_review_data_since_last_sync(mocker, anki_session_with_addon_d
             "ankihub.main.review_data.aqt.mw.col.db.all", return_value=mock_rows
         )
 
-        result = get_daily_review_data_since_last_sync(last_sync)
+        result = get_daily_review_summaries_since_last_sync(last_sync)
 
         expected_data = [
-            DailyCardReviewSummaryData(
+            DailyCardReviewSummary(
                 total_cards_studied=2,
                 total_time_reviewing=70,
                 total_cards_marked_as_again=1,
@@ -2937,7 +2937,7 @@ def test_get_daily_review_data_since_last_sync(mocker, anki_session_with_addon_d
                 total_cards_marked_as_easy=0,
                 review_session_date=(last_sync).date(),
             ),
-            DailyCardReviewSummaryData(
+            DailyCardReviewSummary(
                 total_cards_studied=2,
                 total_time_reviewing=110,
                 total_cards_marked_as_again=0,
@@ -2964,6 +2964,6 @@ def test_get_daily_review_data_no_reviews(mocker, anki_session_with_addon_data):
         last_sync = datetime.now() - timedelta(days=2)
         mocker.patch("ankihub.main.review_data.aqt.mw.col.db.all", return_value=[])
 
-        result = get_daily_review_data_since_last_sync(last_sync)
+        result = get_daily_review_summaries_since_last_sync(last_sync)
 
         assert result == []

--- a/tests/client/cassettes/TestSendDailyCardReviewSummaries.test_basic.yaml
+++ b/tests/client/cassettes/TestSendDailyCardReviewSummaries.test_basic.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: '{"username": "test1", "password": "asdf"}'
+    headers:
+      Accept:
+      - application/json; version=18.0
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8000/api/login/
+  response:
+    body:
+      string: '{"expiry":"2024-11-26T14:56:39.026958Z","token":"98b3a1ea6e551cfbc3be2aaf8322262a52dfe9ff12fba43b41ab18d93ad53ae2"}'
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Content-Language:
+      - en-us
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - unsafe-none
+      Date:
+      - Tue, 29 Oct 2024 14:56:39 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - WSGIServer/0.2 CPython/3.12.3
+      Server-Timing:
+      - TimerPanel_utime;dur=247.85699999999977;desc="User CPU time", TimerPanel_stime;dur=139.52399999999977;desc="System
+        CPU time", TimerPanel_total;dur=387.3809999999995;desc="Total CPU time", TimerPanel_total_time;dur=322.69483400159515;desc="Elapsed
+        time", SQLPanel_sql_time;dur=7.795634999638423;desc="SQL 16 queries", CachePanel_total_time;dur=0;desc="Cache
+        0 Calls"
+      Set-Cookie:
+      - csrftoken=dLPd0WlnUlx7SxlNVEqhd2l9oqONo2DR; expires=Tue, 28 Oct 2025 14:56:39
+        GMT; HttpOnly; Max-Age=31449600; Path=/; SameSite=Lax
+      - sessionid=7b355u25if93f8wel7nbb4frrem9qjvp; expires=Tue, 05 Nov 2024 14:56:39
+        GMT; HttpOnly; Max-Age=604800; Path=/; SameSite=Lax
+      Vary:
+      - Accept, Cookie, Accept-Language, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      djdt-store-id:
+      - e374674c79b441f09f9074c7fe1f2046
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"review_session_date": "2024-10-29", "total_cards_studied": 0, "total_time_reviewing":
+      0, "total_cards_marked_as_again": 0, "total_cards_marked_as_hard": 0, "total_cards_marked_as_good":
+      0, "total_cards_marked_as_easy": 0}'
+    headers:
+      Accept:
+      - application/json; version=18.0
+      Authorization:
+      - Token 98b3a1ea6e551cfbc3be2aaf8322262a52dfe9ff12fba43b41ab18d93ad53ae2
+      Content-Length:
+      - '223'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8000/api/users/daily-card-review-summary/
+  response:
+    body:
+      string: '{"total_cards_studied":0,"total_time_reviewing":0,"total_cards_marked_as_again":0,"total_cards_marked_as_hard":0,"total_cards_marked_as_good":0,"total_cards_marked_as_easy":0,"review_session_date":"2024-10-29"}'
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Content-Language:
+      - en-us
+      Content-Length:
+      - '210'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - unsafe-none
+      Date:
+      - Tue, 29 Oct 2024 14:56:39 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - WSGIServer/0.2 CPython/3.12.3
+      Server-Timing:
+      - TimerPanel_utime;dur=62.96799999999969;desc="User CPU time", TimerPanel_stime;dur=2.1849999999998815;desc="System
+        CPU time", TimerPanel_total;dur=65.15299999999957;desc="Total CPU time", TimerPanel_total_time;dur=72.02545699874463;desc="Elapsed
+        time", SQLPanel_sql_time;dur=2.175153000280261;desc="SQL 6 queries", CachePanel_total_time;dur=0.10115800068888348;desc="Cache
+        2 Calls"
+      Vary:
+      - Accept, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      djdt-store-id:
+      - abef50c7e6584bd195b496fa030bd23f
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -8,7 +8,7 @@ import tempfile
 import uuid
 import zipfile
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Generator, List, Optional, cast
 from unittest.mock import Mock
@@ -52,6 +52,7 @@ from ankihub.ankihub_client import (
 from ankihub.ankihub_client.models import (
     ANKIHUB_DATETIME_FORMAT_STR,
     CardReviewData,
+    DailyCardReviewSummary,
     DeckUpdates,
     NotesActionChoices,
     UserDeckExtensionRelation,
@@ -1781,6 +1782,21 @@ class TestSendCardReviewData:
         )
 
         authorized_client_for_user_test1.send_card_review_data([card_review_data])
+
+
+@pytest.mark.vcr()
+class TestSendDailyCardReviewSummaries:
+    def test_basic(
+        self,
+        authorized_client_for_user_test1: AnkiHubClient,
+    ) -> None:
+        daily_card_review_summaries = [
+            DailyCardReviewSummary(review_session_date=date.today())
+        ]
+
+        authorized_client_for_user_test1.send_daily_card_review_summaries(
+            daily_card_review_summaries
+        )
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
Create a new method on the addon to access the new endpoint created to store the daily summary of the review stats.

## Related issues
https://ankihub.atlassian.net/browse/BUILD-746


## Proposed changes
- Rename `DailyCardReviewSummaryData` to DailyCardReviewSummary`
  - [ref: Rename DailyCardReviewSummary](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1023/commits/0fca729533d09bbcf0b1fadf8bd8f33b3df7fa16)
  - It's the same name as the model on the web app
- Add `send_daily_card_review_summaries` method to `AnkiHubClient`
- Add test

