### PR TITLE
[BUILD-856] Add notifications for amount of resources to buttons

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -188,6 +188,7 @@ def setup():
         config.token_change_hook.append(_set_token_for_ankihub_ai_js)
         reviewer_did_show_question.append(_remove_anking_button)
         reviewer_did_show_answer.append(_remove_anking_button)
+        reviewer_did_show_question.append(_notify_reviewer_buttons_of_card_change)
 
     webview_did_receive_js_message.append(_on_js_message)
     reviewer_will_end.append(_close_split_screen_webview)
@@ -291,8 +292,6 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
         reivewer_button_js = Template(REVIEWER_BUTTONS_JS_PATH.read_text()).render(
             {
                 "THEME": _ankihub_theme(),
-                "BOARDS_AND_BEYOND_RESOURCE_COUNT": 1,
-                "FIRST_AID_RESOURCE_COUNT": 2,
             }
         )
         web_content.body += f"<script>{reivewer_button_js}</script>"
@@ -333,6 +332,16 @@ def _notify_ankihub_ai_of_card_change(card: Card) -> None:
 
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(card.nid)
     js = _wrap_with_ankihubAI_check(f"ankihubAI.cardChanged('{ah_nid}');")
+    aqt.mw.reviewer.web.eval(js)
+
+
+def _notify_reviewer_buttons_of_card_change(card: Card) -> None:
+    note = card.note()
+    bb_count = len([tag for tag in note.tags if "v12::#b&b" in tag.lower()])
+    fa_count = len([tag for tag in note.tags if "v12::#firstaid" in tag])
+    js = _wrap_with_reviewer_buttons_check(
+        "ankihubReviewerButtons.updateResourceCounts(%d, %d);" % (bb_count, fa_count)
+    )
     aqt.mw.reviewer.web.eval(js)
 
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -291,6 +291,8 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
         reivewer_button_js = Template(REVIEWER_BUTTONS_JS_PATH.read_text()).render(
             {
                 "THEME": _ankihub_theme(),
+                "BOARDS_AND_BEYOND_RESOURCE_COUNT": 1,
+                "FIRST_AID_RESOURCE_COUNT": 2,
             }
         )
         web_content.body += f"<script>{reivewer_button_js}</script>"

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -18,13 +18,15 @@ class AnkiHubReviewerButtons {
                 iconPathDarkTheme: "/_b&b_icon_dark_theme.svg",
                 active: false,
                 tooltip: "Boards & Beyond",
+                resourceCount: Number.parseInt("{{ BOARDS_AND_BEYOND_RESOURCE_COUNT }}"),
             },
             {
                 name: "fa4",
                 iconPath: "/_fa4_icon.svg",
                 iconPathDarkTheme: "/_fa4_icon_dark_theme.svg",
                 active: false,
-                tooltip: "First Aid Forward"
+                tooltip: "First Aid Forward",
+                resourceCount: Number.parseInt("{{ FIRST_AID_RESOURCE_COUNT }}"),
             },
             {
                 name: "chatbot",
@@ -57,6 +59,11 @@ class AnkiHubReviewerButtons {
             if (buttonData.tooltip) {
                 this.addTooltip(buttonElement, buttonData.tooltip);
             }
+            if(buttonData.resourceCount) {
+                document.addEventListener("DOMContentLoaded", () => {
+                    this.addResourceCountIndicator(buttonElement, buttonData.resourceCount);
+                });
+            }
 
             buttonElement.onclick = () => {
                 // Deactivate all other buttons when a button is activated
@@ -77,6 +84,7 @@ class AnkiHubReviewerButtons {
         })
 
         document.body.appendChild(buttonContainer);
+        this.injectResourceCountIndicatorStylesheet();
     }
 
     getButtonElement(buttonName) {
@@ -225,6 +233,51 @@ class AnkiHubReviewerButtons {
         document.head.appendChild(style);
     }
 
+    addResourceCountIndicator(button, resourceCount) {
+        const indicator = document.createElement("div");
+        indicator.classList.add("ankihub-reviewer-button-resource-count");
+        indicator.innerHTML = resourceCount;
+        this.setResourceCountIndicatorStyles(button, indicator);
+        document.body.appendChild(indicator);
+    }
+
+    setResourceCountIndicatorStyles(button, indicator) {
+        indicator.style.position = "absolute";
+        indicator.style.right = "10px";
+        indicator.style.zIndex = "999";
+        indicator.style.fontSize = "small";
+        indicator.style.borderRadius = "5px";
+        indicator.style.textAlign = "left";
+        indicator.style.fontWeight = "bold";
+        indicator.style.padding = "8px";
+        indicator.style.height = "12px";
+        indicator.style.width = "48px";
+        indicator.style.borderRadius = "92px";
+        const buttonRect = button.getBoundingClientRect();
+        const indicatorTop = buttonRect.top + 5;
+        indicator.style.top = `${indicatorTop}px`;
+    }
+
+    injectResourceCountIndicatorStylesheet() {
+        const style = document.createElement("style");
+        style.innerHTML = `
+            :root {
+                --primary-600: #4F46E5;
+                --primary-400: #818CF8;
+            }
+
+            .ankihub-reviewer-button-resource-count {
+                background-color: var(--primary-600);
+                color: white;
+            }
+
+            .night-mode .ankihub-reviewer-button-resource-count {
+                background-color: var(--primary-400);
+                color: black;
+            }
+        `;
+        document.head.appendChild(style);
+    }
 }
 
 window.ankihubReviewerButtons = new AnkiHubReviewerButtons();

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -18,7 +18,6 @@ class AnkiHubReviewerButtons {
                 iconPathDarkTheme: "/_b&b_icon_dark_theme.svg",
                 active: false,
                 tooltip: "Boards & Beyond",
-                resourceCount: Number.parseInt("{{ BOARDS_AND_BEYOND_RESOURCE_COUNT }}"),
             },
             {
                 name: "fa4",
@@ -26,7 +25,6 @@ class AnkiHubReviewerButtons {
                 iconPathDarkTheme: "/_fa4_icon_dark_theme.svg",
                 active: false,
                 tooltip: "First Aid Forward",
-                resourceCount: Number.parseInt("{{ FIRST_AID_RESOURCE_COUNT }}"),
             },
             {
                 name: "chatbot",
@@ -59,9 +57,10 @@ class AnkiHubReviewerButtons {
             if (buttonData.tooltip) {
                 this.addTooltip(buttonElement, buttonData.tooltip);
             }
-            if(buttonData.resourceCount) {
+            if(buttonData.name !== "chatbot") {
+                // Delay until button is rendered for positioning
                 document.addEventListener("DOMContentLoaded", () => {
-                    this.addResourceCountIndicator(buttonElement, buttonData.resourceCount);
+                    this.addResourceCountIndicator(buttonElement, buttonData.name);
                 });
             }
 
@@ -233,10 +232,10 @@ class AnkiHubReviewerButtons {
         document.head.appendChild(style);
     }
 
-    addResourceCountIndicator(button, resourceCount) {
+    addResourceCountIndicator(button, buttonName) {
         const indicator = document.createElement("div");
         indicator.classList.add("ankihub-reviewer-button-resource-count");
-        indicator.innerHTML = resourceCount;
+        indicator.dataset.button = buttonName;
         this.setResourceCountIndicatorStyles(button, indicator);
         document.body.appendChild(indicator);
     }
@@ -277,6 +276,20 @@ class AnkiHubReviewerButtons {
             }
         `;
         document.head.appendChild(style);
+    }
+
+    updateResourceCounts(bbCount, faCount) {
+        for(const indicator of document.getElementsByClassName("ankihub-reviewer-button-resource-count")) {
+            if(indicator.dataset.button === "b&b") {
+                indicator.innerHTML = bbCount;
+                const visibility = bbCount ? "visible" : "hidden";
+                indicator.style.visibility = visibility;
+            } else if(indicator.dataset.button === "fa4") {
+                indicator.innerHTML = faCount;
+                const visibility = faCount ? "visible" : "hidden";
+                indicator.style.visibility = visibility;
+            }
+        }
     }
 }
 


### PR DESCRIPTION

## Related issues

https://ankihub.atlassian.net/browse/BUILD-856

## Proposed changes

This adds notifications besides MH buttons indicating the number of resources available.


## How to reproduce

- Use the search query `tag:*v12::#b&b* OR tag:*v12::#firstaid*` in the browser to find cards with MH resources, unuspend some cards and review them.


## Screenshots and videos

![image](https://github.com/user-attachments/assets/f58371aa-b061-408f-91be-ad17c9e4e953)
![image](https://github.com/user-attachments/assets/f571d743-c5ac-4c5d-b0fb-96abe3dc8fed)
![image](https://github.com/user-attachments/assets/d5c6f97a-1528-46f7-ad2d-fb0bc30b0049)
![image](https://github.com/user-attachments/assets/2109e857-13a5-405d-8264-c66789ea9459)


