### PR TITLE
[BUILD-886] feat: Adjust sidebar and chatbot UI

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -44,6 +44,7 @@ NO_URLS_EMPTY_STATE_TEMPLATE_PATH = (
 
 INVALID_AUTH_TOKEN_PYCMD = "ankihub_invalid_auth_token"
 REVIEWER_BUTTON_TOGGLED_PYCMD = "ankihub_reviewer_button_toggled"
+CLOSE_SIDEBAR_PYCMD = "ankihub_close_sidebar"
 CLOSE_ANKIHUB_CHATBOT_PYCMD = "ankihub_close_chatbot"
 OPEN_SPLIT_SCREEN_PYCMD = "ankihub_open_split_screen"
 LOAD_URL_IN_SIDEBAR_PYCMD = "ankihub_load_url_in_sidebar"
@@ -400,6 +401,13 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
             # TODO load correct sidebar content (Boards&Beyond, First Aid or AnkiHub Chatbot)
             # depending on the button that was toggled
             split_screen_webview_manager.toggle_split_screen()
+
+        return True, None
+    elif message == CLOSE_SIDEBAR_PYCMD:
+        js = _wrap_with_reviewer_buttons_check(
+            "ankihubReviewerButtons.unselectAllButtons()"
+        )
+        aqt.mw.reviewer.web.eval(js)
 
         return True, None
     elif message.startswith(LOAD_URL_IN_SIDEBAR_PYCMD):

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -58,6 +58,7 @@ class SplitScreenWebViewManager:
         self.header_webview: Optional[aqt.webview.AnkiWebView] = None
         self.current_active_url = urls_list[0]["url"] if urls_list else None
         self.urls_list = urls_list
+        self.original_mw_min_width = aqt.mw.minimumWidth()
         self._setup_webview()
 
     def _setup_webview(self):
@@ -83,6 +84,7 @@ class SplitScreenWebViewManager:
 
         # Create the web views
         self.webview = aqt.webview.AnkiWebView()
+        self.webview.setMinimumWidth(self.original_mw_min_width)
         # Interceptor that will add the token to the request
         interceptor = AuthenticationRequestInterceptor(self.webview)
 
@@ -150,9 +152,11 @@ class SplitScreenWebViewManager:
     def open_split_screen(self):
         if not self.container.isVisible():
             self.container.show()
+            aqt.mw.setMinimumWidth(self.original_mw_min_width * 2)
 
     def close_split_screen(self):
         self.container.hide()
+        aqt.mw.setMinimumWidth(self.original_mw_min_width)
 
     def _inject_header(self, ok: bool):
         if not ok:

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -280,10 +280,13 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
             # TODO: Replace with the actual URLs
             urls_list = [
                 {
-                    "url": "https://www.google.com",
-                    "title": "Google",
+                    "url": f"{config.app_url}/integrations/mcgraw-hill/preview/asdf/",
+                    "title": "Heart",
                 },
-                {"url": "https://www.bing.com", "title": "Bing"},
+                {
+                    "url": f"{config.app_url}/integrations/mcgraw-hill/preview/foo/",
+                    "title": "Heart Failure",
+                },
             ]
             split_screen_webview_manager = SplitScreenWebViewManager(context, urls_list)
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Tuple
 import aqt
 import aqt.webview
 from anki.cards import Card
+from anki.notes import Note
 from aqt.gui_hooks import (
     reviewer_did_show_answer,
     reviewer_did_show_question,
@@ -265,7 +266,7 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
     if not (feature_flags.get("mh_integration") or feature_flags.get("chatbot")):
         return
 
-    if not _related_ah_deck_has_note_embeddings(context):
+    if not _related_ah_deck_has_note_embeddings(aqt.mw.reviewer.card.note()):
         return
 
     ah_ai_template_vars = {
@@ -309,11 +310,9 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
         web_content.body += f"<script>{ankihub_ai_old_js}</script>"
 
 
-def _related_ah_deck_has_note_embeddings(reviewer: Reviewer) -> bool:
-    ah_did_of_note = ankihub_db.ankihub_did_for_anki_nid(reviewer.card.nid)
-    ah_dids_of_note_type = ankihub_db.ankihub_dids_for_note_type(
-        reviewer.card.note().mid
-    )
+def _related_ah_deck_has_note_embeddings(note: Note) -> bool:
+    ah_did_of_note = ankihub_db.ankihub_did_for_anki_nid(note.id)
+    ah_dids_of_note_type = ankihub_db.ankihub_dids_for_note_type(note.mid)
     ah_did_of_deck = get_ah_did_of_deck_or_ancestor_deck(
         aqt.mw.col.decks.current()["id"]
     )

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -145,12 +145,6 @@ class SplitScreenWebViewManager:
 
         parent_widget.mainLayout.insertWidget(widget_index, self.splitter)
 
-    def toggle_split_screen(self):
-        if self.container.isVisible():
-            self.close_split_screen()
-        else:
-            self.open_split_screen()
-
     def open_split_screen(self):
         if not self.container.isVisible():
             self.container.show()
@@ -392,14 +386,21 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
         assert isinstance(context, Reviewer), context
         kwargs = parse_js_message_kwargs(message)
         button_name = kwargs.get("buttonName")
+        is_active = kwargs.get("isActive")
 
         if button_name == "chatbot":
-            js = _wrap_with_ankihubAI_check("ankihubAI.toggleIframe();")
+            if is_active:
+                js = _wrap_with_ankihubAI_check("ankihubAI.showIframe();")
+            else:
+                js = _wrap_with_ankihubAI_check("ankihubAI.hideIframe();")
             context.web.eval(js)
         else:
             # TODO load correct sidebar content (Boards&Beyond, First Aid or AnkiHub Chatbot)
             # depending on the button that was toggled
-            split_screen_webview_manager.toggle_split_screen()
+            if is_active:
+                split_screen_webview_manager.open_split_screen()
+            else:
+                split_screen_webview_manager.close_split_screen()
 
         return True, None
     elif message == CLOSE_SIDEBAR_PYCMD:

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -66,19 +66,6 @@ class AnkiHubAI {
         return iframe;
     }
 
-    toggleIframe() {
-        if (!this.knoxToken) {
-            this.invalidateSessionAndPromptToLogin()
-            return;
-        }
-        if (!this.iframeVisible) {
-            this.maybeUpdateIframeSrc();
-            this.showIframe();
-        } else {
-            this.hideIframe();
-        }
-    }
-
     invalidateSessionAndPromptToLogin() {
         this.authenticated = false;
         this.knoxToken = null;
@@ -87,14 +74,27 @@ class AnkiHubAI {
     }
 
     showIframe() {
+        if (this.iframeVisible) {
+            return
+        }
+
+        if (!this.knoxToken) {
+            this.invalidateSessionAndPromptToLogin()
+            return;
+        }
+        this.maybeUpdateIframeSrc();
+
         this.iframe.style.display = "block";
         this.iframeVisible = true;
     }
 
     hideIframe() {
+        if (!this.iframeVisible) {
+            return
+        }
         this.iframe.style.display = "none";
         this.iframeVisible = false;
-        window.ankihubReviewerButtons.unselectAllButtons(false);
+        window.ankihubReviewerButtons.setButtonStateByName("chatbot", false);
     }
 
     cardChanged(noteId) {

--- a/ankihub/gui/web/ankihub_ai.js
+++ b/ankihub/gui/web/ankihub_ai.js
@@ -138,8 +138,8 @@ class AnkiHubAI {
         iframe.style.maxHeight = `${parentWindowHeight - 95}px`;
 
         iframe.style.position = "fixed"
-        iframe.style.bottom = "85px"
-        iframe.style.right = "20px"
+        iframe.style.bottom = "10px"
+        iframe.style.right = "60px"
 
         iframe.style.border = "none"
         iframe.style.borderRadius = "10px"

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -92,7 +92,17 @@ class AnkiHubReviewerButtons {
         buttonContainer.style.flexDirection = "column";
     }
 
-    setButtonState(buttonData, buttonElement, active, sendToPython = true) {
+    setButtonStateByName(buttonName, active) {
+        const buttonData = this.buttonsData.find(buttonData => buttonData.name === buttonName);
+        if (!buttonData) {
+            return;
+        }
+
+        const buttonElement = this.getButtonElement(buttonName);
+        this.setButtonState(buttonData, buttonElement, active);
+    }
+
+    setButtonState(buttonData, buttonElement, active) {
         buttonData.active = active;
         if (active) {
             buttonElement.style.backgroundColor = this.theme == "light" ? this.colorButtonSelectedLight : this.colorButtonSelectedDark;
@@ -101,17 +111,15 @@ class AnkiHubReviewerButtons {
             buttonElement.style.backgroundColor = this.theme == "light" ? this.colorButtonLight : this.colorButtonDark;
         }
 
-        if(sendToPython) {
-            const args = `{"buttonName": "${buttonData.name}", "isActive": "${buttonData.active}"}`;
-            pycmd(`ankihub_reviewer_button_toggled ${args}`);
-        }
+        const args = `{"buttonName": "${buttonData.name}", "isActive": ${buttonData.active}}`;
+        pycmd(`ankihub_reviewer_button_toggled ${args}`);
     }
 
-    unselectAllButtons(sendToPython = true) {
+    unselectAllButtons() {
         for (const buttonData of this.buttonsData) {
             if (buttonData.active) {
                 const buttonElement = this.getButtonElement(buttonData.name);
-                this.setButtonState(buttonData, buttonElement, false, sendToPython);
+                this.setButtonState(buttonData, buttonElement, false);
             }
         }
     }

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -10,7 +10,6 @@
         height: 44px;
         width: 100%;
         align-items: center;
-        justify-content: space-between;
         background-color: #f3f4f6;
         border-bottom: 1px solid #d1d5db;
         color: #374151;
@@ -24,13 +23,16 @@
         border-bottom: 1px solid #374151;
     }
     .webview-browser-page-title {
-        flex-grow: 1;
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
         text-align: center;
         font-size: 12px;
         font-weight: 400;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        max-width: calc(100% - 200px);
     }
     .webview-tabs {
         display: flex;
@@ -68,6 +70,7 @@
         border-color: #818cf8;
     }
     .webview-browser-bar button {
+        position: relative;
         background: none;
         border: none;
         cursor: pointer;
@@ -94,6 +97,7 @@
         align-items: center;
         min-width: 92px;
         flex-shrink: 0;
+        margin-left: auto;
     }
 </style>
 <script>
@@ -104,18 +108,6 @@
 </script>
 <div class="{% if theme == 'dark' %}dark{% endif %}">
     <div class="webview-browser-bar">
-        <div class="button-container">
-            <button disabled>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.7906 5.23017C13.0777 5.52875 13.0684 6.00353 12.7698 6.29063L8.83208 10L12.7698 13.7094C13.0684 13.9965 13.0777 14.4713 12.7906 14.7698C12.5035 15.0684 12.0287 15.0777 11.7302 14.7906L7.23017 10.5406C7.08311 10.3992 7 10.204 7 10C7 9.79599 7.08311 9.60078 7.23017 9.45938L11.7302 5.20938C12.0287 4.92228 12.5035 4.93159 12.7906 5.23017Z" />
-                </svg>
-            </button>
-            <button disabled>
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.20938 14.7698C6.92228 14.4713 6.93159 13.9965 7.23017 13.7094L11.1679 10L7.23017 6.29062C6.93159 6.00353 6.92228 5.52875 7.20938 5.23017C7.49647 4.93159 7.97125 4.92228 8.26983 5.20937L12.7698 9.45937C12.9169 9.60078 13 9.79599 13 10C13 10.204 12.9169 10.3992 12.7698 10.5406L8.26983 14.7906C7.97125 15.0777 7.49647 15.0684 7.20938 14.7698Z" />
-                </svg>
-            </button>
-        </div>
         <span class="webview-browser-page-title">{{ page_title }}</span>
         <div class="button-container">
             <button disabled>

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -4,6 +4,7 @@
         padding: 0;
         margin: 0;
     }
+
     .webview-browser-bar {
         display: flex;
         position: relative;
@@ -17,11 +18,13 @@
         padding: 0 16px;
         box-sizing: border-box;
     }
+
     .dark .webview-browser-bar {
         color: #d1d5db;
         background-color: #111827;
         border-bottom: 1px solid #374151;
     }
+
     .webview-browser-page-title {
         position: absolute;
         left: 50%;
@@ -34,6 +37,7 @@
         white-space: nowrap;
         max-width: calc(100% - 200px);
     }
+
     .webview-tabs {
         display: flex;
         background-color: #f3f4f6;
@@ -43,10 +47,12 @@
         width: 100%;
         z-index: 100000;
     }
+
     .dark .webview-tabs {
         background-color: #111827;
         border-bottom: 1px solid #1f2937;
     }
+
     .webview-tab {
         display: flex;
         cursor: pointer;
@@ -61,14 +67,17 @@
         height: 100%;
         align-items: center;
     }
+
     .webview-tab.selected {
         color: #4f46e5;
         border-color: #4f46e5;
     }
+
     .dark .webview-tab.selected {
         color: #818cf8;
         border-color: #818cf8;
     }
+
     .webview-browser-bar button {
         position: relative;
         background: none;
@@ -77,21 +86,27 @@
         padding: 0;
         margin: 0 4px;
     }
+
     .webview-browser-bar button:disabled {
         cursor: not-allowed;
     }
+
     .webview-browser-bar button:not(:disabled) svg {
         fill: #374151;
     }
+
     .webview-browser-bar button svg {
         fill: #9CA3AF;
     }
+
     .webview-browser-bar button:not(:disabled) svg path[stroke-width] {
         stroke: #374151;
     }
+
     .webview-browser-bar button svg path[stroke-width] {
         stroke: #9CA3AF;
     }
+
     .button-container {
         display: flex;
         align-items: center;
@@ -112,17 +127,22 @@
         <div class="button-container">
             <button disabled>
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M3.75 3.75V8.25M3.75 3.75H8.25M3.75 3.75L9 9M3.75 20.25V15.75M3.75 20.25H8.25M3.75 20.25L9 15M20.25 3.75L15.75 3.75M20.25 3.75V8.25M20.25 3.75L15 9M20.25 20.25H15.75M20.25 20.25V15.75M20.25 20.25L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path
+                        d="M3.75 3.75V8.25M3.75 3.75H8.25M3.75 3.75L9 9M3.75 20.25V15.75M3.75 20.25H8.25M3.75 20.25L9 15M20.25 3.75L15.75 3.75M20.25 3.75V8.25M20.25 3.75L15 9M20.25 20.25H15.75M20.25 20.25V15.75M20.25 20.25L15 15"
+                        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
             </button>
             <button disabled>
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M15.75 2.25L21 2.25C21.1989 2.25 21.3897 2.32902 21.5303 2.46967C21.671 2.61032 21.75 2.80109 21.75 3V8.25C21.75 8.66421 21.4142 9 21 9C20.5858 9 20.25 8.66421 20.25 8.25V4.81066L8.03033 17.0303C7.73744 17.3232 7.26256 17.3232 6.96967 17.0303C6.67678 16.7374 6.67678 16.2626 6.96967 15.9697L19.1893 3.75L15.75 3.75C15.3358 3.75 15 3.41421 15 3C15 2.58579 15.3358 2.25 15.75 2.25ZM5.25 6.75C4.42157 6.75 3.75 7.42157 3.75 8.25V18.75C3.75 19.5784 4.42157 20.25 5.25 20.25H15.75C16.5784 20.25 17.25 19.5784 17.25 18.75V10.5C17.25 10.0858 17.5858 9.75 18 9.75C18.4142 9.75 18.75 10.0858 18.75 10.5V18.75C18.75 20.4069 17.4069 21.75 15.75 21.75H5.25C3.59315 21.75 2.25 20.4069 2.25 18.75V8.25C2.25 6.59315 3.59315 5.25 5.25 5.25H13.5C13.9142 5.25 14.25 5.58579 14.25 6C14.25 6.41421 13.9142 6.75 13.5 6.75H5.25Z" />
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                        d="M15.75 2.25L21 2.25C21.1989 2.25 21.3897 2.32902 21.5303 2.46967C21.671 2.61032 21.75 2.80109 21.75 3V8.25C21.75 8.66421 21.4142 9 21 9C20.5858 9 20.25 8.66421 20.25 8.25V4.81066L8.03033 17.0303C7.73744 17.3232 7.26256 17.3232 6.96967 17.0303C6.67678 16.7374 6.67678 16.2626 6.96967 15.9697L19.1893 3.75L15.75 3.75C15.3358 3.75 15 3.41421 15 3C15 2.58579 15.3358 2.25 15.75 2.25ZM5.25 6.75C4.42157 6.75 3.75 7.42157 3.75 8.25V18.75C3.75 19.5784 4.42157 20.25 5.25 20.25H15.75C16.5784 20.25 17.25 19.5784 17.25 18.75V10.5C17.25 10.0858 17.5858 9.75 18 9.75C18.4142 9.75 18.75 10.0858 18.75 10.5V18.75C18.75 20.4069 17.4069 21.75 15.75 21.75H5.25C3.59315 21.75 2.25 20.4069 2.25 18.75V8.25C2.25 6.59315 3.59315 5.25 5.25 5.25H13.5C13.9142 5.25 14.25 5.58579 14.25 6C14.25 6.41421 13.9142 6.75 13.5 6.75H5.25Z" />
                 </svg>
             </button>
-            <button disabled>
+            <button onclick="pycmd('ankihub_close_sidebar')">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M5.46967 5.46967C5.76256 5.17678 6.23744 5.17678 6.53033 5.46967L12 10.9393L17.4697 5.46967C17.7626 5.17678 18.2374 5.17678 18.5303 5.46967C18.8232 5.76256 18.8232 6.23744 18.5303 6.53033L13.0607 12L18.5303 17.4697C18.8232 17.7626 18.8232 18.2374 18.5303 18.5303C18.2374 18.8232 17.7626 18.8232 17.4697 18.5303L12 13.0607L6.53033 18.5303C6.23744 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9393 12L5.46967 6.53033C5.17678 6.23744 5.17678 5.76256 5.46967 5.46967Z" />
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                        d="M5.46967 5.46967C5.76256 5.17678 6.23744 5.17678 6.53033 5.46967L12 10.9393L17.4697 5.46967C17.7626 5.17678 18.2374 5.17678 18.5303 5.46967C18.8232 5.76256 18.8232 6.23744 18.5303 6.53033L13.0607 12L18.5303 17.4697C18.8232 17.7626 18.8232 18.2374 18.5303 18.5303C18.2374 18.8232 17.7626 18.8232 17.4697 18.5303L12 13.0607L6.53033 18.5303C6.23744 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9393 12L5.46967 6.53033C5.17678 6.23744 5.17678 5.76256 5.46967 5.46967Z"
+                        fill="#D1D5DB" />
                 </svg>
             </button>
         </div>
@@ -130,13 +150,11 @@
     {% if tabs %}
     <nav class="webview-tabs">
         {% for tab in tabs %}
-            <div
-                class="webview-tab {% if current_active_tab_url == tab.url %}selected{% endif %}"
-                onclick="selectTab(this); pycmd('ankihub_load_url_in_sidebar { &quot;url&quot;: &quot;{{ tab.url }}&quot; }')"
-                data-tab="{{ tab.url }}"
-            >
-                {{ tab.title }}
-            </div>
+        <div class="webview-tab {% if current_active_tab_url == tab.url %}selected{% endif %}"
+            onclick="selectTab(this); pycmd('ankihub_load_url_in_sidebar { &quot;url&quot;: &quot;{{ tab.url }}&quot; }')"
+            data-tab="{{ tab.url }}">
+            {{ tab.title }}
+        </div>
         {% endfor %}
     </nav>
     {% endif %}

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -3,6 +3,7 @@
         box-sizing: border-box;
         padding: 0;
         margin: 0;
+        font-family: "Merriweather Sans", sans-serif;
     }
 
     .webview-browser-bar {
@@ -36,6 +37,11 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         max-width: calc(100% - 200px);
+        color: #374151;
+    }
+
+    .dark .webview-browser-page-title {
+        color: #D1D5DB;
     }
 
     .webview-tabs {
@@ -84,33 +90,44 @@
         border: none;
         cursor: pointer;
         padding: 0;
-        margin: 0 4px;
+        border-radius: 4px;
+        padding: 10px;
+        transition: background-color 0.2s;
+    }
+
+    .webview-browser-bar button svg {
+        width: 16px;
+        height: 16px;
+        fill: #374151;
+    }
+
+    .dark .webview-browser-bar button svg {
+        fill: #D1D5DB;
     }
 
     .webview-browser-bar button:disabled {
         cursor: not-allowed;
     }
 
-    .webview-browser-bar button:not(:disabled) svg {
-        fill: #374151;
-    }
-
-    .webview-browser-bar button svg {
+    .webview-browser-bar button:disabled svg {
         fill: #9CA3AF;
     }
 
-    .webview-browser-bar button:not(:disabled) svg path[stroke-width] {
-        stroke: #374151;
+    .dark .webview-browser-bar button:disabled svg {
+        fill: #6B7280
     }
 
-    .webview-browser-bar button svg path[stroke-width] {
-        stroke: #9CA3AF;
+    .webview-browser-bar button:hover:not(:disabled) {
+        background-color: #E5E7EB;
+    }
+
+    .dark .webview-browser-bar button:hover:not(:disabled) {
+        background-color: #374151;
     }
 
     .button-container {
         display: flex;
         align-items: center;
-        min-width: 92px;
         flex-shrink: 0;
         margin-left: auto;
     }
@@ -127,13 +144,6 @@
         <div class="button-container">
             <button disabled>
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        d="M3.75 3.75V8.25M3.75 3.75H8.25M3.75 3.75L9 9M3.75 20.25V15.75M3.75 20.25H8.25M3.75 20.25L9 15M20.25 3.75L15.75 3.75M20.25 3.75V8.25M20.25 3.75L15 9M20.25 20.25H15.75M20.25 20.25V15.75M20.25 20.25L15 15"
-                        stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </button>
-            <button disabled>
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd"
                         d="M15.75 2.25L21 2.25C21.1989 2.25 21.3897 2.32902 21.5303 2.46967C21.671 2.61032 21.75 2.80109 21.75 3V8.25C21.75 8.66421 21.4142 9 21 9C20.5858 9 20.25 8.66421 20.25 8.25V4.81066L8.03033 17.0303C7.73744 17.3232 7.26256 17.3232 6.96967 17.0303C6.67678 16.7374 6.67678 16.2626 6.96967 15.9697L19.1893 3.75L15.75 3.75C15.3358 3.75 15 3.41421 15 3C15 2.58579 15.3358 2.25 15.75 2.25ZM5.25 6.75C4.42157 6.75 3.75 7.42157 3.75 8.25V18.75C3.75 19.5784 4.42157 20.25 5.25 20.25H15.75C16.5784 20.25 17.25 19.5784 17.25 18.75V10.5C17.25 10.0858 17.5858 9.75 18 9.75C18.4142 9.75 18.75 10.0858 18.75 10.5V18.75C18.75 20.4069 17.4069 21.75 15.75 21.75H5.25C3.59315 21.75 2.25 20.4069 2.25 18.75V8.25C2.25 6.59315 3.59315 5.25 5.25 5.25H13.5C13.9142 5.25 14.25 5.58579 14.25 6C14.25 6.41421 13.9142 6.75 13.5 6.75H5.25Z" />
                 </svg>
@@ -141,8 +151,7 @@
             <button onclick="pycmd('ankihub_close_sidebar')">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M5.46967 5.46967C5.76256 5.17678 6.23744 5.17678 6.53033 5.46967L12 10.9393L17.4697 5.46967C17.7626 5.17678 18.2374 5.17678 18.5303 5.46967C18.8232 5.76256 18.8232 6.23744 18.5303 6.53033L13.0607 12L18.5303 17.4697C18.8232 17.7626 18.8232 18.2374 18.5303 18.5303C18.2374 18.8232 17.7626 18.8232 17.4697 18.5303L12 13.0607L6.53033 18.5303C6.23744 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9393 12L5.46967 6.53033C5.17678 6.23744 5.17678 5.76256 5.46967 5.46967Z"
-                        fill="#D1D5DB" />
+                        d="M5.46967 5.46967C5.76256 5.17678 6.23744 5.17678 6.53033 5.46967L12 10.9393L17.4697 5.46967C17.7626 5.17678 18.2374 5.17678 18.5303 5.46967C18.8232 5.76256 18.8232 6.23744 18.5303 6.53033L13.0607 12L18.5303 17.4697C18.8232 17.7626 18.8232 18.2374 18.5303 18.5303C18.2374 18.8232 17.7626 18.8232 17.4697 18.5303L12 13.0607L6.53033 18.5303C6.23744 18.8232 5.76256 18.8232 5.46967 18.5303C5.17678 18.2374 5.17678 17.7626 5.46967 17.4697L10.9393 12L5.46967 6.53033C5.17678 6.23744 5.17678 5.76256 5.46967 5.46967Z" />
                 </svg>
             </button>
         </div>


### PR DESCRIPTION
This task makes the following adjustments to the reviewer UI:
- Adjusts chatbot position to not overlap with the reviewer buttons according to the [design on Figma](https://www.figma.com/design/rWzQ7PPqAXf1piz5yTntaT/%F0%9F%91%91--Ankihub?node-id=7722-55966&t=gM6naxDA47rE3UkS-1)
- Set a minimum width for the sidebar and the main Anki window when the sidebar is open
- Remove arrow buttons from the sidebar header
- Make the close button in the sidebar header work
- Remove expand button as per the discussion here: https://www.figma.com/design/rWzQ7PPqAXf1piz5yTntaT?node-id=7721-53457#1051310302
- Adjust sidebar header styling

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-886


## Screenshots and videos
https://github.com/user-attachments/assets/5cddc30d-a9c4-4ec6-8135-1aa3bba5a95e

