### PR TITLE
[BUILD: 1062] fix: Mashumaro not handling module names with numbers

### DIFF
--- a/ankihub/lib/mashumaro/core/meta/helpers.py
+++ b/ankihub/lib/mashumaro/core/meta/helpers.py
@@ -281,7 +281,14 @@ def type_name(
         if short:
             return typ.__qualname__  # type: ignore
         else:
-            return f"{typ.__module__}.{typ.__qualname__}"  # type: ignore
+            # patched for ankihub_addon to support module names starting with a number
+            # as Anki installs an add-on downloaded from AnkiWeb in a directory named by a number - its AnkiWeb id
+            module_name = typ.__module__
+            qualname = typ.__qualname__
+
+            if module_name[0].isdigit():
+                return f'(__import__("sys")).modules["{module_name}"].{qualname}'
+            return f"{module_name}.{qualname}"
     except AttributeError:
         return str(typ)
 


### PR DESCRIPTION
This task fixes the add-on not working due to an update of the mashumaro library.

The PR re-applies a patch to the mashumaro library which was previously added in #351 and got removed when updating to mashumaro version 3.15 in #1097.

From the description of #351:
> This error was caused because the mashumaro (https://github.com/Fatal1ty/mashumaro) serialization library couldn't handle the module name of the add-on starting with a number. (Anki installs add-ons downloaded from AnkiWeb into directories named by their AnkiWeb id which consists of numbers).

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1062

## Proposed changes
- Apply a patch to mashumaro to make it handle module names starting with numbers


## How to reproduce
You can reproduce the `SyntaxError` by checking out the main branch and renaming the symlink at `anki_base/addons21/ankihub` to `1234` or a some different number and starting Anki.
(Note that the "Setup add-on symlink" vscode prelaunch task will create the `anki_base/addons21/ankihub` symlink if it doesn't exist, so you will have two symlinks to the add-on code. You can temporarily disable one of them from Anki's add-on dialog.)
With the changes in this PR there is no such error.