### PR TITLE
 [BUILD-748] feat: Add function to send the daily summary review data after the sync

### DIFF
--- a/ankihub/feature_flags.py
+++ b/ankihub/feature_flags.py
@@ -1,6 +1,5 @@
 """Feature flags are used to enable/disable features on the client side. The flags are fetched from the server."""
 
-from dataclasses import asdict, dataclass, fields
 from typing import Callable, List
 
 import aqt
@@ -10,15 +9,12 @@ from .addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from .ankihub_client import AnkiHubHTTPError, AnkiHubRequestException
 from .gui.operations import AddonQueryOp
 
-
-@dataclass
-class _FeatureFlags:
-    show_flashcards_selector_button: bool = False
-    chatbot: bool = False
-    send_addon_logs_to_datadog: bool = False
-
-
-feature_flags = _FeatureFlags()
+# TODO: We should replace these values with values of a environment variable
+feature_flags = {
+    "show_flashcards_selector_button": False,
+    "chatbot": False,
+    "send_addon_logs_to_datadog": False,
+}
 
 # List of callbacks that are called when the feature flags are updated.
 # This can e.g. be used to update the UI once the feature flags are fetched.
@@ -41,33 +37,14 @@ def update_feature_flags_in_background() -> None:
 
 def _setup_feature_flags() -> None:
     """Fetch feature flags from the server. If the server is not reachable, use the default values."""
-
-    if not fields(_FeatureFlags):
-        return
     try:
         feature_flags_dict = AnkiHubClient().get_feature_flags()
-    except (AnkiHubRequestException, AnkiHubHTTPError) as e:
-        LOGGER.warning(
-            "Failed to fetch feature flags from the server, using default values.",
-            exc_info=e,
-        )
-        feature_flags_dict = {}
+    except (AnkiHubRequestException, AnkiHubHTTPError):
+        pass
 
-    # Set the feature flags to the values fetched from the server or to the default values
-    for field in fields(_FeatureFlags):
-        try:
-            value = feature_flags_dict[field.name]
-        except KeyError:
-            setattr(feature_flags, field.name, field.default)
-            LOGGER.warning(
-                "No such feature flag found, using default value",
-                feature_flag=field.name,
-                default_value=field.default,
-            )
-        else:
-            setattr(feature_flags, field.name, value)
+    feature_flags = feature_flags_dict
 
-    LOGGER.info("Feature flags", feature_flags=asdict(feature_flags))
+    LOGGER.info("Feature flags", feature_flags=feature_flags)
 
 
 def add_feature_flags_update_callback(callback: Callable[[], None]) -> None:

--- a/ankihub/feature_flags.py
+++ b/ankihub/feature_flags.py
@@ -8,13 +8,7 @@ from . import LOGGER
 from .addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from .ankihub_client import AnkiHubHTTPError, AnkiHubRequestException
 from .gui.operations import AddonQueryOp
-
-# TODO: We should replace these values with values of a environment variable
-feature_flags = {
-    "show_flashcards_selector_button": False,
-    "chatbot": False,
-    "send_addon_logs_to_datadog": False,
-}
+from .settings import config
 
 # List of callbacks that are called when the feature flags are updated.
 # This can e.g. be used to update the UI once the feature flags are fetched.
@@ -42,9 +36,8 @@ def _setup_feature_flags() -> None:
     except (AnkiHubRequestException, AnkiHubHTTPError):
         pass
 
-    feature_flags = feature_flags_dict
-
-    LOGGER.info("Feature flags", feature_flags=feature_flags)
+    config.set_feature_flags(feature_flags_dict)
+    LOGGER.info("Feature flags", feature_flags=feature_flags_dict)
 
 
 def add_feature_flags_update_callback(callback: Callable[[], None]) -> None:

--- a/ankihub/feature_flags.py
+++ b/ankihub/feature_flags.py
@@ -31,10 +31,13 @@ def update_feature_flags_in_background() -> None:
 
 def _setup_feature_flags() -> None:
     """Fetch feature flags from the server. If the server is not reachable, use the default values."""
+    feature_flags_dict = {}
     try:
         feature_flags_dict = AnkiHubClient().get_feature_flags()
-    except (AnkiHubRequestException, AnkiHubHTTPError):
-        pass
+    except (AnkiHubRequestException, AnkiHubHTTPError) as exc:
+        LOGGER.error(f"Failed to fetch feature flags: {exc}. Using default values.")
+    else:
+        config.set_feature_flags(feature_flags_dict)
 
     config.set_feature_flags(feature_flags_dict)
     LOGGER.info("Feature flags", feature_flags=feature_flags_dict)

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -134,15 +134,17 @@ def _on_sync_done(future: Future, on_done: Callable[[Future], None]) -> None:
     last_summary_sent_date = config.get_last_summary_sent_date()
     if not last_summary_sent_date:
         last_summary_sent_date = (
-            datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(microseconds=1)
-        ) - timedelta(days=1)
+            (
+                datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                - timedelta(microseconds=1)
+            )
+            - timedelta(days=1)
+        ).date()
 
     feature_flags = config.get_feature_flags()
     if (
         feature_flags.get("daily_card_review_summary", False)
-        and last_summary_sent_date
-        and last_summary_sent_date.date() < datetime.now().date()
+        and last_summary_sent_date < datetime.now().date()
     ):
         aqt.mw.taskman.run_in_background(
             lambda: send_daily_review_summaries(last_summary_sent_date),

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 from functools import partial
 from typing import Callable, List, Optional
 
@@ -133,18 +133,12 @@ def _on_sync_done(future: Future, on_done: Callable[[Future], None]) -> None:
 
     last_summary_sent_date = config.get_last_summary_sent_date()
     if not last_summary_sent_date:
-        last_summary_sent_date = (
-            (
-                datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-                - timedelta(microseconds=1)
-            )
-            - timedelta(days=1)
-        ).date()
+        last_summary_sent_date = date.today() - timedelta(days=1)
 
     feature_flags = config.get_feature_flags()
     if (
         feature_flags.get("daily_card_review_summary", False)
-        and last_summary_sent_date < datetime.now().date()
+        and last_summary_sent_date < date.today()
     ):
         aqt.mw.taskman.run_in_background(
             lambda: send_daily_review_summaries(last_summary_sent_date),

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -15,7 +15,7 @@ from aqt.webview import AnkiWebView
 from jinja2 import Template
 
 from .. import LOGGER
-from ..feature_flags import add_feature_flags_update_callback, feature_flags
+from ..feature_flags import add_feature_flags_update_callback
 from ..settings import config, url_flashcard_selector, url_flashcard_selector_embed
 from .deck_updater import ah_deck_updater
 from .js_message_handling import parse_js_message_kwargs
@@ -63,6 +63,7 @@ def _maybe_add_flashcard_selector_button() -> None:
     ):
         return
 
+    feature_flags = config.get_feature_flags()
     if not feature_flags.get("show_flashcards_selector_button", False):
         LOGGER.debug(
             "Feature flag to show flashcard selector button is disabled, not adding the button."

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -63,7 +63,7 @@ def _maybe_add_flashcard_selector_button() -> None:
     ):
         return
 
-    if not feature_flags.show_flashcards_selector_button:
+    if not feature_flags.get("show_flashcards_selector_button", False):
         LOGGER.debug(
             "Feature flag to show flashcard selector button is disabled, not adding the button."
         )

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -112,7 +112,7 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
     if not isinstance(context, Reviewer):
         return
 
-    if not feature_flags.chatbot:
+    if not feature_flags.get("chatbot", False):
         return
 
     reviewer: Reviewer = context
@@ -151,7 +151,7 @@ def _ankihub_theme() -> str:
 
 
 def _notify_ankihub_ai_of_card_change(card: Card) -> None:
-    if not feature_flags.chatbot:
+    if not feature_flags.get("chatbot", False):
         return
 
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(card.nid)
@@ -162,7 +162,7 @@ def _notify_ankihub_ai_of_card_change(card: Card) -> None:
 def _remove_anking_button(_: Card) -> None:
     """Removes the AnKing button (provided by the AnKing note types) from the webview if it exists.
     This is necessary because it overlaps with the AnkiHub AI chatbot button."""
-    if not feature_flags.chatbot:
+    if not feature_flags.get("chatbot", False):
         return
 
     js = _wrap_with_ankihubAI_check(REMOVE_ANKING_BUTTON_JS_PATH.read_text())
@@ -170,7 +170,7 @@ def _remove_anking_button(_: Card) -> None:
 
 
 def _set_token_for_ankihub_ai_js() -> None:
-    if not feature_flags.chatbot:
+    if not feature_flags.get("chatbot", False):
         return
 
     js = _wrap_with_ankihubAI_check(f"ankihubAI.setToken('{config.token()}');")

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -18,7 +18,6 @@ from aqt.webview import WebContent
 from jinja2 import Template
 
 from ..db import ankihub_db
-from ..feature_flags import feature_flags
 from ..gui.menu import AnkiHubLogin
 from ..settings import config
 from .js_message_handling import VIEW_NOTE_PYCMD
@@ -112,6 +111,7 @@ def _add_ankihub_ai_js_to_reviewer_web_content(web_content: WebContent, context)
     if not isinstance(context, Reviewer):
         return
 
+    feature_flags = config.get_feature_flags()
     if not feature_flags.get("chatbot", False):
         return
 
@@ -151,6 +151,7 @@ def _ankihub_theme() -> str:
 
 
 def _notify_ankihub_ai_of_card_change(card: Card) -> None:
+    feature_flags = config.get_feature_flags()
     if not feature_flags.get("chatbot", False):
         return
 
@@ -162,6 +163,7 @@ def _notify_ankihub_ai_of_card_change(card: Card) -> None:
 def _remove_anking_button(_: Card) -> None:
     """Removes the AnKing button (provided by the AnKing note types) from the webview if it exists.
     This is necessary because it overlaps with the AnkiHub AI chatbot button."""
+    feature_flags = config.get_feature_flags()
     if not feature_flags.get("chatbot", False):
         return
 
@@ -170,6 +172,7 @@ def _remove_anking_button(_: Card) -> None:
 
 
 def _set_token_for_ankihub_ai_js() -> None:
+    feature_flags = config.get_feature_flags()
     if not feature_flags.get("chatbot", False):
         return
 

--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -146,3 +146,22 @@ def get_daily_review_summaries_since_last_sync(
             )
         )
     return daily_card_review_data
+
+
+def send_daily_review_summaries() -> None:
+    """Send daily review summaries to the server."""
+    last_summary_sent_date = config.get_last_summary_sent_date()
+    if not last_summary_sent_date:
+        last_summary_sent_date = (
+            datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(microseconds=1)
+        ) - timedelta(days=1)
+
+    daily_review_summaries = get_daily_review_summaries_since_last_sync(
+        last_summary_sent_date
+    )
+    client = AnkiHubClient()
+    client.send_daily_card_review_summaries(daily_review_summaries)
+
+    LOGGER.info("Daily review summaries sent to AnkiHub.")
+    config.save_last_summary_sent_date(datetime.now())

--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -162,4 +162,4 @@ def send_daily_review_summaries(last_summary_sent_date: date) -> None:
     else:
         LOGGER.info("No daily review summaries to send to AnkiHub.")
 
-    config.save_last_summary_sent_date(datetime.now().date())
+    config.save_last_summary_sent_date(date.today())

--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -148,20 +148,16 @@ def get_daily_review_summaries_since_last_sync(
     return daily_card_review_data
 
 
-def send_daily_review_summaries() -> None:
+def send_daily_review_summaries(last_summary_sent_date) -> None:
     """Send daily review summaries to the server."""
-    last_summary_sent_date = config.get_last_summary_sent_date()
-    if not last_summary_sent_date:
-        last_summary_sent_date = (
-            datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(microseconds=1)
-        ) - timedelta(days=1)
-
     daily_review_summaries = get_daily_review_summaries_since_last_sync(
         last_summary_sent_date
     )
     client = AnkiHubClient()
-    client.send_daily_card_review_summaries(daily_review_summaries)
+    if daily_review_summaries:
+        client.send_daily_card_review_summaries(daily_review_summaries)
+        LOGGER.info("Daily review summaries sent to AnkiHub.")
+    else:
+        LOGGER.info("No daily review summaries to send to AnkiHub.")
 
-    LOGGER.info("Daily review summaries sent to AnkiHub.")
     config.save_last_summary_sent_date(datetime.now())

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -15,7 +15,7 @@ import time
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from json import JSONDecodeError
 from logging.handlers import RotatingFileHandler
@@ -179,7 +179,7 @@ class PrivateConfig(DataClassJSONMixin):
     # used to determine whether to skip the full sync dialog
     # and choose "Upload" for the user automatically on next sync.
     schema_to_do_full_upload_for_once: Optional[int] = None
-    last_summary_sent_date: Optional[datetime] = None
+    last_summary_sent_date: Optional[date] = None
     feature_flags: dict = field(default_factory=dict)
 
 
@@ -280,7 +280,7 @@ class _Config:
         self.deck_config(ankihub_did).latest_media_update = latest_media_update
         self._update_private_config()
 
-    def save_last_summary_sent_date(self, last_summary_sent_date: Optional[datetime]):
+    def save_last_summary_sent_date(self, last_summary_sent_date: Optional[date]):
         self._private_config.last_summary_sent_date = last_summary_sent_date
         self._update_private_config()
 
@@ -414,7 +414,7 @@ class _Config:
     def deck_extension_ids(self) -> List[int]:
         return list(self._private_config.deck_extensions.keys())
 
-    def get_last_summary_sent_date(self) -> Optional[datetime]:
+    def get_last_summary_sent_date(self) -> Optional[date]:
         return self._private_config.last_summary_sent_date
 
     def create_or_update_deck_extension_config(self, extension: DeckExtension) -> None:

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -14,7 +14,7 @@ import threading
 import time
 import uuid
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from json import JSONDecodeError
@@ -180,6 +180,7 @@ class PrivateConfig(DataClassJSONMixin):
     # and choose "Upload" for the user automatically on next sync.
     schema_to_do_full_upload_for_once: Optional[int] = None
     last_summary_sent_date: Optional[datetime] = None
+    feature_flags: dict = field(default_factory=dict)
 
 
 class _Config:
@@ -304,6 +305,13 @@ class _Config:
             ankihub_did
         ).behavior_on_remote_note_deleted = note_delete_behavior
         self._update_private_config()
+
+    def set_feature_flags(self, feature_flags: Optional[dict]):
+        self._private_config.feature_flags = feature_flags
+        self._update_private_config()
+
+    def get_feature_flags(self) -> Optional[dict]:
+        return self._private_config.feature_flags
 
     def add_deck(
         self,
@@ -764,7 +772,7 @@ class DatadogLogHandler(logging.Handler):
         # flush is also called when the logging module shuts down when Anki is closing.
         # in_background=False is used to not create a new thread when the add-on is closing,
         # as this leads to an error in the shutdown, because at this point no new threads can be created.
-        from .feature_flags import feature_flags
+        feature_flags = config.get_feature_flags()
 
         if not feature_flags.get("send_addon_logs_to_datadog", False):
             with self.lock:

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -95,12 +95,13 @@ def anki_session_with_addon_data(
         os.environ["ANKIHUB_BASE_PATH"] = tmpdir
 
         # Create temporary private config json file
-        with open(os.path.join(tmpdir, "private_config.json"), "w") as f:
-            f.write(json.dumps({}))
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_file:
+            temp_file.write(json.dumps({}).encode('utf-8'))
+            temp_file_path = temp_file.name
 
         config.setup_public_config_and_other_settings()
         config._private_config = PrivateConfig()
-        config._private_config_path = tmpdir + "/private_config.json"
+        config._private_config_path = temp_file_path
         setup_logger()
 
         mock_all_feature_flags_to_default_values()
@@ -112,6 +113,7 @@ def anki_session_with_addon_data(
             with anki_session.profile_loaded():
                 _profile_setup()
 
+        os.remove(temp_file_path)
         yield anki_session
 
 

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -101,7 +101,7 @@ def anki_session_with_addon_data(
 
         config.setup_public_config_and_other_settings()
         config._private_config = PrivateConfig()
-        config._private_config_path = temp_file_path
+        config._private_config_path = Path(temp_file_path)
         setup_logger()
 
         mock_all_feature_flags_to_default_values()

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -82,7 +82,7 @@ def anki_session_with_addon_data(
     Instead the tests run the code in the ankihub folder of the repo.
     """
     from ankihub.entry_point import _profile_setup
-    from ankihub.settings import config, setup_logger
+    from ankihub.settings import PrivateConfig, config, setup_logger
 
     # Add the add-ons public config to Anki
     config_path = REPO_ROOT_PATH / "ankihub" / "config.json"
@@ -94,7 +94,13 @@ def anki_session_with_addon_data(
         # Change the ankihub base path to a temporary folder to isolate the tests
         os.environ["ANKIHUB_BASE_PATH"] = tmpdir
 
+        # Create temporary private config json file
+        with open(os.path.join(tmpdir, "private_config.json"), "w") as f:
+            f.write(json.dumps({}))
+
         config.setup_public_config_and_other_settings()
+        config._private_config = PrivateConfig()
+        config._private_config_path = tmpdir + "/private_config.json"
         setup_logger()
 
         mock_all_feature_flags_to_default_values()

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -96,7 +96,7 @@ def anki_session_with_addon_data(
 
         # Create temporary private config json file
         with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_file:
-            temp_file.write(json.dumps({}).encode('utf-8'))
+            temp_file.write(json.dumps({}).encode("utf-8"))
             temp_file_path = temp_file.name
 
         config.setup_public_config_and_other_settings()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2988,7 +2988,7 @@ def test_get_daily_review_data_no_reviews(mocker, anki_session_with_addon_data):
 
 
 def test_send_daily_review_summaries_with_data(mocker):
-    last_summary_sent_date = datetime.now() - timedelta(days=1)
+    last_summary_sent_date = (datetime.now() - timedelta(days=1)).date()
     mock_summary = MagicMock()
 
     mock_config = mocker.patch("ankihub.main.review_data.config")
@@ -3007,11 +3007,13 @@ def test_send_daily_review_summaries_with_data(mocker):
         [mock_summary]
     )
     mock_config.save_last_summary_sent_date.assert_called_once()
-    assert mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now()
+    assert (
+        mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now().date()
+    )
 
 
 def test_send_daily_review_summaries_without_data(mocker):
-    last_summary_sent_date = datetime.now() - timedelta(days=1)
+    last_summary_sent_date = (datetime.now() - timedelta(days=1)).date()
 
     mock_config = mocker.patch("ankihub.main.review_data.config")
     MockAnkiHubClient = mocker.patch("ankihub.main.review_data.AnkiHubClient")
@@ -3027,4 +3029,6 @@ def test_send_daily_review_summaries_without_data(mocker):
     mock_get_daily_review_summaries.assert_called_once_with(last_summary_sent_date)
     mock_anki_hub_client.send_daily_card_review_summaries.assert_not_called()
     mock_config.save_last_summary_sent_date.assert_called_once()
-    assert mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now()
+    assert (
+        mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now().date()
+    )

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2725,7 +2725,7 @@ class TestDatadogLogHandler:
     def test_emit_and_flush(
         self, mocker: MockerFixture, send_logs_to_datadog_feature_flag: bool
     ):
-        feature_flags.send_addon_logs_to_datadog = send_logs_to_datadog_feature_flag
+        feature_flags["send_addon_logs_to_datadog"] = send_logs_to_datadog_feature_flag
 
         # Mock the requests.post call to always return a response with status code 202
         response = Mock()
@@ -2767,7 +2767,7 @@ class TestDatadogLogHandler:
             post_mock.assert_not_called()
 
     def test_periodic_flush(self, mocker):
-        feature_flags.send_addon_logs_to_datadog = True
+        feature_flags["send_addon_logs_to_datadog"] = True
 
         # Mock the requests.post call to always return a response with status code 202
         response = Mock()
@@ -2798,7 +2798,7 @@ class TestDatadogLogHandler:
         )
 
     def test_capacity_flush(self, mocker):
-        feature_flags.send_addon_logs_to_datadog = True
+        feature_flags["send_addon_logs_to_datadog"] = True
 
         # Create a DatadogLogHandler with a short flush interval and a LogRecord
         handler = DatadogLogHandler(capacity=3)

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1820,7 +1820,6 @@ class TestFeatureFlags:
         _feature_flags_update_callbacks.clear()
 
     def test_update_feature_flags_in_background(self, mocker):
-        # MockAddonQueryOp = mocker.patch("ankihub.feature_flags.AddonQueryOp")
         MockAnkiHubClient = mocker.patch("ankihub.feature_flags.AnkiHubClient")
         mock_logger = mocker.patch("ankihub.feature_flags.LOGGER")
         mock_config = mocker.patch("ankihub.feature_flags.config")
@@ -1828,15 +1827,8 @@ class TestFeatureFlags:
         mock_anki_hub_client = MockAnkiHubClient.return_value
         feature_flags_dict = {"flag1": True, "flag2": False}
         mock_anki_hub_client.get_feature_flags.return_value = feature_flags_dict
-        # mock_addon_query_op = MockAddonQueryOp.return_value
-        # mock_addon_query_op.without_collection.return_value = mock_addon_query_op
 
         update_feature_flags_in_background()
-
-        # mock_addon_query_op.without_collection.assert_called_once()
-        # mock_addon_query_op.run_in_background.assert_called_once()
-
-        # mock_addon_query_op.success(mock_addon_query_op.op(None))
 
         mock_logger_expected_calls = [
             call.info("Feature flags", feature_flags=feature_flags_dict),

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -5,7 +5,7 @@ import sqlite3
 import tempfile
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from logging import LogRecord
 from pathlib import Path
 from textwrap import dedent
@@ -3007,9 +3007,7 @@ def test_send_daily_review_summaries_with_data(mocker):
         [mock_summary]
     )
     mock_config.save_last_summary_sent_date.assert_called_once()
-    assert (
-        mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now().date()
-    )
+    assert mock_config.save_last_summary_sent_date.call_args[0][0] == date.today()
 
 
 def test_send_daily_review_summaries_without_data(mocker):
@@ -3029,6 +3027,4 @@ def test_send_daily_review_summaries_without_data(mocker):
     mock_get_daily_review_summaries.assert_called_once_with(last_summary_sent_date)
     mock_anki_hub_client.send_daily_card_review_summaries.assert_not_called()
     mock_config.save_last_summary_sent_date.assert_called_once()
-    assert (
-        mock_config.save_last_summary_sent_date.call_args[0][0] <= datetime.now().date()
-    )
+    assert mock_config.save_last_summary_sent_date.call_args[0][0] == date.today()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1820,10 +1820,10 @@ class TestFeatureFlags:
         _feature_flags_update_callbacks.clear()
 
     def test_update_feature_flags_in_background(self):
-        with patch("feature_flags.AddonQueryOp") as MockAddonQueryOp, patch(
-            "feature_flags.AnkiHubClient"
+        with patch("ankihub.feature_flags.AddonQueryOp") as MockAddonQueryOp, patch(
+            "ankihub.feature_flags.AnkiHubClient"
         ) as MockAnkiHubClient, patch("feature_flags.LOGGER") as mock_logger, patch(
-            "feature_flags.config"
+            "ankihub.feature_flags.config"
         ) as mock_config:
 
             mock_anki_hub_client = MockAnkiHubClient.return_value

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -117,27 +117,6 @@ def set_feature_flag_state(monkeypatch: MonkeyPatch) -> SetFeatureFlagState:
     return set_feature_flag_state_inner
 
 
-class MockAllFeatureFlagsToDefaultValues(Protocol):
-    def __call__(self) -> None:
-        ...
-
-
-@pytest.fixture
-def mock_all_feature_flags_to_default_values(
-    monkeypatch: MonkeyPatch,
-) -> MockAllFeatureFlagsToDefaultValues:
-    def mock_all_feature_flags_to_default_values_inner() -> None:
-        monkeypatch.setattr(
-            AnkiHubClient,
-            "get_feature_flags",
-            lambda *args, **kwargs: {},
-        )
-        # this is needed so that the feature flags are reloaded for the feature_flags singleton
-        _setup_feature_flags()
-
-    return mock_all_feature_flags_to_default_values_inner
-
-
 class ImportAHNote(Protocol):
     def __call__(
         self,


### PR DESCRIPTION
## Related issues
- [BUILD-748](https://ankihub.atlassian.net/browse/BUILD-748)


## Proposed changes
This PR makes these changes:
* Add the function `send_daily_review_summaries` which will send to the AnkiHub server the compiled data of the daily reviews
* Call this function in the background after the user sync
* Update the `feature_flags.py` module and its use to avoid the need to update the dataclass if a new feature flag is created on the server


## How to reproduce
1. Run the instance of the ankihub server and make sure that the feature flag `daily_card_review_summary` is enabled
2. Open a deck and review a card
3. Open the anki database and update the ID of the newly created `revlog` row to the value of a timestamp of yesterday's date
4.  Click on the "Sync with AnkiHub" option on the Ankihub menu
5. Go to a shell instance of the Ankihub server and check if a register of the `DailyCardReviewSummary` was created successfully


[BUILD-748]: https://ankihub.atlassian.net/browse/BUILD-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ