### PR TITLE
[BUILD-918] feat:  Add toggle element to sidebar buttons

### DIFF
--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -59,12 +59,11 @@ class AnkiHubReviewerButtons {
             isButtonsVisible = !isButtonsVisible;
             toggleButtonsButton.innerHTML = isButtonsVisible ? iconArrowRight : iconArrowLeft;
             if (isButtonsVisible) {
-                buttonContainer.style.visibility = "visible";
                 toggleButtonsButton.style.borderRadius = "0px";
             } else {
-                buttonContainer.style.visibility = "hidden";
                 toggleButtonsButton.style.borderRadius = "4px 0px 0px 4px";
             }
+            buttonContainer.classList.toggle("ankihub-toggle-buttons-button-slide");
         }
 
         this.setToggleButtonsButtonStyle(toggleButtonsButton);
@@ -75,6 +74,10 @@ class AnkiHubReviewerButtons {
             if(!this.isAnKingDeck && buttonData.name !== "chatbot") {
                 return;
             }
+            const container = document.createElement("div");
+            container.style.display = "flex";
+            container.style.flexDirection = "row-reverse";
+
             const buttonElement = document.createElement("button");
             buttonElement.id = `ankihub-${buttonData.name}-button`;
             this.setButtonStyle(
@@ -93,7 +96,7 @@ class AnkiHubReviewerButtons {
             if(buttonData.name !== "chatbot") {
                 // Delay until button is rendered for positioning
                 document.addEventListener("DOMContentLoaded", () => {
-                    this.addResourceCountIndicator(buttonElement, buttonData.name);
+                    this.addResourceCountIndicator(buttonData.name, container);
                 });
             }
 
@@ -112,7 +115,8 @@ class AnkiHubReviewerButtons {
                 this.setButtonState(buttonData, buttonElement, !buttonData.active);
             };
 
-            buttonContainer.appendChild(buttonElement);
+            container.appendChild(buttonElement);
+            buttonContainer.appendChild(container);
         })
 
         elementsContainer.appendChild(buttonContainer);
@@ -130,6 +134,9 @@ class AnkiHubReviewerButtons {
             .ankihub-toggle-buttons-button:hover {
                 background: ${this.theme == "light" ? "#e5e7eb" : "#1f2937"} !important;
             }
+            .ankihub-toggle-buttons-button-slide {
+                transform: translateX(100px);
+            }
         `;
         const styleSheet = document.createElement("style");
         styleSheet.innerText = styles;
@@ -142,6 +149,7 @@ class AnkiHubReviewerButtons {
         toggleButtonsButton.style.borderRadius = "0px";
         toggleButtonsButton.style.boxSizing = "border-box";
         toggleButtonsButton.style.color = this.theme == "light" ? "#000000" : "#ffffff";
+        toggleButtonsButton.style.zIndex = "2"
         toggleButtonsButton.classList.add("ankihub-toggle-buttons-button");
     }
 
@@ -156,6 +164,7 @@ class AnkiHubReviewerButtons {
     setButtonContainerStyle(buttonContainer) {
         buttonContainer.style.display = "flex";
         buttonContainer.style.flexDirection = "column";
+        buttonContainer.style.transition = "transform 0.8s ease";
     }
 
     setButtonStateByName(buttonName, active) {
@@ -299,17 +308,15 @@ class AnkiHubReviewerButtons {
         document.head.appendChild(style);
     }
 
-    addResourceCountIndicator(button, buttonName) {
+    addResourceCountIndicator(buttonName, container) {
         const indicator = document.createElement("div");
         indicator.classList.add("ankihub-reviewer-button-resource-count");
         indicator.dataset.button = buttonName;
-        this.setResourceCountIndicatorStyles(button, indicator);
-        document.body.appendChild(indicator);
+        this.setResourceCountIndicatorStyles(indicator);
+        container.appendChild(indicator);
     }
 
-    setResourceCountIndicatorStyles(button, indicator) {
-        indicator.style.position = "absolute";
-        indicator.style.right = "64px";
+    setResourceCountIndicatorStyles(indicator) {
         indicator.style.zIndex = "999";
         indicator.style.fontFamily = "Merriweather sans-serif";
         indicator.style.fontSize = "12px";
@@ -320,10 +327,7 @@ class AnkiHubReviewerButtons {
         indicator.style.display = "flex";
         indicator.style.alignItems = "center";
         indicator.style.justifyContent = "center";
-
-        const buttonRect = button.getBoundingClientRect();
-        const indicatorTop = buttonRect.top + 5;
-        indicator.style.top = `${indicatorTop}px`;
+        indicator.style.marginTop = "6px";
     }
 
     injectResourceCountIndicatorStylesheet() {

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -39,7 +39,36 @@ class AnkiHubReviewerButtons {
     }
 
     setupButtons() {
+        const elementsContainer = document.createElement("div");
         const buttonContainer = document.createElement("div");
+        const toggleButtonsButton = document.createElement("button");
+
+        let isButtonsVisible = true;
+        const iconArrowRight = `
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+        </svg>
+        `;
+        const iconArrowLeft = `
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+        </svg>
+        `;
+        toggleButtonsButton.innerHTML = isButtonsVisible ? iconArrowRight : iconArrowLeft;
+        toggleButtonsButton.onclick = () => {
+            isButtonsVisible = !isButtonsVisible;
+            toggleButtonsButton.innerHTML = isButtonsVisible ? iconArrowRight : iconArrowLeft;
+            if (isButtonsVisible) {
+                buttonContainer.style.visibility = "visible";
+                toggleButtonsButton.style.borderRadius = "0px";
+            } else {
+                buttonContainer.style.visibility = "hidden";
+                toggleButtonsButton.style.borderRadius = "4px 0px 0px 4px";
+            }
+        }
+
+        this.setToggleButtonsButtonStyle(toggleButtonsButton);
+        this.setElementsContainerStyle(elementsContainer);
         this.setButtonContainerStyle(buttonContainer);
 
         this.buttonsData.forEach((buttonData, buttonIdx) => {
@@ -86,7 +115,9 @@ class AnkiHubReviewerButtons {
             buttonContainer.appendChild(buttonElement);
         })
 
-        document.body.appendChild(buttonContainer);
+        elementsContainer.appendChild(buttonContainer);
+        elementsContainer.appendChild(toggleButtonsButton);
+        document.body.appendChild(elementsContainer);
         this.injectResourceCountIndicatorStylesheet();
     }
 
@@ -94,11 +125,35 @@ class AnkiHubReviewerButtons {
         return document.getElementById(`ankihub-${buttonName}-button`);
     }
 
+    setToggleButtonsButtonStyle(toggleButtonsButton) {
+        const styles = `
+            .ankihub-toggle-buttons-button:hover {
+                background: ${this.theme == "light" ? "#e5e7eb" : "#1f2937"} !important;
+            }
+        `;
+        const styleSheet = document.createElement("style");
+        styleSheet.innerText = styles;
+        document.head.appendChild(styleSheet);
+        toggleButtonsButton.style.width = "16px";
+        toggleButtonsButton.style.padding = "0px";
+        toggleButtonsButton.style.margin = "0px";
+        toggleButtonsButton.style.backgroundColor = this.theme == "light" ? this.colorButtonLight : this.colorButtonDark;
+        toggleButtonsButton.style.border = this.theme == "light" ? `1px solid ${this.colorButtonBorderLight}` : `1px solid ${this.colorButtonBorderDark}`;
+        toggleButtonsButton.style.borderRadius = "0px";
+        toggleButtonsButton.style.boxSizing = "border-box";
+        toggleButtonsButton.style.color = this.theme == "light" ? "#000000" : "#ffffff";
+        toggleButtonsButton.classList.add("ankihub-toggle-buttons-button");
+    }
+
+    setElementsContainerStyle(elementsContainer) {
+        elementsContainer.style.position = "fixed";
+        elementsContainer.style.bottom = "28px";
+        elementsContainer.style.right = "0px";
+        elementsContainer.style.zIndex = "9999";
+        elementsContainer.style.display = "flex";
+    }
+
     setButtonContainerStyle(buttonContainer) {
-        buttonContainer.style.position = "fixed";
-        buttonContainer.style.bottom = "0px";
-        buttonContainer.style.right = "0px";
-        buttonContainer.style.zIndex = "9999";
         buttonContainer.style.display = "flex";
         buttonContainer.style.flexDirection = "column";
     }
@@ -196,7 +251,7 @@ class AnkiHubReviewerButtons {
 
     setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
         tooltip.style.position = "absolute";
-        tooltip.style.right = "60px";
+        tooltip.style.right = "76px";
         tooltip.style.zIndex = "1000";
         tooltip.style.fontSize = "medium";
         tooltip.style.borderRadius = "5px";
@@ -254,7 +309,7 @@ class AnkiHubReviewerButtons {
 
     setResourceCountIndicatorStyles(button, indicator) {
         indicator.style.position = "absolute";
-        indicator.style.right = "48px";
+        indicator.style.right = "64px";
         indicator.style.zIndex = "999";
         indicator.style.fontFamily = "Merriweather sans-serif";
         indicator.style.fontSize = "12px";

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -147,7 +147,7 @@ class AnkiHubReviewerButtons {
 
     setElementsContainerStyle(elementsContainer) {
         elementsContainer.style.position = "fixed";
-        elementsContainer.style.bottom = "28px";
+        elementsContainer.style.bottom = "0px";
         elementsContainer.style.right = "0px";
         elementsContainer.style.zIndex = "9999";
         elementsContainer.style.display = "flex";

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -261,7 +261,7 @@ class AnkiHubReviewerButtons {
     setTooltipAndTooltipArrowStyles(tooltip, tooltipArrow) {
         tooltip.style.position = "absolute";
         tooltip.style.right = "76px";
-        tooltip.style.zIndex = "1000";
+        tooltip.style.zIndex = "20000";
         tooltip.style.fontSize = "medium";
         tooltip.style.borderRadius = "5px";
         tooltip.style.textAlign = "center";

--- a/ankihub/gui/web/sidebar_tabs.html
+++ b/ankihub/gui/web/sidebar_tabs.html
@@ -156,6 +156,7 @@
             </button>
         </div>
     </div>
+    {% if tabs %}
     <nav class="webview-tabs">
         {% for tab in tabs %}
         <div class="webview-tab {% if current_active_tab_url == tab.url %}selected{% endif %}"
@@ -165,4 +166,5 @@
         </div>
         {% endfor %}
     </nav>
+    {% endif %}
 </div>


### PR DESCRIPTION
## Related issues
- [BUILD-918](https://ankihub.atlassian.net/browse/BUILD-918)

## Proposed changes
This PR adds a toggle button that will hide the sidebar buttons.


## How to reproduce
1. Go to the card review
2. Click on the button with the right arrow to collapse the buttons
3. Click again to show the buttons


## Screenshots and videos

[Screencast from 2024-12-17 10-11-12.webm](https://github.com/user-attachments/assets/c826f4db-1013-4337-accf-63c141c830e7)

![image](https://github.com/user-attachments/assets/121f21e9-0b58-492f-a387-73f660b10a2e)
![image](https://github.com/user-attachments/assets/856d0a89-6345-428d-b5d5-ded4a3996a91)
![image](https://github.com/user-attachments/assets/bace2114-b4cc-408f-bfb8-1383b7627b5c)
![image](https://github.com/user-attachments/assets/2c447449-32de-4d33-abfe-02cb6bf44fa1)


[BUILD-918]: https://ankihub.atlassian.net/browse/BUILD-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ