### PR TITLE
[BUILD-989] fix: Missing AnkiHub menu on MacOS

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -49,6 +49,7 @@ menu_state = _MenuState()
 
 def setup_ankihub_menu() -> None:
     menu_state.ankihub_menu = QMenu("&AnkiHub", parent=aqt.mw)
+    menu_state.ankihub_menu.addAction("Loading...").setEnabled(False)
     aqt.mw.form.menubar.addMenu(menu_state.ankihub_menu)
 
     qconnect(menu_state.ankihub_menu.aboutToShow, refresh_ankihub_menu)

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -49,6 +49,7 @@ menu_state = _MenuState()
 
 def setup_ankihub_menu() -> None:
     menu_state.ankihub_menu = QMenu("&AnkiHub", parent=aqt.mw)
+    # We can't leave the menu empty, otherwise it won't show up on MacOS
     menu_state.ankihub_menu.addAction("Loading...").setEnabled(False)
     aqt.mw.form.menubar.addMenu(menu_state.ankihub_menu)
 


### PR DESCRIPTION
This fixes the AnkiHub menu missing on MacOS.  

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-989

QA comment: https://ankihub.atlassian.net/browse/BUILD-974?focusedCommentId=14224

## Proposed changes
- Add a place holder menu action so that the menu is not empty
  - Since https://github.com/AnkiHubSoftware/ankihub_addon/commit/74ede28633794a3d083caa4ee869efdf9e2cdfc2 we are starting with an empty AnkiHub menu and set up the menu actions dynamically when the menu is clicked.
  - Apparently MacOS doesn't show empty menus, which lead to the menu not showing up.
  - Now we will have a placeholder menu action so that the menu is not empty.