### PR TITLE
[BUILD-940] refactor: Refactor slug generation in mh_tag_to_resource_title_and_slug function

### DIFF
--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -664,7 +664,7 @@ def mh_tag_to_resource_title_and_slug(tag: str) -> Optional[Tuple[str, str]]:
 
     Example:
     #AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia
-    -> ('Ammonia', 'step1-bb-biochem-amino_acids-ammonia')
+    -> ('Ammonia', 'step1-bb-3-3-4')
     """
     try:
         step = int(re.match(r"#AK_Step(\d+)_v12::", tag, re.IGNORECASE).group(1))
@@ -683,8 +683,9 @@ def mh_tag_to_resource_title_and_slug(tag: str) -> Optional[Tuple[str, str]]:
             path_parts = path_parts[:-1]
 
         path_parts = [part.lower() for part in path_parts]
+        content_numbers = [str(int(re.sub(r"\D", "", part))) for part in path_parts]
         cleaned_path_parts = [re.sub(r"\d+_", "", part) for part in path_parts]
-        slug = f"step{step}-{resource_slug_str}-{'-'.join(cleaned_path_parts)}"
+        slug = f"step{step}-{resource_slug_str}-{'-'.join(content_numbers)}"
 
         title = cleaned_path_parts[-1].replace("_", " ")
         title = " ".join([word.capitalize() for word in title.split()])

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3062,25 +3062,25 @@ def test_send_daily_review_summaries_without_data(mocker):
         (
             "#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia",
             "Ammonia",
-            "step1-bb-biochem-amino_acids-ammonia",
+            "step1-bb-3-3-4",
         ),
         # With First Aid tag
         (
             "#AK_Step2_v12::#FirstAid::14_Pulm::16_Nose_and_Throat::01_Rhinitis",
             "Rhinitis",
-            "step2-fa-pulm-nose_and_throat-rhinitis",
+            "step2-fa-14-16-1",
         ),
         # With lowercase tag
         (
             "#ak_step1_v12::#b&b::03_biochem::03_amino_acids::04_ammonia",
             "Ammonia",
-            "step1-bb-biochem-amino_acids-ammonia",
+            "step1-bb-3-3-4",
         ),
         # With trailing Extra tag part that should be ignored
         (
             "#AK_Step1_v12::#B&B::03_Biochem::03_Amino_Acids::04_Ammonia::Extra",
             "Ammonia",
-            "step1-bb-biochem-amino_acids-ammonia",
+            "step1-bb-3-3-4",
         ),
         # With tag part group starting with "*" that should be ignored
         (
@@ -3089,7 +3089,7 @@ def test_send_daily_review_summaries_without_data(mocker):
                 "*B-Antagonists::Cardioselective_B1_Antagonists"
             ),
             "Beta-blockers",
-            "step1-fa-pharm-autonomic_drugs-beta-blockers",
+            "step1-fa-5-2-15",
         ),
         # With invalid tag
         ("invalid_tag", None, None),


### PR DESCRIPTION
## Related issues
- [BUILD-940](https://ankihub.atlassian.net/browse/BUILD-940)


## Proposed changes
This PR updates the function `mh_tag_to_resource_title_and_slug` to use a new pattern to extract the slug from the tags


## How to reproduce
1. Access the reviewer with a note of the Anking deck
2. Check if the contents of the Boards & Beyond, and First Aid Forward are being loaded in the sidebar

## Further Comments
To test this branch the reviewer needs to make a checkout to the ankihub repository on the branch `refactor/update-mh-scripts-to-new-slug-pattern`, and follow the steps described in this [PR](https://github.com/AnkiHubSoftware/ankihub/pull/2499)

[BUILD-940]: https://ankihub.atlassian.net/browse/BUILD-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ