### PR TITLE
[BUILD-773] fix: Show update-addon dialog when api version not supported

### DIFF
--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1690,7 +1690,10 @@ class TestErrorHandling:
         ask_user_mock = mocker.patch("ankihub.gui.errors.ask_user", return_value=False)
         handled = _try_handle_exception(
             exc_value=AnkiHubHTTPError(
-                response=Mock(status_code=406, reason=OUTDATED_CLIENT_RESPONSE_DETAIL)
+                response=Mock(
+                    status_code=406,
+                    json=lambda: {"detail": OUTDATED_CLIENT_RESPONSE_DETAIL},
+                )
             ),
             tb=None,
         )

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -84,7 +84,7 @@ from ankihub.feature_flags import (
 )
 from ankihub.gui.error_dialog import ErrorDialog
 from ankihub.gui.errors import (
-    OUTDATED_CLIENT_ERROR_REASON,
+    OUTDATED_CLIENT_RESPONSE_DETAIL,
     _contains_path_to_this_addon,
     _normalize_url,
     _try_handle_exception,
@@ -1690,7 +1690,7 @@ class TestErrorHandling:
         ask_user_mock = mocker.patch("ankihub.gui.errors.ask_user", return_value=False)
         handled = _try_handle_exception(
             exc_value=AnkiHubHTTPError(
-                response=Mock(status_code=406, reason=OUTDATED_CLIENT_ERROR_REASON)
+                response=Mock(status_code=406, reason=OUTDATED_CLIENT_RESPONSE_DETAIL)
             ),
             tb=None,
         )
@@ -1722,9 +1722,7 @@ class TestUploadLogs:
             # The exception should not be reported for these two specific cases
             (AnkiHubHTTPError(response=Mock(status_code=401)), False),
             (
-                AnkiHubHTTPError(
-                    response=Mock(status_code=406, reason=OUTDATED_CLIENT_ERROR_REASON)
-                ),
+                AnkiHubHTTPError(response=Mock(status_code=406)),
                 False,
             ),
             # The exception should be reported in all other cases


### PR DESCRIPTION
Related web app PR: https://github.com/AnkiHubSoftware/ankihub/pull/2411

> We changed the API version and this requires users to update the addon.
When this happens, the add-on should show a message that it need to be update.
However, it shows an error message instead.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-773
Sentry: https://ankihub.sentry.io/issues/5458237219/?project=6546414&query=is%3Aunresolved%20406&referrer=issue-stream&statsPeriod=7d&stream_index=0
Discourse: https://community.ankihub.net/t/406-error-master-thread/335342

## Proposed changes
We were expecting this to be true for the response (on the client-side): 
```python
response.reason="Outdated client, please update the AnkiHub add-on."
```

This works locally, but when communicating with the production server `response.reason` doesn't contain the custom message, instead it contains the default reason for responses with the status code 406 (`Not Allowed`).

To fix this, we will now return the message in the content of the response instead of in the reason and the client will be adjusted accordingly.

## How to reproduce
- Change the api version to `18.0` here:
  https://github.com/AnkiHubSoftware/ankihub_addon/blob/dcfa06dbfc1cec370e3d0f30a9bd9d09afd66f3a/ankihub/ankihub_client/ankihub_client.py#L77
- Start the add-on
- Try to open the Deck Management dialog (or doing any other actions which makes the add-on communicate with the API)
- This dialog should show up:
  <img src="https://github.com/user-attachments/assets/fe122def-e3ef-4c70-9fa9-b1973e22c104" width="500" />
  
Try the same thing with the api version set to `19.0`. In this case the deck management dialog should open as usual.