### PR TITLE
[BUILD-816] fix: Handle connection errors

### DIFF
--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -3,6 +3,7 @@
 import dataclasses
 import os
 import re
+import socket
 import sys
 import tempfile
 import time
@@ -255,21 +256,15 @@ def _try_handle_exception(
             return True
 
     if isinstance(exc_value, (exceptions.ConnectionError, ConnectionError)):
-        error_message = str(exc_value)
-        if "[Errno -2] Name or service not known" in error_message:
-            show_tooltip(
-                "🚧 AnkiHub is undergoing routine maintenance. "
-                "Please visit ankihub.net/status and check your email for details.",
-                period=5000,
-            )
-        elif "[Errno -3] Temporary failure in name resolution" in error_message:
+        if not _is_internet_available():
             show_tooltip(
                 "🔌 No Internet Connection detected. Please check your internet connection and try again.",
                 period=5000,
             )
         else:
             show_tooltip(
-                "📶 Could not connect to AnkiHub (no internet or the site is down for maintenance)",
+                "🚧 AnkiHub is undergoing routine maintenance. "
+                "Please visit ankihub.net/status and check your email for details.",
                 period=5000,
             )
         return True
@@ -310,6 +305,15 @@ def _try_handle_exception(
         return True
 
     return False
+
+
+def _is_internet_available():
+    try:
+        # Connect to 8.8.8.8 (Google DNS) with a timeout of 3 seconds
+        socket.create_connection(("8.8.8.8", 53), timeout=3)
+        return True
+    except OSError:
+        return False
 
 
 def _maybe_handle_ankihub_http_error(error: AnkiHubHTTPError) -> bool:

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -254,31 +254,25 @@ def _try_handle_exception(
             LOGGER.info("AnkiHubRequestError was handled.")
             return True
 
-    if isinstance(exc_value, AnkiHubRequestException):
-        if isinstance(
-            exc_value.original_exception, (exceptions.ConnectionError, ConnectionError)
-        ):
-            if "[Errno -2] Name or service not known" in str(
-                exc_value.original_exception
-            ):
-                show_tooltip(
-                    "🚧 AnkiHub is undergoing routine maintenance. "
-                    "Please visit ankihub.net/status and check your email for details.",
-                    period=5000,
-                )
-            elif "[Errno -3] Temporary failure in name resolution" in str(
-                exc_value.original_exception
-            ):
-                show_tooltip(
-                    "🔌 No Internet Connection detected. Please check your internet connection and try again.",
-                    period=5000,
-                )
-            else:
-                show_tooltip(
-                    "📶 Could not connect to AnkiHub (no internet or the site is down for maintenance)",
-                    period=5000,
-                )
-            return True
+    if isinstance(exc_value, (exceptions.ConnectionError, ConnectionError)):
+        error_message = str(exc_value)
+        if "[Errno -2] Name or service not known" in error_message:
+            show_tooltip(
+                "🚧 AnkiHub is undergoing routine maintenance. "
+                "Please visit ankihub.net/status and check your email for details.",
+                period=5000,
+            )
+        elif "[Errno -3] Temporary failure in name resolution" in error_message:
+            show_tooltip(
+                "🔌 No Internet Connection detected. Please check your internet connection and try again.",
+                period=5000,
+            )
+        else:
+            show_tooltip(
+                "📶 Could not connect to AnkiHub (no internet or the site is down for maintenance)",
+                period=5000,
+            )
+        return True
 
     if _is_memory_full_error(exc_value):
         show_error_dialog(

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 import aqt
 import pytest
+import requests
 from anki.decks import DeckId
 from anki.models import NotetypeDict
 from anki.notes import Note, NoteId
@@ -27,7 +28,10 @@ from pytestqt.qtbot import QtBot  # type: ignore
 from requests import Response
 from requests_mock import Mocker
 
-from ankihub.ankihub_client.ankihub_client import DEFAULT_API_URL
+from ankihub.ankihub_client.ankihub_client import (
+    DEFAULT_API_URL,
+    AnkiHubRequestException,
+)
 from ankihub.ankihub_client.models import (  # type: ignore
     CardReviewData,
     DailyCardReviewSummary,
@@ -35,6 +39,7 @@ from ankihub.ankihub_client.models import (  # type: ignore
 )
 from ankihub.gui import menu
 from ankihub.gui.config_dialog import setup_config_dialog_manager
+from ankihub.gui.exceptions import DeckDownloadAndInstallError
 from ankihub.main.review_data import (
     get_daily_review_summaries_since_last_sync,
     send_daily_review_summaries,
@@ -1699,6 +1704,27 @@ class TestErrorHandling:
         )
         assert handled
         ask_user_mock.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            ConnectionError(),
+            requests.exceptions.ConnectionError(),
+            # wrapped connection erros should be handled as well
+            AnkiHubRequestException(original_exception=ConnectionError()),
+            DeckDownloadAndInstallError(
+                original_exception=ConnectionError(), ankihub_did=uuid.uuid4()
+            ),
+        ],
+    )
+    def test_handle_connection_error(self, exception: str, mocker: MockerFixture):
+        show_tooltip_mock = mocker.patch("ankihub.gui.errors.show_tooltip")
+        handled = _try_handle_exception(
+            exc_value=exception,
+            tb=None,
+        )
+        assert handled
+        show_tooltip_mock.assert_called_once()
 
 
 def test_show_error_dialog(

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1717,7 +1717,7 @@ class TestErrorHandling:
             ),
         ],
     )
-    def test_handle_connection_error(self, exception: str, mocker: MockerFixture):
+    def test_handle_connection_error(self, exception: Exception, mocker: MockerFixture):
         show_tooltip_mock = mocker.patch("ankihub.gui.errors.show_tooltip")
         handled = _try_handle_exception(
             exc_value=exception,


### PR DESCRIPTION
Currently, when the add-on has no internet connection, and you try to do an action which requires communication with AnkiHub, you get an error message instead of the no-connection message.

This task fixes this.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-816

## Proposed changes
- Check type of `exc_value` instead of type of `exc_value.original_exception` in `_try_handle_exception`
  - The `exc_value` is now unwrapped here:
  https://github.com/AnkiHubSoftware/ankihub_addon/blob/758cea7b3e5995e97cc3c1565fc869adbfc35c1f/ankihub/gui/errors.py#L245-L246
- Check if internet connection is available using socket, instead of based on the connection error message
  - Before this change I was getting the "AnkiHub is undergoing routine maintenance" message even if I didn't have an internet connection.


## How to reproduce
- Remove internet connection
- Try to open the Deck Management dialog
- The tooltip with the no-connection message should show up