### PR TITLE
[BUILD-932] fix: Don't show duplicate resource tabs

### DIFF
--- a/ankihub/gui/web/templates.py
+++ b/ankihub/gui/web/templates.py
@@ -11,11 +11,11 @@ env = Environment(
 
 
 def get_header_webview_html(
-    urls_list, current_active_tab_url: str, page_title: str, theme: str
+    tabs, current_active_tab_url: str, page_title: str, theme: str
 ) -> str:
     return env.get_template("sidebar_tabs.html").render(
         {
-            "tabs": urls_list,
+            "tabs": tabs,
             "current_active_tab_url": current_active_tab_url,
             "page_title": page_title,
             "theme": theme,


### PR DESCRIPTION
We need to prevent showing duplicate resources for a note.
If there are multiple tags that reference a resource, there should still be just one tab for the resource.

Here is a screenshot of the problem:
<img src="https://github.com/user-attachments/assets/ffa79330-6e78-44d7-bf90-bdb032804996" width="600" />

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-932

## Proposed changes
- Add the `_get_resources` function, which returns a list of resources without duplicates
  https://github.com/AnkiHubSoftware/ankihub_addon/blob/117bfe33a6b0cf0237cf3f0df1b10dfb328ce9b9/ankihub/gui/reviewer.py#L519
- Use the `_get_resources` function for updating tabs and for updating the resource counts on the reviewer buttons

## How to reproduce
- You can add these tags to a note
  ```
  AK_Step1_v12::#FirstAid::05_Pharm::02_Autonomic_Drugs::15_beta-blockers::*B-Antagonists::Cardioselective_B1_Antagonists::Basics
  AK_Step1_v12::#FirstAid::05_Pharm::02_Autonomic_Drugs::15_beta-blockers::*B-Antagonists::Cardioselective_B1_Antagonists
  AK_Step1_v12::#FirstAid::05_Pharm::02_Autonomic_Drugs::15_beta-blockers
  ```
  - You can just copy paste all of them into the tag field
  - Without the changes in this PR, there would be 3 beta-blocker tabs
  - With the changes in this PR, there should be just one