### PR TITLE
fix: Refresh ankihub menu when about to show

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -1,4 +1,5 @@
 """AnkiHub menu on Anki's main window."""
+
 import re
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -49,13 +50,8 @@ menu_state = _MenuState()
 def setup_ankihub_menu() -> None:
     menu_state.ankihub_menu = QMenu("&AnkiHub", parent=aqt.mw)
     aqt.mw.form.menubar.addMenu(menu_state.ankihub_menu)
-    config.token_change_hook.append(
-        lambda: aqt.mw.taskman.run_on_main(refresh_ankihub_menu)
-    )
-    config.subscriptions_change_hook = lambda: aqt.mw.taskman.run_on_main(
-        refresh_ankihub_menu
-    )
-    refresh_ankihub_menu()
+
+    menu_state.ankihub_menu.aboutToShow.connect(refresh_ankihub_menu)
 
 
 def refresh_ankihub_menu() -> None:

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -51,7 +51,7 @@ def setup_ankihub_menu() -> None:
     menu_state.ankihub_menu = QMenu("&AnkiHub", parent=aqt.mw)
     aqt.mw.form.menubar.addMenu(menu_state.ankihub_menu)
 
-    menu_state.ankihub_menu.aboutToShow.connect(refresh_ankihub_menu)
+    qconnect(menu_state.ankihub_menu.aboutToShow, refresh_ankihub_menu)
 
 
 def refresh_ankihub_menu() -> None:

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -190,7 +190,6 @@ class _Config:
         self._private_config: Optional[PrivateConfig] = None
         self._private_config_path: Optional[Path] = None
         self.token_change_hook: List[Callable[[], None]] = []
-        self.subscriptions_change_hook: Optional[Callable[[], None]] = None
         self.app_url: Optional[str] = None
         self.s3_bucket_url: Optional[str] = None
         self.anking_deck_id: Optional[uuid.UUID] = None
@@ -340,9 +339,6 @@ class _Config:
         self.save_latest_deck_update(ankihub_did, latest_udpate)
         self._update_private_config()
 
-        if self.subscriptions_change_hook:
-            self.subscriptions_change_hook()
-
     def update_deck(self, deck: Deck):
         """Update the deck config with the values from the Deck object."""
         deck_config = self.deck_config(deck.ah_did)
@@ -363,8 +359,6 @@ class _Config:
         if self._private_config.decks.get(ankihub_did):
             self._private_config.decks.pop(ankihub_did)
             self._update_private_config()
-        if self.subscriptions_change_hook:
-            self.subscriptions_change_hook()
 
     def log_private_config(self, log_level=logging.INFO):
         config_copy = deepcopy(self._private_config)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -165,7 +165,7 @@ from ankihub.gui.js_message_handling import (
     _post_message_to_ankihub_js,
 )
 from ankihub.gui.media_sync import media_sync
-from ankihub.gui.menu import AnkiHubLogin, menu_state
+from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
@@ -5541,6 +5541,8 @@ class TestConfigDialog:
     def test_ankihub_menu_item_exists(self, anki_session_with_addon_data: AnkiSession):
         entry_point.run()
         with anki_session_with_addon_data.profile_loaded():
+            refresh_ankihub_menu()
+
             # Assert that the Config menu item exists
             config_action = next(
                 child


### PR DESCRIPTION


## Proposed changes
- Refresh the AnkiHub menu when it's about to show
  - This makes sure that the menu state is always correct
- Remove `Config.subscriptions_change_hook`, which became unnecessary now