### PR TITLE
[BUILD-1023] fix: Fix state filter not working on smart search

### DIFF
--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -121,11 +121,10 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
 
         from .reviewer import reviewer_sidebar
 
-        if reviewer_sidebar:
-            _post_message_to_ankihub_js(
-                message={"noteSuspensionStates": note_suspension_states},
-                web=reviewer_sidebar.content_webview,
-            )
+        _post_message_to_ankihub_js(
+            message={"noteSuspensionStates": note_suspension_states},
+            web=reviewer_sidebar.content_webview if reviewer_sidebar else context.web,
+        )
         return (True, None)
     elif message.startswith(COPY_TO_CLIPBOARD_PYCMD):
         kwargs = parse_js_message_kwargs(message)


### PR DESCRIPTION
## Related issues
- [BUILD-1023](https://ankihub.atlassian.net/browse/BUILD-1023)


## Proposed changes
This PR updates the conditional of `GET_NOTE_SUSPENSION_STATES_PYCMD` on the `js_message_handling.py` module allowing sending the suspension state of the notes on the smart search dialog

## How to reproduce
1. Open the smart search dialog
2. Make a search
3. Use the state filter
4. Change the slider to and see if everything is working properly


[BUILD-1023]: https://ankihub.atlassian.net/browse/BUILD-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ