### PR TITLE
fix: `AttributeError` in `reviewer._get_resources`

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -623,7 +623,8 @@ def _get_resources(tags: List[str], resource_type: ResourceType) -> List[Resourc
         resource
         for tag in resource_tags
         if (
-            (resource := mh_tag_to_resource(tag)).usmle_step
+            (resource := mh_tag_to_resource(tag))
+            and resource.usmle_step
             in _get_enabled_steps_for_resource_type(resource_type)
         )
     }


### PR DESCRIPTION
Users are getting errors when reviewing cards that have B&B/FA tags which don't follow the correct format for being used to show the resource information in the sidebar.

This task fixes the problem.

## Related issues
Sentry https://ankihub.sentry.io/issues/6236884494/?project=6546414&referrer=github-pr-bot

## Proposed changes
- Check whether the return value of `mh_tag_to_resource(tag)` is `None` before trying to access its `usmle_step` attribute 
