### PR TITLE
[BUILD-817] fix: Exclude reschedules from review data

### DIFF
--- a/ankihub/main/review_data.py
+++ b/ankihub/main/review_data.py
@@ -111,12 +111,14 @@ def get_daily_review_summaries_since_last_sync(
     rows = aqt.mw.col.db.all(
         """
         SELECT r.id, r.ease, r.time
-        FROM revlog as r
-        JOIN cards as c ON r.cid = c.id
+        FROM revlog AS r
+        JOIN cards AS c ON r.cid = c.id
         WHERE r.id BETWEEN ? AND ?
+        AND r.type != ?
         """,
         int(datetime.timestamp(start_of_day_after_last_sent_summary_date)) * 1000,
         int(datetime.timestamp(timeframe_end)) * 1000,
+        anki_consts.REVLOG_RESCHED,
     )
 
     daily_reviews = defaultdict(list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [
+  'ankihub.media_import.*',
+  'ankihub.media_export.*',
   'structlog.*',
   'mashumaro.*',
   'ankihub.gui.ankiaddonconfig.*',

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -14,8 +14,6 @@ from pytest_anki.plugin import anki_running
 from pytestqt.qtbot import QtBot  # type: ignore
 from requests_mock import Mocker
 
-from ankihub.ankihub_client.ankihub_client import AnkiHubClient
-
 from ..fixtures import (  # noqa F401
     add_anki_note,
     ankihub_basic_note_type,
@@ -33,6 +31,12 @@ from ..fixtures import (  # noqa F401
     next_deterministic_uuid,
     set_feature_flag_state,
 )
+
+# workaround for vscode test discovery not using pytest.ini which sets this env var
+# has to be set before importing ankihub
+os.environ["SKIP_INIT"] = "1"
+
+from ankihub.ankihub_client.ankihub_client import AnkiHubClient
 
 REPO_ROOT_PATH = Path(__file__).absolute().parent.parent.parent
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4456,6 +4456,7 @@ class TestSyncWithAnkiHub:
                 else not any(is_ankihub_note_type)
             )
 
+    @pytest.mark.qt_no_exception_capture
     def test_sync_updates_api_version_on_last_sync(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4470,6 +4470,7 @@ class TestSyncWithAnkiHub:
 
         assert config._private_config.api_version_on_last_sync == API_VERSION
 
+    @pytest.mark.qt_no_exception_capture
     @pytest.mark.parametrize(
         "is_for_anking_deck",
         [True, False],

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6372,6 +6372,7 @@ class TestAnkiHubAIInReviewer:
 
 
 class TestMaybeSendDailyReviewSummaries:
+    @fixture
     def initialize_review_data(
         self, anki_session_with_addon_data: AnkiSession, add_anki_note: AddAnkiNote
     ):

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6517,7 +6517,9 @@ class TestMaybeSendDailyReviewSummaries:
             dates_from_summaries = [
                 summary.review_session_date for summary in review_summaries
             ]
-            assert all(
-                (date_ in dates_from_summaries) == (revlog_type != REVLOG_RESCHED)
+            expected_dates = [
+                date_
                 for revlog_type, date_ in revlog_type_to_date.items()
-            )
+                if revlog_type != REVLOG_RESCHED
+            ]
+            assert dates_from_summaries == expected_dates

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, Mock
 import aqt
 import pytest
 from anki.cards import CardId
+from anki.consts import REVLOG_LRN
 from anki.decks import DeckId
 from anki.models import NotetypeDict, NotetypeId
 from anki.notes import Note, NoteId
@@ -690,17 +691,21 @@ def latest_instance_tracker(mocker: MockerFixture) -> LatestInstanceTracker:
 
 
 def record_review_for_anki_nid(
-    anki_nid: NoteId, date_time: Optional[datetime] = None
+    anki_nid: NoteId,
+    date_time: Optional[datetime] = None,
+    revlog_type: int = REVLOG_LRN,
 ) -> None:
     """Adds a review for the note with the given anki_nid at the given date_time."""
     if date_time is None:
         date_time = datetime.now()
 
     cid = aqt.mw.col.get_note(anki_nid).card_ids()[0]
-    record_review(cid, int(date_time.timestamp() * 1000))
+    record_review(cid, int(date_time.timestamp() * 1000), revlog_type=revlog_type)
 
 
-def record_review(cid: CardId, review_time_ms: int) -> None:
+def record_review(
+    cid: CardId, review_time_ms: int, revlog_type: int = REVLOG_LRN
+) -> None:
     aqt.mw.col.db.execute(
         "INSERT INTO revlog VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         # the revlog table stores the timestamp in milliseconds
@@ -712,7 +717,7 @@ def record_review(cid: CardId, review_time_ms: int) -> None:
         1,
         1,
         1,
-        0,
+        revlog_type,
     )
 
 


### PR DESCRIPTION
When processing revlog entries to create daily review summaries, we should be excluding revlog entries with `revlog_type==anki.consts.REVLOG_RESCHED`. These entries are created when an user reschedules the reviews of cards and do not represent real reviews.

This leads to review summaries such as [this](https://app.ankihub.net/careless-chimp-oasis/users/dailycardreviewsummary/15/change/) one, where the "total cards studied" does not equal the sum of "total cards marked again", "total cards marked good", etc.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-817


## Proposed changes
- Exclude reschedules from review data
- Add tests
- chore: [Ignore mypy errors in media_import and media_export](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1034/commits/de5c2b6c20d8df2f2493de96388e0735c5d01aca)
- [chore: Fix vscode test discovery](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1034/commits/3457fcf45c69166369ea7f26dc6ef529982ba87f)
- chore: Fix flaky tests
  - [Fix flaky test](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1034/commits/7d0ec17022f73c1400551fd63f9afb986d237bdf)
    - Example of failure of this test in CI: https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/11769057972/job/32779596844
  - [Fix flaky test](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1034/commits/5f00e4caa3a239e479eb6268a38a59a1b3c78654)
    - Example of failure of this test in CI: https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/11727164250/job/32667562588 
  

