### PR TITLE
[BUILD-960] fix: Tag to slug conversion with number later in tag part

### DIFF
--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -683,11 +683,13 @@ def mh_tag_to_resource_title_and_slug(tag: str) -> Optional[Tuple[str, str]]:
             path_parts = path_parts[:-1]
 
         path_parts = [part.lower() for part in path_parts]
-        content_numbers = [str(int(re.sub(r"\D", "", part))) for part in path_parts]
-        cleaned_path_parts = [re.sub(r"\d+_", "", part) for part in path_parts]
+        content_numbers = [
+            str(int(re.match(r"\d+", part).group(0))) for part in path_parts
+        ]
         slug = f"step{step}-{resource_slug_str}-{'-'.join(content_numbers)}"
 
-        title = cleaned_path_parts[-1].replace("_", " ")
+        title = re.sub(r"\d+_", "", path_parts[-1])
+        title = title.replace("_", " ")
         title = " ".join([word.capitalize() for word in title.split()])
     except (KeyError, AttributeError, IndexError):
         # We want to ignore any tags that don't match the expected format

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3091,6 +3091,12 @@ def test_send_daily_review_summaries_without_data(mocker):
             "Beta-blockers",
             "step1-fa-5-2-15",
         ),
+        # With number in title
+        (
+            "#AK_Step1_v12::#FirstAid::01_Biochem::03_Laboratory_Techniques::02_CRISPR/Cas9",
+            "Crispr/cas9",
+            "step1-fa-1-3-2",
+        ),
         # With invalid tag
         ("invalid_tag", None, None),
     ],


### PR DESCRIPTION
For some tags the tag-to-slug conversion results in a slug with extra numbers.

For example:
`#AK_Step1_v12::#FirstAid::01_Biochem::03_Laboratory_Techniques::02_CRISPR/Cas9`
currently results in this slug:
`step1-fa-1-3-29`
while it should be this:
`step1-fa-1-3-2`

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-960

## Proposed changes
- Only use numbers from beginning of the tag parts

