### PR TITLE
[BUILD-973] fix: Fix incorrect username/token profile keys being used

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -1,4 +1,5 @@
 """AnkiHub menu on Anki's main window."""
+
 import re
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -49,13 +50,8 @@ menu_state = _MenuState()
 def setup_ankihub_menu() -> None:
     menu_state.ankihub_menu = QMenu("&AnkiHub", parent=aqt.mw)
     aqt.mw.form.menubar.addMenu(menu_state.ankihub_menu)
-    config.token_change_hook.append(
-        lambda: aqt.mw.taskman.run_on_main(refresh_ankihub_menu)
-    )
-    config.subscriptions_change_hook = lambda: aqt.mw.taskman.run_on_main(
-        refresh_ankihub_menu
-    )
-    refresh_ankihub_menu()
+
+    qconnect(menu_state.ankihub_menu.aboutToShow, refresh_ankihub_menu)
 
 
 def refresh_ankihub_menu() -> None:

--- a/ankihub/private_config_migrations.py
+++ b/ankihub/private_config_migrations.py
@@ -125,13 +125,21 @@ def _maybe_prompt_user_for_behavior_on_remote_note_deleted(
 def _move_credentials_to_profile_config(
     private_config_dict: Dict,
 ) -> None:
-    """Move login credentials to Anki's profile config."""
+    """
+    Move login credentials to Anki's profile config.
+    Also move the ankiHubToken/ankiHubUsername profile config keys to thirdPartyAnkiHubToken/thirdPartyAnkiHubUsername
+    as the keys used by Anki have changed.
+    """
 
-    token = private_config_dict.pop("token", None)
-    username = private_config_dict.pop("user", None)
+    token = private_config_dict.pop("token", None) or aqt.mw.pm.profile.pop(
+        "ankiHubToken", None
+    )
+    username = private_config_dict.pop("user", None) or aqt.mw.pm.profile.pop(
+        "ankiHubUsername", None
+    )
     if token:
         # aqt.mw.pm.set_ankihub_token(token)
-        aqt.mw.pm.profile["ankiHubToken"] = token
+        aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = token
     if username:
         # aqt.mw.pm.set_ankihub_username(username)
-        aqt.mw.pm.profile["ankiHubUsername"] = username
+        aqt.mw.pm.profile["thirdPartyAnkiHubUsername"] = username

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -260,13 +260,13 @@ class _Config:
 
     def save_token(self, token: str):
         # aqt.mw.pm.set_ankihub_token(token)
-        aqt.mw.pm.profile["ankiHubToken"] = token
+        aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = token
         for func in self.token_change_hook:
             func()
 
     def save_user_email(self, user_email: str):
         # aqt.mw.pm.set_ankihub_username(user_email)
-        aqt.mw.pm.profile["ankiHubUsername"] = user_email
+        aqt.mw.pm.profile["thirdPartyAnkiHubUsername"] = user_email
 
     def save_latest_deck_update(
         self, ankihub_did: uuid.UUID, latest_update: Optional[datetime]
@@ -398,11 +398,11 @@ class _Config:
 
     def token(self) -> Optional[str]:
         # return aqt.mw.pm.ankihub_token()
-        return aqt.mw.pm.profile.get("ankiHubToken")
+        return aqt.mw.pm.profile.get("thirdPartyAnkiHubToken")
 
     def user(self) -> Optional[str]:
         # return aqt.mw.pm.ankihub_username()
-        return aqt.mw.pm.profile.get("ankiHubUsername")
+        return aqt.mw.pm.profile.get("thirdPartyAnkiHubUsername")
 
     def ui_config(self) -> UIConfig:
         return self._private_config.ui

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -190,7 +190,6 @@ class _Config:
         self._private_config: Optional[PrivateConfig] = None
         self._private_config_path: Optional[Path] = None
         self.token_change_hook: List[Callable[[], None]] = []
-        self.subscriptions_change_hook: Optional[Callable[[], None]] = None
         self.app_url: Optional[str] = None
         self.s3_bucket_url: Optional[str] = None
         self.anking_deck_id: Optional[uuid.UUID] = None
@@ -340,9 +339,6 @@ class _Config:
         self.save_latest_deck_update(ankihub_did, latest_udpate)
         self._update_private_config()
 
-        if self.subscriptions_change_hook:
-            self.subscriptions_change_hook()
-
     def update_deck(self, deck: Deck):
         """Update the deck config with the values from the Deck object."""
         deck_config = self.deck_config(deck.ah_did)
@@ -363,8 +359,6 @@ class _Config:
         if self._private_config.decks.get(ankihub_did):
             self._private_config.decks.pop(ankihub_did)
             self._update_private_config()
-        if self.subscriptions_change_hook:
-            self.subscriptions_change_hook()
 
     def log_private_config(self, log_level=logging.INFO):
         config_copy = deepcopy(self._private_config)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -165,7 +165,7 @@ from ankihub.gui.js_message_handling import (
     _post_message_to_ankihub_js,
 )
 from ankihub.gui.media_sync import media_sync
-from ankihub.gui.menu import AnkiHubLogin, menu_state
+from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
@@ -5541,6 +5541,8 @@ class TestConfigDialog:
     def test_ankihub_menu_item_exists(self, anki_session_with_addon_data: AnkiSession):
         entry_point.run()
         with anki_session_with_addon_data.profile_loaded():
+            refresh_ankihub_menu()
+
             # Assert that the Config menu item exists
             config_action = next(
                 child


### PR DESCRIPTION
## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-973

## Proposed changes

The profile config keys used for the native integration were changed in https://github.com/ankitects/anki/pull/3232 before the PR was merged, and I forgot to update the keys in the add-on...

## How to reproduce

Log in to AnkiHub from the preferences screen and confirm the login is reflected in the add-on.

