### PR TITLE
[BUILD-762] perf: Use set when filtering notes to upsert into AnkiHub DB

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -124,8 +124,11 @@ class _AnkiHubDB:
         skipped_notes = self._determine_notes_to_skip(
             notes_data, ankihub_did=ankihub_did
         )
+        nids_to_skip = set(note_data.anki_nid for note_data in skipped_notes)
         notes_data = [
-            note_data for note_data in notes_data if note_data not in skipped_notes
+            note_data
+            for note_data in notes_data
+            if note_data.anki_nid not in nids_to_skip
         ]
 
         upserted_notes: List[NoteInfo] = []


### PR DESCRIPTION
The filtering of the notes to upsert takes a very long time when there are many notes to filter out. 
I tested with 30k notes and it took more than a minute.
With this change it takes a couple of seconds at most.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-762


## Proposed changes
- Use set instead of list when filtering notes to upsert into AnkiHub DB