### PR TITLE
fix: Exception in exception handler, handling of 401 in reviewer

### DIFF
--- a/ankihub/feature_flags.py
+++ b/ankihub/feature_flags.py
@@ -20,7 +20,7 @@ def update_feature_flags_in_background() -> None:
         LOGGER.info("Set up feature flags.")
 
         for callback in _feature_flags_update_callbacks:
-            callback()
+            aqt.mw.taskman.run_on_main(callback)
 
     AddonQueryOp(
         parent=aqt.mw,

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -104,11 +104,16 @@ def upload_logs_in_background(
 
     key = f"ankihub_addon_logs_{_username_or_hash(hide_username=hide_username)}_{int(time.time())}.log"
 
-    AddonQueryOp(
-        parent=aqt.mw,
-        op=lambda _: _upload_logs(key),
-        success=on_done if on_done is not None else lambda _: None,
-    ).failure(_on_upload_logs_failure).without_collection().run_in_background()
+    op = (
+        AddonQueryOp(
+            parent=aqt.mw,
+            op=lambda _: _upload_logs(key),
+            success=on_done if on_done is not None else lambda _: None,
+        )
+        .failure(_on_upload_logs_failure)
+        .without_collection()
+    )
+    aqt.mw.taskman.run_on_main(op.run_in_background)
 
     return key
 
@@ -124,11 +129,16 @@ def upload_logs_and_data_in_background(
     # many users use their email address as their username and may not want to share it on a forum
     key = f"ankihub_addon_debug_info_{_username_or_hash(hide_username=True)}_{int(time.time())}.zip"
 
-    AddonQueryOp(
-        parent=aqt.mw,
-        op=lambda _: _upload_logs_and_data_in_background(key),
-        success=on_done if on_done is not None else lambda _: None,
-    ).failure(_on_upload_logs_failure).without_collection().run_in_background()
+    op = (
+        AddonQueryOp(
+            parent=aqt.mw,
+            op=lambda _: _upload_logs_and_data_in_background(key),
+            success=on_done if on_done is not None else lambda _: None,
+        )
+        .failure(_on_upload_logs_failure)
+        .without_collection()
+    )
+    aqt.mw.taskman.run_on_main(op.run_in_background)
 
     return key
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -494,9 +494,13 @@ def _check_premium_and_notify_buttons() -> None:
         )
         aqt.mw.reviewer.web.eval(js)
 
+    def on_failure(exception: Exception) -> None:
+        notify_reviewer_buttons(False)
+        raise exception
+
     AddonQueryOp(
         op=fetch_is_premium_or_trialing, success=notify_reviewer_buttons, parent=aqt.mw
-    ).without_collection().run_in_background()
+    ).without_collection().failure(on_failure).run_in_background()
 
 
 def _related_ah_deck_has_note_embeddings(note: Note) -> bool:

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -475,10 +475,7 @@ def _inject_ankihub_features_and_setup_sidebar(
 def _check_premium_and_notify_buttons_once(*args, **kwargs) -> None:
     card = aqt.mw.reviewer.card
 
-    if not card:
-        return
-
-    if _visible_buttons(card):
+    if card and _visible_buttons(card):
         _check_premium_and_notify_buttons()
         reviewer_did_show_question.remove(_check_premium_and_notify_buttons_once)
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -465,12 +465,22 @@ def _inject_ankihub_features_and_setup_sidebar(
         reviewer.sidebar = reviewer_sidebar  # type: ignore[attr-defined]
         reviewer_sidebar.set_on_auth_failure_hook(_handle_auth_failure)
 
-    def check_premium_and_notify_buttons_once(card: Card) -> None:
-        if _visible_buttons(card):
-            _check_premium_and_notify_buttons()
-            reviewer_did_show_question.remove(check_premium_and_notify_buttons_once)
+    if _check_premium_and_notify_buttons_once not in reviewer_did_show_question._hooks:
+        reviewer_did_show_question.append(_check_premium_and_notify_buttons_once)
 
-    reviewer_did_show_question.append(check_premium_and_notify_buttons_once)
+    if _check_premium_and_notify_buttons_once not in config.token_change_hook:
+        config.token_change_hook.append(_check_premium_and_notify_buttons_once)
+
+
+def _check_premium_and_notify_buttons_once(*args, **kwargs) -> None:
+    card = aqt.mw.reviewer.card
+
+    if not card:
+        return
+
+    if _visible_buttons(card):
+        _check_premium_and_notify_buttons()
+        reviewer_did_show_question.remove(_check_premium_and_notify_buttons_once)
 
 
 def _check_premium_and_notify_buttons() -> None:

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -258,11 +258,15 @@ class _Config:
         self.public_config = aqt.mw.addonManager.getConfig(ADDON_PATH.name)
 
     def save_token(self, token: str):
+        token_changed = self.token() != token
+
         # aqt.mw.pm.set_ankihub_token(token)
         aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = token
-        for func in self.token_change_hook:
-            # Prevent potential exceptions from being backpropagated to the caller.
-            aqt.mw.taskman.run_on_main(func)
+
+        if token_changed:
+            for func in self.token_change_hook:
+                # Prevent potential exceptions from being backpropagated to the caller.
+                aqt.mw.taskman.run_on_main(func)
 
     def save_user_email(self, user_email: str):
         # aqt.mw.pm.set_ankihub_username(user_email)

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -261,7 +261,8 @@ class _Config:
         # aqt.mw.pm.set_ankihub_token(token)
         aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = token
         for func in self.token_change_hook:
-            func()
+            # Prevent potential exceptions from being backpropagated to the caller.
+            aqt.mw.taskman.run_on_main(func)
 
     def save_user_email(self, user_email: str):
         # aqt.mw.pm.set_ankihub_username(user_email)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1745,7 +1745,7 @@ class TestGetNoteType:
             anki_note_type_id=ANKI_ID_OF_NOTE_TYPE_OF_USER_TEST1
         )
         assert note_type["id"] == ANKI_ID_OF_NOTE_TYPE_OF_USER_TEST1
-        assert note_type["name"] == "Cloze"
+        assert note_type["name"] == "Cloze (test1)"
 
     def test_get_not_existing_note_type(
         self, authorized_client_for_user_test1: AnkiHubClient

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -336,14 +336,14 @@ def new_note_suggestion(
         ah_nid=ah_nid,
         anki_nid=1,
         fields=[
-            Field(name="Front", value="front1", order=0),
-            Field(name="Back", value="back1", order=1),
+            Field(name="Text", value="text1", order=0),
+            Field(name="Extra", value="extra1", order=1),
         ],
         tags=["tag1", "tag2"],
         guid="asdf",
         comment="comment1",
         ah_did=ah_nid,
-        note_type_name="Cloze",
+        note_type_name="Cloze (test1)",
         anki_note_type_id=1,
     )
 
@@ -356,8 +356,8 @@ def new_note_suggestion_note_info(
         ah_nid=next_deterministic_uuid(),
         anki_nid=1,
         fields=[
-            Field(name="Front", value="front1", order=0),
-            Field(name="Back", value="back1", order=1),
+            Field(name="Text", value="text1", order=0),
+            Field(name="Extra", value="extra1", order=1),
         ],
         tags=["tag1", "tag2"],
         mid=1,
@@ -374,8 +374,8 @@ def change_note_suggestion(
         ah_nid=next_deterministic_uuid(),
         anki_nid=1,
         fields=[
-            Field(name="Front", value="front2", order=0),
-            Field(name="Back", value="back2", order=1),
+            Field(name="Text", value="text2", order=0),
+            Field(name="Extra", value="extra2", order=1),
         ],
         added_tags=["tag3", "tag4"],
         removed_tags=[],
@@ -610,7 +610,7 @@ class TestCreateSuggestion:
         cns: ChangeNoteSuggestion = change_note_suggestion
         cns.ah_nid = new_note_suggestion.ah_nid
         cns.fields = [
-            Field(name="Front", value="front2", order=0),
+            Field(name="Text", value="text2", order=0),
         ]
 
         # ... this shouldn't raise an exception


### PR DESCRIPTION
Fixes an error users were occasionally getting in the reviewer when not logged in.
https://ankihub.sentry.io/issues/6253435393/events/f027550d1cb344b9ad9a5cb6b6c3aa9c/?project=6546414

Also makes some other improvements to the handling of 401 exceptions in the reviewer.

## Related issues
https://ankihub.sentry.io/issues/6253435393/events/f027550d1cb344b9ad9a5cb6b6c3aa9c/?project=6546414
https://community.ankihub.net/t/got-an-error-message/397521

## Proposed changes
The error was caused by our exception handler raising an exception while handling an 401 `AnkiHubHTTPError`.
The exception handler raised an exception because it was calling `config.save_token()`, which in turn called the callbacks in `config.token_change_hook`. 
One of the callbacks  (`update_feature_flags_in_background`) called `aqt.mw.taskman.run_in_background`.
 `aqt.mw.taskman.run_in_background` runs any pending closures from tasks that just finished.
One of the pending closures re-raised an exception which was raised in the associated background task.

Summarizing, the issue is that calling `aqt.mw.taskman.run_in_background()` can raise an exception if there were was an exception in a (possibly unrelated) background task that was just run. (When this happens, the new background task is not run.) 

This is something that should probably be fixed in Anki.

For now, the fix that this PR applies is to use `aqt.mw.taskman.run_on_main()` to call functions which call `aqt.mw.taskman.run_in_background()` in some relevant places. Using `aqt.mw.taskman.run_on_main(closure)` prevents exceptions raised by the closure from getting backpropagated to the caller.
So, the code which calls `aqt.mw.taskman.run_in_background`, won't be interrupted the exception. (The background task which it tried to start won't be run though.)

We used this technique before in this decorator:
https://github.com/AnkiHubSoftware/ankihub_addon/blob/bd9f882c3af8922e03cdc057132e2a083f515132/ankihub/gui/operations/utils.py#L21

- [Run token_change_hook callbacks using run_on_main](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/5fe50965f44cfeabdc6cf134dcfcb7f6d6ccf7d2)
  - With this change, the exception handler won't get exceptions from `token_change_hook` callbacks when calling `config.save_token()`
- [Run other background tasks in errors.py using run_on_main](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/a1b5e0c86221ffb4c943fc243e19cc6603ca33ca)
- [Run feature flag update callbacks using run_on_main](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/d9d2b1d80e9942978be0a4c7c389550839030766)

Other fixes/improvements:
- [Only call token_change_hook callbacks if token actually changes](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/1d2ca757b08356f0040924bdaae782361041ac19)
- [Only add _check_premium_and_notify_buttons_once callback if not present](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/8c46127f885b10b162b6ffe040b33d2ddbae4c0e)
  - Makes sure that the callback gets added only once. Not sure if multiple callbacks were added previously
- [Update reviewer buttons when user signs out](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1098/commits/7b45d0d4545a45a417dcfad8e09caeb11eb94386)
  - When you sign out in the reviewer, the chatbot icon will change to the sleeping robot now
- Fix client tests
  - Unrelated to the rest of the PR
  - Updates the tests to adapt to the web app changes made in https://github.com/AnkiHubSoftware/ankihub/pull/2577


## Notes
Logs which were helpful while debugging the error:
https://app.datadoghq.com/logs?query=host%3Ashannons-air.dhcp.swmed.org%20service%3Aankihub_addon&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZUBBKq2AABE-P7_kAS1CQAK&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Casc&viz=&from_ts=1739478517555&to_ts=1739480376381&live=false