### PR TITLE
[BUILD-928] fix: Update `mh_tag_to_resource_title_and_slug`

### DIFF
--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -672,6 +672,16 @@ def mh_tag_to_resource_title_and_slug(tag: str) -> Optional[Tuple[str, str]]:
         resource_slug_str = {"b&b": "bb", "firstaid": "fa"}[resource_type_str.lower()]
         path = re.sub(r".+_v12::#.+?::", "", tag, re.IGNORECASE)
         path_parts = path.split("::")
+
+        # Remove path parts after first path part starting with "*"
+        for index, part in enumerate(path_parts):
+            if part.startswith("*"):
+                path_parts = path_parts[:index]
+                break
+
+        if path_parts[-1].lower() == "extra":
+            path_parts = path_parts[:-1]
+
         path_parts = [part.lower() for part in path_parts]
         cleaned_path_parts = [re.sub(r"\d+_", "", part) for part in path_parts]
         slug = f"step{step}-{resource_slug_str}-{'-'.join(cleaned_path_parts)}"

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3058,21 +3058,40 @@ def test_send_daily_review_summaries_without_data(mocker):
 @pytest.mark.parametrize(
     "tag, expected_title, expected_slug",
     [
+        # With B&B tag
         (
             "#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia",
             "Ammonia",
             "step1-bb-biochem-amino_acids-ammonia",
         ),
-        (
-            "#ak_step1_v12::#b&b::03_biochem::03_amino_acids::04_ammonia",
-            "Ammonia",
-            "step1-bb-biochem-amino_acids-ammonia",
-        ),
+        # With First Aid tag
         (
             "#AK_Step2_v12::#FirstAid::14_Pulm::16_Nose_and_Throat::01_Rhinitis",
             "Rhinitis",
             "step2-fa-pulm-nose_and_throat-rhinitis",
         ),
+        # With lowercase tag
+        (
+            "#ak_step1_v12::#b&b::03_biochem::03_amino_acids::04_ammonia",
+            "Ammonia",
+            "step1-bb-biochem-amino_acids-ammonia",
+        ),
+        # With trailing Extra tag part that should be ignored
+        (
+            "#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia::Extra",
+            "Ammonia",
+            "step1-bb-biochem-amino_acids-ammonia",
+        ),
+        # With tag part group starting with "*" that should be ignored
+        (
+            (
+                "#AK_Step1_v12::#FirstAid::05_Pharm::02_Autonomic_Drugs::15_beta-blockers::"
+                "*B-Antagonists::Cardioselective_B1_Antagonists"
+            ),
+            "Beta-blockers",
+            "step1-fa-pharm-autonomic_drugs-beta-blockers",
+        ),
+        # With invalid tag
         ("invalid_tag", None, None),
     ],
 )


### PR DESCRIPTION
The `mh_tag_to_resource_title_and_slug` function doesn't work correctly for some tags.
In particular, it doesn't ignore some parts of the tag which should be ignored.

It should ignore trailing `::Extra` tag parts, for example for this tag:
`#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia::Extra`
the slug should be this:
`step1-bb-biochem-amino_acids-ammonia`
(The `::Extra` part indicates that the tag is a secondary tag for the resource referenced by it.)

It should also ignore all tag parts starting with a tag part that begins with `*`. For example for this tag:
`#AK_Step1_v12::#FirstAid::05_Pharm::02_Autonomic_Drugs::15_beta-blockers::*B-Antagonists::Cardioselective_B1_Antagonists`
the slug should be this:
`step1-fa-pharm-autonomic_drugs-beta-blockers`
Everything after the tag part starting with `*` is more granular information which isn't part of the slug of the resource.



## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-928


## Proposed changes
- Update `mh_tag_to_resource_title_and_slug` to ignore parts which should be ignored
- Update tests

## Comments
We also need to make similar changes to the JS on the note type