### PR TITLE
feat: Add terms and policy submenu to AnkiHub menu

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -531,8 +531,7 @@ def _ankihub_terms_and_policy_setup(parent: QMenu):
     qconnect(
         q_terms_and_conditions_action.triggered,
         lambda: openLink(
-            """https://community.ankihub.net/tos?_gl=1*14cx6gn*_ga*MTUwNTk4MjUuMTcwNDk5NTI1NA..\
-            *_ga_T2ZF93TKF6*MTczMzQyNTA4NS42Mi4xLjE3MzM0MjUyMDcuMC4wLjA."""
+            "https://community.ankihub.net/tos"
         ),
     )
     terms_and_policy_menu.addAction(q_terms_and_conditions_action)

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -530,9 +530,7 @@ def _ankihub_terms_and_policy_setup(parent: QMenu):
     )
     qconnect(
         q_terms_and_conditions_action.triggered,
-        lambda: openLink(
-            "https://community.ankihub.net/tos"
-        ),
+        lambda: openLink("https://community.ankihub.net/tos"),
     )
     terms_and_policy_menu.addAction(q_terms_and_conditions_action)
 

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -525,10 +525,15 @@ def _ankihub_terms_and_policy_setup(parent: QMenu):
     """Set up the sub menu for terms and policy related items."""
     terms_and_policy_menu = QMenu("🤝 Terms and Policy", parent)
 
-    q_terms_and_conditions_action = QAction("Terms && Conditions", terms_and_policy_menu)
+    q_terms_and_conditions_action = QAction(
+        "Terms && Conditions", terms_and_policy_menu
+    )
     qconnect(
         q_terms_and_conditions_action.triggered,
-        lambda: openLink("https://community.ankihub.net/tos?_gl=1*14cx6gn*_ga*MTUwNTk4MjUuMTcwNDk5NTI1NA..*_ga_T2ZF93TKF6*MTczMzQyNTA4NS42Mi4xLjE3MzM0MjUyMDcuMC4wLjA."),
+        lambda: openLink(
+            """https://community.ankihub.net/tos?_gl=1*14cx6gn*_ga*MTUwNTk4MjUuMTcwNDk5NTI1NA..\
+            *_ga_T2ZF93TKF6*MTczMzQyNTA4NS42Mi4xLjE3MzM0MjUyMDcuMC4wLjA."""
+        ),
     )
     terms_and_policy_menu.addAction(q_terms_and_conditions_action)
 
@@ -540,6 +545,7 @@ def _ankihub_terms_and_policy_setup(parent: QMenu):
     terms_and_policy_menu.addAction(q_privacy_policy_action)
 
     parent.addMenu(terms_and_policy_menu)
+
 
 def _ankihub_logout_setup(parent: QMenu):
     q_action = QAction("🔑 Sign out", aqt.mw)

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -74,6 +74,7 @@ def refresh_ankihub_menu() -> None:
         _ankihub_login_setup(parent=menu_state.ankihub_menu)
 
     _config_setup(parent=menu_state.ankihub_menu)
+    _ankihub_terms_and_policy_setup(parent=menu_state.ankihub_menu)
     _ankihub_help_setup(parent=menu_state.ankihub_menu)
 
 
@@ -519,6 +520,26 @@ def _trigger_install_release_version():
 
     check_and_prompt_for_updates_on_main_window()
 
+
+def _ankihub_terms_and_policy_setup(parent: QMenu):
+    """Set up the sub menu for terms and policy related items."""
+    terms_and_policy_menu = QMenu("🤝 Terms and Policy", parent)
+
+    q_terms_and_conditions_action = QAction("Terms && Conditions", terms_and_policy_menu)
+    qconnect(
+        q_terms_and_conditions_action.triggered,
+        lambda: openLink("https://community.ankihub.net/tos?_gl=1*14cx6gn*_ga*MTUwNTk4MjUuMTcwNDk5NTI1NA..*_ga_T2ZF93TKF6*MTczMzQyNTA4NS42Mi4xLjE3MzM0MjUyMDcuMC4wLjA."),
+    )
+    terms_and_policy_menu.addAction(q_terms_and_conditions_action)
+
+    q_privacy_policy_action = QAction("Privacy Policy", terms_and_policy_menu)
+    qconnect(
+        q_privacy_policy_action.triggered,
+        lambda: openLink("https://community.ankihub.net/privacy"),
+    )
+    terms_and_policy_menu.addAction(q_privacy_policy_action)
+
+    parent.addMenu(terms_and_policy_menu)
 
 def _ankihub_logout_setup(parent: QMenu):
     q_action = QAction("🔑 Sign out", aqt.mw)


### PR DESCRIPTION
**Related issues**

- [BUILD-954](https://ankihub.atlassian.net/browse/BUILD-954)

**Proposed changes**

This pull request adds a new "Terms and Policy" submenu to the AnkiHub menu. The submenu includes links to the Terms and Conditions and Privacy Policy documents, which are accessible directly from the main menu.

The modifications include adding a new function `_ankihub_terms_and_policy_setup` in `menu.py`, which creates the terms and policy sub-menu with two actions: "Terms && Conditions" and "Privacy Policy". These actions are connected to open links to the respective documents on the AnkiHub community website.

**How to reproduce**

1. Run the AnkiHub application.
2. Access the main menu.
3. Click on the new "Terms and Policy" submenu.
4. Select either "Terms && Conditions" or "Privacy Policy" to access the corresponding document link.

**Screenshots and videos**

![image](https://github.com/user-attachments/assets/90d93879-43f6-41c1-ae77-315a2794a194)


[BUILD-954]: https://ankihub.atlassian.net/browse/BUILD-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ