### PR TITLE
[BUILD-897] Show B&B and FA buttons for the AnKing deck only

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -273,7 +273,11 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
     }
     if feature_flags.get("mh_integration"):
         global split_screen_webview_manager
-        if not split_screen_webview_manager:
+        is_anking_deck = (
+            ankihub_db.ankihub_did_for_anki_nid(aqt.mw.reviewer.card.note().id)
+            == config.anking_deck_id
+        )
+        if not split_screen_webview_manager and is_anking_deck:
             # TODO: Replace with the actual URLs
             urls_list = [
                 {
@@ -295,10 +299,7 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
         reivewer_button_js = Template(REVIEWER_BUTTONS_JS_PATH.read_text()).render(
             {
                 "THEME": _ankihub_theme(),
-                "IS_ANKING_DECK": ankihub_db.ankihub_did_for_anki_nid(
-                    aqt.mw.reviewer.card.note().id
-                )
-                == config.anking_deck_id,
+                "IS_ANKING_DECK": is_anking_deck,
             }
         )
         web_content.body += f"<script>{reivewer_button_js}</script>"

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -295,6 +295,10 @@ def _add_ankihub_ai_and_sidebar_and_buttons(web_content: WebContent, context):
         reivewer_button_js = Template(REVIEWER_BUTTONS_JS_PATH.read_text()).render(
             {
                 "THEME": _ankihub_theme(),
+                "IS_ANKING_DECK": ankihub_db.ankihub_did_for_anki_nid(
+                    aqt.mw.reviewer.card.note().id
+                )
+                == config.anking_deck_id,
             }
         )
         web_content.body += f"<script>{reivewer_button_js}</script>"

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -2,6 +2,7 @@
 class AnkiHubReviewerButtons {
     constructor() {
         this.theme = "{{ THEME }}";
+        this.isAnKingDeck = "{{ IS_ANKING_DECK }}" === "True";
 
         this.colorButtonLight = "#F9FAFB";
         this.colorButtonSelectedLight = "#C7D2FE";
@@ -42,6 +43,9 @@ class AnkiHubReviewerButtons {
         this.setButtonContainerStyle(buttonContainer);
 
         this.buttonsData.forEach((buttonData, buttonIdx) => {
+            if(!this.isAnKingDeck && buttonData.name !== "chatbot") {
+                return;
+            }
             const buttonElement = document.createElement("button");
             buttonElement.id = `ankihub-${buttonData.name}-button`;
             this.setButtonStyle(


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/BUILD-897

## Proposed changes

This PR hides the B&B and FA buttons side panel buttons for non-AnKing decks.

## How to reproduce

1. Go to the AnKing deck and confirm the buttons are still displayed.
2. Go to a different deck and confirm the buttons are not displayed.

## Screenshots and videos

In the AnKing deck:
![image](https://github.com/user-attachments/assets/12e2dd13-3709-4677-9683-4434490b5bc9)


In other decks:
![image](https://github.com/user-attachments/assets/4fcf57b4-7bc7-47cf-9a52-e56b32a3cc20)
