### PR TITLE
[BUILD-935] chore: Fix tests hanging in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test-addon:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -45,7 +45,7 @@ jobs:
       - name: Run pytest with coverage
         run: |
           pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml
-          pytest ./tests/addon -n 0 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
+          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
           pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append
 
       - name: Upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          pytest ./tests/addon -n 1 -m sequential --cov --cov-report=xml --retries 2
-          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append --retries 2
-          pytest ./tests/addon -n 1 -m performance --cov-report=xml --cov-append --retries 2
+          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml --retries 2
+          pytest ./tests/addon -n 0 -m "not sequential and not performance" --cov --cov-report=xml --cov-append --retries 2
+          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append --retries 2
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml --retries 2
-          pytest ./tests/addon -n 0 -m "not sequential and not performance" --cov --cov-report=xml --cov-append --retries 2
-          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append --retries 2
+          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml
+          pytest ./tests/addon -n 0 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
+          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          pytest ./tests/addon -n 0 -m sequential
-          pytest ./tests/addon -n 4 -m "not sequential and not performance"
-          pytest ./tests/addon -n 0 -m performance
+          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml
+          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
+          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml
-          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
-          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append
+          pytest ./tests/addon -n 0 -m sequential
+          pytest ./tests/addon -n 4 -m "not sequential and not performance"
+          pytest ./tests/addon -n 0 -m performance
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml
-          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append
-          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append
+          pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml --retries 2
+          pytest ./tests/addon -n 4 -m "not sequential and not performance" --cov --cov-report=xml --cov-append --retries 2
+          pytest ./tests/addon -n 0 -m performance --cov-report=xml --cov-append --retries 2
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Tests are currently hanging in the GHA:
https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/12411140318/job/34648205589

This PR fixes this by using an older ubuntu version for the tests runner.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-935


## Proposed changes
- Use `ubuntu-22.04` instead of `ubuntu-latest` (`ubuntu-24.04`)
  - I don't know why, but the tests don't hang on `ubuntu-22.04`

