### PR TITLE
[BUILD-1016] fix: Hide ankihub_id field in editor

### DIFF
--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -221,7 +221,7 @@ def _refresh_editor_fields_for_anki_v50_and_up_js(hide_last_field: bool) -> str:
     # This is the common part of the JS code for refreshing the fields.
     # (using an old-style format string here to avoid having to escape braces)
     refresh_fields_js = """
-        require("svelte/internal").tick().then(() => {
+        setTimeout(() => {
             let hide_last_field = %s;
             let num_fields = require('anki/NoteEditor').instances[0].fields.length;
 
@@ -234,7 +234,7 @@ def _refresh_editor_fields_for_anki_v50_and_up_js(hide_last_field: bool) -> str:
             if (hide_last_field) {
                 changeVisibilityOfField(num_fields - 1, false);
             }
-        });
+        })
         """ % (
         "true" if hide_last_field else "false"
     )


### PR DESCRIPTION
The `ankihub_id` field should be hidden in the editor, but it isn't, due to some change to Anki.

<img src="https://github.com/user-attachments/assets/11699c63-745b-43e1-bb66-81e58b2206db" width="500" />

**With this PR**
<img src="https://github.com/user-attachments/assets/f698aae1-f19f-4c72-bf24-c8144a18e596" width="500" />

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1016
https://forums.ankiweb.net/t/anki-24-11-addon-using-svelte-failing-with-cannot-require-svelte-internal/53068/6


## Proposed changes
- Use `setTimeout` instead of `require("svelte/internal").tick().then`