### PR TITLE
[BUILD-944] refactor: Update empty stage page

### DIFF
--- a/ankihub/gui/web/mh_no_urls_empty_state.html
+++ b/ankihub/gui/web/mh_no_urls_empty_state.html
@@ -50,11 +50,13 @@
     <div class="empty-state-container">
         <div class="empty-state-center-content">
             <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M20.0011 14.9997V21.2497M4.49568 26.8758C3.05337 29.3758 4.85765 32.4997 7.74387 32.4997H32.2583C35.1445 32.4997 36.9488 29.3758 35.5065 26.8758L23.2493 5.62995C21.8062 3.12856 18.196 3.12856 16.7529 5.62995L4.49568 26.8758ZM20.0011 26.2497H20.0136V26.2622H20.0011V26.2497Z" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M25.9841 23.9493C26.158 24.688 26.25 25.4583 26.25 26.25C26.25 31.7728 21.7728 36.25 16.25 36.25V28.2505M25.9841 23.9493C32.2073 19.4019 36.25 12.0479 36.25 3.75C27.9524 3.75035 20.5991 7.7931 16.052 14.0163M25.9841 23.9493C23.1365 26.0302 19.8323 27.5234 16.25 28.2505M16.052 14.0163C15.313 13.8421 14.5422 13.75 13.75 13.75C8.22715 13.75 3.75 18.2272 3.75 23.75H11.7512M16.052 14.0163C13.9714 16.8638 12.4783 20.1678 11.7512 23.75M16.25 28.2505C16.0776 28.2855 15.9047 28.3187 15.731 28.3502C14.2195 27.1516 12.8498 25.782 11.6513 24.2704C11.6828 24.0963 11.7161 23.9228 11.7512 23.75M8.01985 27.7346C6.18689 29.102 5 31.2874 5 33.75C5 34.1448 5.0305 34.5324 5.08927 34.9107C5.46757 34.9695 5.85522 35 6.25 35C8.71263 35 10.898 33.8131 12.2654 31.9801M27.5 15C27.5 16.3807 26.3807 17.5 25 17.5C23.6193 17.5 22.5 16.3807 22.5 15C22.5 13.6193 23.6193 12.5 25 12.5C26.3807 12.5 27.5 13.6193 27.5 15Z" stroke="#F59E0B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
-            <h1 class="empty-state-title">Uh oh! No content here</h1>
+            <h1 class="empty-state-title">Coming soon!</h1>
         </div>
-        <p class="empty-state-message">😅 Unfortunately, there is no extra material linked to this card. Keep studying to find more <strong>{% if resource_type == 'b&b' %}Boards&Beyond{% else %}First AID Forward{% endif %}</strong> content on other notes.</p>
+        <p class="empty-state-message">
+            🚧 We are working on the full mapping to link extra material to this card. Keep studying and find <strong>{% if resource_type == "b&b" %}Boards & Beyond{% else %}First AID Forward{% endif %}</strong> content on other notes!
+        </p>
     </div>
 </div>
 


### PR DESCRIPTION
## Related issues
- [BUILD-944](https://ankihub.atlassian.net/browse/BUILD-944)


## Proposed changes
This PR updates the style and the content of the empty state page when accessing the boards & beyond/first aid forward content

## Screenshots and videos
![image](https://github.com/user-attachments/assets/b710409d-96ab-4947-bc5a-b0d55920f682)
![image](https://github.com/user-attachments/assets/bfc6dca2-83b7-455b-801e-52b83a794098)



[BUILD-944]: https://ankihub.atlassian.net/browse/BUILD-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ