### PR TITLE
[BUILD-921] Update smart search upsell

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1259,12 +1259,15 @@ class AnkiHubClient:
         if response.status_code != 204:
             raise AnkiHubHTTPError(response)
 
-    def owned_deck_ids(self) -> List[uuid.UUID]:
+    def get_user_details(self) -> Dict[str, Any]:
         response = self._send_request("GET", API.ANKIHUB, "/users/me")
         if response.status_code != 200:
             raise AnkiHubHTTPError(response)
 
-        data = response.json()
+        return response.json()
+
+    def owned_deck_ids(self) -> List[uuid.UUID]:
+        data = self.get_user_details()
         result = [uuid.UUID(deck["id"]) for deck in data["created_decks"]]
         return result
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -55,7 +55,7 @@ from aqt.gui_hooks import (
     browser_will_show_context_menu,
 )
 from aqt.importing import AnkiPackageImporter
-from aqt.qt import QAction, Qt, QUrl
+from aqt.qt import QAction, Qt, QUrl, QWidget
 from aqt.theme import theme_manager
 from aqt.webview import AnkiWebView
 from pytest import fixture
@@ -5672,6 +5672,16 @@ class TestFlashCardSelector:
 
             mocker.patch.object(AnkiWebView, "load_url")
 
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_user_details",
+                return_value={
+                    "is_premium": True,
+                    "is_trialing": False,
+                    "show_trial_ended_message": False,
+                },
+            )
+
             overview_web: AnkiWebView = aqt.mw.overview.web
             overview_web.eval(
                 f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}').click()",
@@ -5709,6 +5719,16 @@ class TestFlashCardSelector:
 
             mocker.patch.object(AnkiWebView, "load_url")
 
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_user_details",
+                return_value={
+                    "is_premium": True,
+                    "is_trialing": False,
+                    "show_trial_ended_message": False,
+                },
+            )
+
             overview_web: AnkiWebView = aqt.mw.overview.web
             overview_web.eval(
                 f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}').click()",
@@ -5735,6 +5755,64 @@ class TestFlashCardSelector:
             qtbot.wait_until(flashcard_selector_opened)
 
             assert FlashCardSelectorDialog.dialog == dialog
+
+    @pytest.mark.sequential
+    @pytest.mark.parametrize(
+        "show_trial_ended_message",
+        [False, True],
+    )
+    def test_shows_flashcard_selector_upsell_if_no_access(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        set_feature_flag_state: SetFeatureFlagState,
+        mocker: MockerFixture,
+        show_trial_ended_message: bool,
+    ):
+        set_feature_flag_state("show_flashcards_selector_button")
+
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token")
+
+            anki_did = DeckId(1)
+            install_ah_deck(
+                anki_did=anki_did,
+                has_note_embeddings=True,
+            )
+            aqt.mw.deckBrowser.set_current_deck(anki_did)
+
+            qtbot.wait(500)
+
+            mocker.patch.object(AnkiWebView, "load_url")
+
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_user_details",
+                return_value={
+                    "is_premium": False,
+                    "is_trialing": False,
+                    "show_trial_ended_message": show_trial_ended_message,
+                },
+            )
+
+            overview_web: AnkiWebView = aqt.mw.overview.web
+            overview_web.eval(
+                f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}').click()",
+            )
+
+            def upsell_dialog_opened():
+                dialog: QWidget = aqt.mw.app.activeWindow()
+                if not isinstance(dialog, utils._Dialog):
+                    return False
+                return (
+                    "Trial" in dialog.windowTitle()
+                    if show_trial_ended_message
+                    else True
+                )
+
+            qtbot.wait_until(upsell_dialog_opened)
 
     def test_with_no_auth_token(
         self,


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/BUILD-921

## Proposed changes

This PR updates the flashcard selector button to show an upsell dialog if the user doesn't have access to the feature, with the same copy shown in the web app.

## How to reproduce

### Premium/trialing users (no changes)

- Log in as a premium user.
- Open the flashcard selector and confirm no changes to existing behavior.

### Non-premium

- Log in to a non-premium account.
- Open the flashcard selector and confirm the new upsell dialog is shown.
- Set/unset the `saw_trial_ended_message` field in the Django user model on the backend side and confirm the change in the title.

## Screenshots and videos

![image](https://github.com/user-attachments/assets/c18564c0-99d4-45b0-8b98-cfdb4f0e6ab7)
![image](https://github.com/user-attachments/assets/2882ff88-63a6-4c36-8572-e026b302298c)

(emojis broken due to a font issue in my system)

