### PR TITLE
fix: UI fixes for note type creation

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -648,7 +648,7 @@ class DeckManagementDialog(QDialog):
             confirm = ask_user(
                 "<b>Proceed?</b><br><br>"
                 "Confirm to publish this note type to all AnkiHub users of your deck.<br><br>",
-                title="Publish note type to all users",
+                title="Publish note type",
                 no_button_label="Cancel",
             )
             if not confirm:
@@ -704,7 +704,7 @@ class DeckManagementDialog(QDialog):
                     "<b>Proceed?</b><br><br>"
                     "Confirm to publish the fields to all AnkiHub users of your deck.<br><br>"
                     + NOTE_TYPE_CHANGES_WARNING,
-                    title="Publish fields to all users",
+                    title="Publish fields",
                     no_button_label="Cancel",
                 )
                 if not confirm:
@@ -737,7 +737,7 @@ class DeckManagementDialog(QDialog):
                 "Confirm to update note styling and templates for all AnkiHub users of your deck.<br><br>"
                 + "⚠️ Please note that <b>certain changes may break the note type</b> so proceed with caution.<br><br>"
                 + NOTE_TYPE_CHANGES_WARNING,
-                title="Publish style/template updates to all users",
+                title="Publish style/template updates",
                 no_button_label="Cancel",
             )
             if not confirm:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -351,8 +351,6 @@ class _Dialog(QDialog):
 
     def _setup_button_box(self) -> QDialogButtonBox:
         button_box = QDialogButtonBox()
-        # Use Windows layout
-        button_box.setStyleSheet("button-layout: 0")
 
         self.default_button = None
         for button_index, button in enumerate(self.buttons):


### PR DESCRIPTION
## Proposed changes

Fix more issues reported during QA of [BUILD-1013](https://ankihub.atlassian.net/browse/BUILD-1013):

- Update titles of confirmation dialogs.
- Revert to using default QDialogButtonBox button layout
-  Report note type creation errors (e.g. "A note type with this name already exists.")



[BUILD-1013]: https://ankihub.atlassian.net/browse/BUILD-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ