### PR TITLE
[BUILD-929] fix: Remove `setUpdatesEnabled` calls

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -233,7 +233,6 @@ class ReviewerSidebar:
         self._update_content_webview_theme()
 
         if url:
-            self.content_webview.setUpdatesEnabled(False)
             self.url_page.setUrl(aqt.QUrl(url))
             if self.content_webview.page() != self.url_page:
                 self.content_webview.setPage(self.url_page)
@@ -246,8 +245,6 @@ class ReviewerSidebar:
         )
 
     def _on_url_page_loaded(self, ok: bool) -> None:
-        self.content_webview.setUpdatesEnabled(True)
-
         if ok:
             return
 


### PR DESCRIPTION
I added the `setUpdatesEnabled` (https://doc.qt.io/qt-6/qwidget.html#updatesEnabled-prop) call in order to try to reduce flickering of the sidebar webviews when switching to a new page.
However when the page takes long to load and you resize the sidebar using the slider, it leads to very odd liking visuals, the sidebar leaves some kind of traces on its old position.
This is why we should remove the `setUpdatesEnabled` calls.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-929

## Proposed changes
- Remove `setUpdatesEnabled` calls

## Screenshots
<img src="https://github.com/user-attachments/assets/24b59848-5619-4e46-bcf9-6a955b3dfb9e" width="500" />