### PR TITLE
[BUILD-1048] Check features access instead of plan or trial

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1293,9 +1293,9 @@ class AnkiHubClient:
         if response.status_code != 201:
             raise AnkiHubHTTPError(response)
 
-    def is_premium_or_trialing(self) -> bool:
+    def has_reviewer_extension_access(self) -> bool:
         data = self.get_user_details()
-        return data["is_premium"] or data["is_trialing"]
+        return data.get("has_reviewer_extension_access", False)
 
 
 class ThreadLocalSession:

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -91,7 +91,7 @@ def _show_flashcard_selector_upsell_if_user_has_no_access(
     on_done: Callable[[bool], None]
 ) -> None:
     user_details = AnkiHubClient().get_user_details()
-    has_access = user_details["is_premium"] or user_details["is_trialing"]
+    has_access = user_details["has_flashcard_selector_access"]
     if has_access:
         on_done(True)
         return

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -465,32 +465,32 @@ def _inject_ankihub_features_and_setup_sidebar(
         reviewer.sidebar = reviewer_sidebar  # type: ignore[attr-defined]
         reviewer_sidebar.set_on_auth_failure_hook(_handle_auth_failure)
 
-    if _check_premium_and_notify_buttons_once not in reviewer_did_show_question._hooks:
-        reviewer_did_show_question.append(_check_premium_and_notify_buttons_once)
+    if _check_access_and_notify_buttons_once not in reviewer_did_show_question._hooks:
+        reviewer_did_show_question.append(_check_access_and_notify_buttons_once)
 
-    if _check_premium_and_notify_buttons_once not in config.token_change_hook:
-        config.token_change_hook.append(_check_premium_and_notify_buttons_once)
+    if _check_access_and_notify_buttons_once not in config.token_change_hook:
+        config.token_change_hook.append(_check_access_and_notify_buttons_once)
 
 
-def _check_premium_and_notify_buttons_once(*args, **kwargs) -> None:
+def _check_access_and_notify_buttons_once(*args, **kwargs) -> None:
     card = aqt.mw.reviewer.card
 
     if card and _visible_buttons(card):
-        _check_premium_and_notify_buttons()
-        reviewer_did_show_question.remove(_check_premium_and_notify_buttons_once)
+        _check_access_and_notify_buttons()
+        reviewer_did_show_question.remove(_check_access_and_notify_buttons_once)
 
 
-def _check_premium_and_notify_buttons() -> None:
-    """Fetches the user's premium or trialing status in the background and notifies the reviewer buttons
+def _check_access_and_notify_buttons() -> None:
+    """Fetches the user's access to the reviwer extension feature in the background and notifies the reviewer buttons
     once the status is fetched."""
 
-    def fetch_is_premium_or_trialing(_) -> bool:
+    def fetch_has_reviewer_extension_access(_) -> bool:
         client = AnkiHubClient()
-        return client.is_premium_or_trialing()
+        return client.has_reviewer_extension_access()
 
-    def notify_reviewer_buttons(is_premium_or_trialing: bool) -> None:
+    def notify_reviewer_buttons(has_reviewer_extension_access: bool) -> None:
         js = _wrap_with_reviewer_buttons_check(
-            f"ankihubReviewerButtons.updateIsPremiumOrTrialing({'true' if is_premium_or_trialing else 'false'})"
+            f"ankihubReviewerButtons.updateHasReviewerExtensionAccess({'true' if has_reviewer_extension_access else 'false'})"
         )
         aqt.mw.reviewer.web.eval(js)
 
@@ -499,7 +499,7 @@ def _check_premium_and_notify_buttons() -> None:
         raise exception
 
     AddonQueryOp(
-        op=fetch_is_premium_or_trialing, success=notify_reviewer_buttons, parent=aqt.mw
+        op=fetch_has_reviewer_extension_access, success=notify_reviewer_buttons, parent=aqt.mw
     ).without_collection().failure(on_failure).run_in_background()
 
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -499,7 +499,9 @@ def _check_access_and_notify_buttons() -> None:
         raise exception
 
     AddonQueryOp(
-        op=fetch_has_reviewer_extension_access, success=notify_reviewer_buttons, parent=aqt.mw
+        op=fetch_has_reviewer_extension_access,
+        success=notify_reviewer_buttons,
+        parent=aqt.mw,
     ).without_collection().failure(on_failure).run_in_background()
 
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -490,7 +490,7 @@ def _check_access_and_notify_buttons() -> None:
 
     def notify_reviewer_buttons(has_reviewer_extension_access: bool) -> None:
         js = _wrap_with_reviewer_buttons_check(
-            f"ankihubReviewerButtons.updateHasReviewerExtensionAccess({'true' if has_reviewer_extension_access else 'false'})"
+            f"ankihubReviewerButtons.updateHasReviewerExtensionAccess({'true' if has_reviewer_extension_access else 'false'})"  # noqa: E501
         )
         aqt.mw.reviewer.web.eval(js)
 

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -3,7 +3,7 @@
 class AnkiHubReviewerButtons {
     constructor() {
         this.theme = "{{ THEME }}";
-        this.isPremiumOrTrialing = false;
+        this.hasReviewerExtensionAccess = false;
         this.bbCount = 0;
         this.faCount = 0;
 
@@ -142,12 +142,12 @@ class AnkiHubReviewerButtons {
         const isDark = this.theme === "dark";
 
         if (isDark && button.iconPathDarkTheme) {
-            return this.isPremiumOrTrialing && button.premiumIconPathDarkTheme
+            return this.hasReviewerExtensionAccess && button.premiumIconPathDarkTheme
                 ? button.premiumIconPathDarkTheme
                 : button.iconPathDarkTheme;
         }
 
-        return this.isPremiumOrTrialing && button.premiumIconPath
+        return this.hasReviewerExtensionAccess && button.premiumIconPath
             ? button.premiumIconPath
             : button.iconPath;
     }
@@ -339,8 +339,8 @@ class AnkiHubReviewerButtons {
         }
     }
 
-    updateIsPremiumOrTrialing(isPremiumOrTrialing) {
-        this.isPremiumOrTrialing = isPremiumOrTrialing;
+    updateHasReviewerExtensionAccess(hasReviewerExtensionAccess) {
+        this.hasReviewerExtensionAccess = hasReviewerExtensionAccess;
 
         this.updateButtons(
             this.bbCount, this.faCount, this.getVisibleButtons().map(buttonData => buttonData.name)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6142,7 +6142,10 @@ def mock_using_qt5_to_return_false(mocker: MockerFixture):
 
 @pytest.fixture
 def mock_user_details(mocker: MockerFixture):
-    user_details = {"has_flashcard_selector_access": True, "has_reviewer_extension_access": True}
+    user_details = {
+        "has_flashcard_selector_access": True,
+        "has_reviewer_extension_access": True,
+    }
     mocker.patch.object(AnkiHubClient, "get_user_details", return_value=user_details)
 
 
@@ -6615,7 +6618,13 @@ def test_terms_agreement_not_accepted_with_reviewer_sidebar_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6646,7 +6655,13 @@ def test_terms_agreement_not_accepted_with_flashcard_selector_dialog_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6677,7 +6692,13 @@ def test_terms_agreement_accepted(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5724,8 +5724,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": True,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": True,
                     "show_trial_ended_message": False,
                 },
             )
@@ -5771,8 +5770,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": True,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": True,
                     "show_trial_ended_message": False,
                 },
             )
@@ -5839,8 +5837,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": False,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": False,
                     "show_trial_ended_message": show_trial_ended_message,
                 },
             )
@@ -6145,7 +6142,7 @@ def mock_using_qt5_to_return_false(mocker: MockerFixture):
 
 @pytest.fixture
 def mock_user_details(mocker: MockerFixture):
-    user_details = {"is_premium": True, "is_trialing": False}
+    user_details = {"has_flashcard_selector_access": True, "has_reviewer_extension_access": True}
     mocker.patch.object(AnkiHubClient, "get_user_details", return_value=user_details)
 
 
@@ -6618,7 +6615,7 @@ def test_terms_agreement_not_accepted_with_reviewer_sidebar_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6649,7 +6646,7 @@ def test_terms_agreement_not_accepted_with_flashcard_selector_dialog_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6680,7 +6677,7 @@ def test_terms_agreement_accepted(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get("https://app.ankihub.net/api/users/me", json={"has_flashcard_selector_access": True, "has_reviewer_extension_access": True})
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)


### PR DESCRIPTION
## Related issues
[BUILD-1048](https://ankihub.atlassian.net/browse/BUILD-1048)
[Webapp - PR](https://github.com/AnkiHubSoftware/ankihub/pull/2585)

## Proposed changes
Modify the `api/users/me` endpoint to check user's access to the _reviewer extension_ and _flashcard selector_ features. 
Remove `is_premium` and `is_trialing` fields as they don't define feature's access.
Add `has_reviewer_extension_access` and `has_flashcard_selector_access` fields to the user details
Refactor all code that involve `is_premium` and `is_trialing` 


## How to reproduce

1. Select any user with no access to the features (not trialing, premium or lifetime) - related webapp [branch](https://github.com/AnkiHubSoftware/ankihub/pull/2585)
2. Open the addon
3. Select any deck and click on the flashcard selector icon on the bottom left
4. A upsell dialog must appear
5. Open any card and check the chatbot
6. An upsell message must be loaded
7. Create a beta tester group on django's admin (add the permission _users/beta_testers_ to this group)
8. Add the select user to the beta testers group
9. Test chatbot and flashcard selector again, it must work as expected
10. Check access for premium and trial users as well.


## Screenshots and videos


### No access
https://github.com/user-attachments/assets/873d259e-6728-41ee-833b-060310843d08

### Beta tester
https://github.com/user-attachments/assets/497aa7a4-e098-40fb-a821-61647bffba0d



[BUILD-1048]: https://ankihub.atlassian.net/browse/BUILD-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ