### PR TITLE
[BUILD-890] feat: Populate sidebar tabs based on mh tags

### DIFF
--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -29,6 +29,7 @@ SUSPEND_NOTES_PYCMD = "ankihub_suspend_notes"
 GET_NOTE_SUSPENSION_STATES_PYCMD = "ankihub_get_note_suspension_states"
 ANKIHUB_UPSELL = "ankihub_ai_upsell"
 COPY_TO_CLIPBOARD_PYCMD = "ankihub_copy_to_clipboard"
+OPEN_LINK_PYCMD = "ankihub_open_link"
 
 POST_MESSAGE_TO_ANKIHUB_JS_PATH = (
     Path(__file__).parent / "web/post_message_to_ankihub_js.js"
@@ -111,6 +112,13 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
         content = kwargs.get("content")
         if content:
             aqt.mw.app.clipboard().setText(content)
+
+        return (True, None)
+    elif message.startswith(OPEN_LINK_PYCMD):
+        kwargs = parse_js_message_kwargs(message)
+        url = kwargs.get("url")
+        if url:
+            openLink(url)
 
         return (True, None)
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -453,6 +453,7 @@ def _update_sidebar_tabs_based_on_tags(resource_type: ResourceType) -> None:
         {"title": title, "url": url_mh_integrations_preview(slug)}
         for title, slug in resource_title_slug_pairs
     ]
+    resource_urls_list = sorted(resource_urls_list, key=lambda x: x["title"])
 
     sidebar_manager.update_tabs(resource_urls_list, resource_type)
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -453,7 +453,7 @@ def _update_sidebar_tabs_based_on_tags(resource_type: ResourceType) -> None:
         {"title": title, "url": url_mh_integrations_preview(slug)}
         for title, slug in resource_title_slug_pairs
     ]
-    resource_urls_list = sorted(resource_urls_list, key=lambda x: x["title"])
+    resource_urls_list = list(sorted(resource_urls_list, key=lambda x: x["title"]))
 
     sidebar_manager.update_tabs(resource_urls_list, resource_type)
 

--- a/ankihub/gui/web/mh_no_urls_empty_state.html
+++ b/ankihub/gui/web/mh_no_urls_empty_state.html
@@ -52,6 +52,6 @@
             </svg>
             <h1 class="empty-state-title">Uh oh! No content here</h1>
         </div>
-        <p class="empty-state-message">😅 Unfortunately, there is no extra material linked to this card. Keep studying to find more <strong>{% if current_selected_button == 'boards_and_beyond' %}Boards&Beyond{% else %}First AID Forward{% endif %}</strong> content on other notes.</p>
+        <p class="empty-state-message">😅 Unfortunately, there is no extra material linked to this card. Keep studying to find more <strong>{% if resource_type == 'b&B' %}Boards&Beyond{% else %}First AID Forward{% endif %}</strong> content on other notes.</p>
     </div>
 </div>

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -156,7 +156,6 @@
             </button>
         </div>
     </div>
-    {% if tabs %}
     <nav class="webview-tabs">
         {% for tab in tabs %}
         <div class="webview-tab {% if current_active_tab_url == tab.url %}selected{% endif %}"
@@ -166,5 +165,4 @@
         </div>
         {% endfor %}
     </nav>
-    {% endif %}
 </div>

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -134,7 +134,7 @@
 </style>
 <script>
     function selectTab(element) {
-        document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('selected'));
+        document.querySelectorAll('.webview-tab').forEach(tab => tab.classList.remove('selected'));
         element.classList.add('selected');
     }
 </script>

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -875,6 +875,9 @@ url_flashcard_selector_embed = (
     lambda deck_id: f"{config.app_url}/ai/{deck_id}/flashcard-selector-embed?is_on_anki=true"
 )  # noqa: E731
 url_plans_page = lambda: f"{config.app_url}/memberships/plans/"  # noqa: E731
+url_mh_integrations_preview = (
+    lambda resource_slug: f"{config.app_url}/integrations/mcgraw-hill/preview/{resource_slug}"
+)  # noqa: E731
 
 ANKIHUB_NOTE_TYPE_FIELD_NAME = "ankihub_id"
 ANKIHUB_NOTE_TYPE_MODIFICATION_STRING = "ANKIHUB MODFICATIONS"

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -150,6 +150,7 @@ from ankihub.main.suggestions import ChangeSuggestionResult
 from ankihub.main.utils import (
     clear_empty_cards,
     lowest_level_common_ancestor_deck_name,
+    mh_tag_to_resource_title_and_slug,
     mids_of_notes,
     note_type_with_updated_templates,
     retain_nids_with_ah_note_type,
@@ -3052,3 +3053,28 @@ def test_send_daily_review_summaries_without_data(mocker):
 
     mock_get_daily_review_summaries.assert_called_once_with(last_summary_sent_date)
     mock_anki_hub_client.send_daily_card_review_summaries.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "tag, expected_title, expected_slug",
+    [
+        (
+            "#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia",
+            "Ammonia",
+            "step1-bb-biochem-amino_acids-ammonia",
+        ),
+        (
+            "#AK_Step2_v12::#FirstAid::14_Pulm::16_Nose_and_Throat::01_Rhinitis",
+            "Rhinitis",
+            "step2-fa-pulm-nose_and_throat-rhinitis",
+        ),
+        ("invalid_tag", None, None),
+    ],
+)
+def test_mh_tag_to_resource_title_and_slug(
+    tag: str, expected_title: str, expected_slug: str
+):
+    if expected_title is None:
+        assert mh_tag_to_resource_title_and_slug(tag) is None
+    else:
+        assert mh_tag_to_resource_title_and_slug(tag) == (expected_title, expected_slug)


### PR DESCRIPTION
We need to set the tabs in the sidebar based on the B&B and FA4 tags of the reviewed card.
The tabs should be updated when the sidebar is opened and when the reviewed card changes. 

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-890


## Proposed changes
- `js_message_handling.py`: Set up message handler for `OPEN_LINK_PYCMD`, which will be sent by the web app in order to open pages in an external browser if needed (for example for Boards and Beyond)
  - The command gets introduced into the web app in this PR: https://github.com/AnkiHubSoftware/ankihub/pull/2458
- `reviewer.py`: 
  - Update the tabs based on B&B and FA tags when the sidebar is opened
  - Handle auth failures in the sidebar when accessing the preview pages
    - The auth failure is handled by closing the sidebar and showing the login dialog
- Adjustments and refactoring of the sidebar
- Adjustments to the header html (`sidebar_tabs.html`)

## How to reproduce
Run `python manage.py runscript process_mh_integration_resources` on the web app if you haven't already.

Add some supported tags to the notes:
**B&B**
#AK_Step1_v12::#B&B::01_Basic_Pharmacology::01_General::01_Enzymes
#AK_Step1_v12::#B&B::01_Basic_Pharmacology::01_General::02_Enzyme_Inhibitors
#AK_Step1_v12::#B&B::01_Basic_Pharmacology::01_General::03_Dose-Response

**FA**
#AK_Step1_v12::#FirstAid::01_Biochem::06_Metabolism::31_Alkaptonuria
#AK_Step1_v12::#FirstAid::01_Biochem::06_Metabolism::32_Homocystinuria
#AK_Step1_v12::#FirstAid::01_Biochem::06_Metabolism::33_Cystinuria

Suspend all cards, except for the ones to which you added the tags. This way you will be able to review the cards you just set up. 

## Screenshots and videos
![image](https://github.com/user-attachments/assets/2399c8f1-0730-4731-90dc-1a387ed5bd39)


## Comments
We should handle the case that the url derived from the tag doesn't exist on AnkiHub. This will be done in another task.

I also noticed that the `content_webview` of the sidebar sometimes goes blank for some reason after it was opened for some amount of time (about 5-10 minutes maybe?). Closing the sidebar and opening it again fixes it. We will need to investigate this.

When this happens it looks like this:
<img src="https://github.com/user-attachments/assets/62b3c035-4dd8-4ed9-acc8-3bf2f07674ce" width="700" />