### PR TITLE
fix: Fix fields dialog not accepting input on macOS

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -74,7 +74,7 @@ STAGING_APP_URL = "https://staging.ankihub.net"
 STAGING_API_URL = f"{STAGING_APP_URL}/api"
 STAGING_S3_BUCKET_URL = "https://ankihub-staging.s3.amazonaws.com"
 
-API_VERSION = 21.0
+API_VERSION = 22.0
 
 DECK_UPDATE_PAGE_SIZE = 2000  # seems to work well in terms of speed
 DECK_EXTENSION_UPDATE_PAGE_SIZE = 2000
@@ -1345,9 +1345,9 @@ class AnkiHubClient:
         if response.status_code != 201:
             raise AnkiHubHTTPError(response)
 
-    def is_premium_or_trialing(self) -> bool:
+    def has_reviewer_extension_access(self) -> bool:
         data = self.get_user_details()
-        return data["is_premium"] or data["is_trialing"]
+        return data.get("has_reviewer_extension_access", False)
 
 
 class ThreadLocalSession:

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -693,7 +693,7 @@ class DeckManagementDialog(QDialog):
                     ("Cancel", QDialogButtonBox.ButtonRole.RejectRole),
                 ],
                 title="Select fields to publish",
-                parent=self,
+                parent=ret,
             )
             if new_fields:
                 confirm = ask_user(

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -640,8 +640,10 @@ class DeckManagementDialog(QDialog):
         ]
 
     def _on_add_note_type_btn_clicked(self):
-        def on_note_type_selected(ret: SearchableSelectionDialog) -> None:
-            if not ret.name:
+        def on_note_type_selected(
+            note_type_selector: SearchableSelectionDialog,
+        ) -> None:
+            if not note_type_selector.name:
                 return
             confirm = ask_user(
                 "<b>Proceed?</b><br><br>"
@@ -652,7 +654,7 @@ class DeckManagementDialog(QDialog):
             if not confirm:
                 return
 
-            note_type = aqt.mw.col.models.by_name(ret.name)
+            note_type = aqt.mw.col.models.by_name(note_type_selector.name)
             add_note_type(self._selected_ah_did(), note_type)
 
             tooltip("Note type published", parent=aqt.mw)
@@ -669,11 +671,13 @@ class DeckManagementDialog(QDialog):
         )
 
     def _on_add_field_btn_clicked(self) -> None:
-        def on_note_type_selected(ret: SearchableSelectionDialog) -> None:
-            if not ret.name:
+        def on_note_type_selected(
+            note_type_selector: SearchableSelectionDialog,
+        ) -> None:
+            if not note_type_selector.name:
                 return
 
-            note_type = aqt.mw.col.models.by_name(ret.name)
+            note_type = aqt.mw.col.models.by_name(note_type_selector.name)
             field_names = aqt.mw.col.models.field_names(note_type)
             ankihub_field_names = ankihub_db.note_type_field_names(
                 self._selected_ah_did(), note_type["id"]
@@ -693,7 +697,7 @@ class DeckManagementDialog(QDialog):
                     ("Cancel", QDialogButtonBox.ButtonRole.RejectRole),
                 ],
                 title="Select fields to publish",
-                parent=ret,
+                parent=note_type_selector,
             )
             if new_fields:
                 confirm = ask_user(
@@ -721,11 +725,13 @@ class DeckManagementDialog(QDialog):
         )
 
     def _on_update_templates_btn_clicked(self) -> None:
-        def on_note_type_selected(ret: SearchableSelectionDialog) -> None:
-            if not ret.name:
+        def on_note_type_selected(
+            note_type_selector: SearchableSelectionDialog,
+        ) -> None:
+            if not note_type_selector.name:
                 return
 
-            note_type = aqt.mw.col.models.by_name(ret.name)
+            note_type = aqt.mw.col.models.by_name(note_type_selector.name)
             confirm = ask_user(
                 "<b>Proceed?</b><br><br>"
                 "Confirm to update note styling and templates for all AnkiHub users of your deck.<br><br>"
@@ -835,11 +841,11 @@ class DeckManagementDialog(QDialog):
         else:
             current = current_destination_deck["name"]
 
-        def update_deck_config(ret: SearchableSelectionDialog):
-            if not ret.name:
+        def update_deck_config(note_type_selector: SearchableSelectionDialog):
+            if not note_type_selector.name:
                 return
 
-            anki_did = aqt.mw.col.decks.id(ret.name)
+            anki_did = aqt.mw.col.decks.id(note_type_selector.name)
             config.set_home_deck(ankihub_did=ah_did, anki_did=anki_did)
             self._refresh_new_cards_destination_details_label(ah_did)
 

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -91,7 +91,7 @@ def _show_flashcard_selector_upsell_if_user_has_no_access(
     on_done: Callable[[bool], None]
 ) -> None:
     user_details = AnkiHubClient().get_user_details()
-    has_access = user_details["is_premium"] or user_details["is_trialing"]
+    has_access = user_details["has_flashcard_selector_access"]
     if has_access:
         on_done(True)
         return

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -465,32 +465,32 @@ def _inject_ankihub_features_and_setup_sidebar(
         reviewer.sidebar = reviewer_sidebar  # type: ignore[attr-defined]
         reviewer_sidebar.set_on_auth_failure_hook(_handle_auth_failure)
 
-    if _check_premium_and_notify_buttons_once not in reviewer_did_show_question._hooks:
-        reviewer_did_show_question.append(_check_premium_and_notify_buttons_once)
+    if _check_access_and_notify_buttons_once not in reviewer_did_show_question._hooks:
+        reviewer_did_show_question.append(_check_access_and_notify_buttons_once)
 
-    if _check_premium_and_notify_buttons_once not in config.token_change_hook:
-        config.token_change_hook.append(_check_premium_and_notify_buttons_once)
+    if _check_access_and_notify_buttons_once not in config.token_change_hook:
+        config.token_change_hook.append(_check_access_and_notify_buttons_once)
 
 
-def _check_premium_and_notify_buttons_once(*args, **kwargs) -> None:
+def _check_access_and_notify_buttons_once(*args, **kwargs) -> None:
     card = aqt.mw.reviewer.card
 
     if card and _visible_buttons(card):
-        _check_premium_and_notify_buttons()
-        reviewer_did_show_question.remove(_check_premium_and_notify_buttons_once)
+        _check_access_and_notify_buttons()
+        reviewer_did_show_question.remove(_check_access_and_notify_buttons_once)
 
 
-def _check_premium_and_notify_buttons() -> None:
-    """Fetches the user's premium or trialing status in the background and notifies the reviewer buttons
+def _check_access_and_notify_buttons() -> None:
+    """Fetches the user's access to the reviwer extension feature in the background and notifies the reviewer buttons
     once the status is fetched."""
 
-    def fetch_is_premium_or_trialing(_) -> bool:
+    def fetch_has_reviewer_extension_access(_) -> bool:
         client = AnkiHubClient()
-        return client.is_premium_or_trialing()
+        return client.has_reviewer_extension_access()
 
-    def notify_reviewer_buttons(is_premium_or_trialing: bool) -> None:
+    def notify_reviewer_buttons(has_reviewer_extension_access: bool) -> None:
         js = _wrap_with_reviewer_buttons_check(
-            f"ankihubReviewerButtons.updateIsPremiumOrTrialing({'true' if is_premium_or_trialing else 'false'})"
+            f"ankihubReviewerButtons.updateHasReviewerExtensionAccess({'true' if has_reviewer_extension_access else 'false'})"  # noqa: E501
         )
         aqt.mw.reviewer.web.eval(js)
 
@@ -499,7 +499,9 @@ def _check_premium_and_notify_buttons() -> None:
         raise exception
 
     AddonQueryOp(
-        op=fetch_is_premium_or_trialing, success=notify_reviewer_buttons, parent=aqt.mw
+        op=fetch_has_reviewer_extension_access,
+        success=notify_reviewer_buttons,
+        parent=aqt.mw,
     ).without_collection().failure(on_failure).run_in_background()
 
 

--- a/ankihub/gui/web/reviewer_buttons.js
+++ b/ankihub/gui/web/reviewer_buttons.js
@@ -3,7 +3,7 @@
 class AnkiHubReviewerButtons {
     constructor() {
         this.theme = "{{ THEME }}";
-        this.isPremiumOrTrialing = false;
+        this.hasReviewerExtensionAccess = false;
         this.bbCount = 0;
         this.faCount = 0;
 
@@ -142,12 +142,12 @@ class AnkiHubReviewerButtons {
         const isDark = this.theme === "dark";
 
         if (isDark && button.iconPathDarkTheme) {
-            return this.isPremiumOrTrialing && button.premiumIconPathDarkTheme
+            return this.hasReviewerExtensionAccess && button.premiumIconPathDarkTheme
                 ? button.premiumIconPathDarkTheme
                 : button.iconPathDarkTheme;
         }
 
-        return this.isPremiumOrTrialing && button.premiumIconPath
+        return this.hasReviewerExtensionAccess && button.premiumIconPath
             ? button.premiumIconPath
             : button.iconPath;
     }
@@ -339,8 +339,8 @@ class AnkiHubReviewerButtons {
         }
     }
 
-    updateIsPremiumOrTrialing(isPremiumOrTrialing) {
-        this.isPremiumOrTrialing = isPremiumOrTrialing;
+    updateHasReviewerExtensionAccess(hasReviewerExtensionAccess) {
+        this.hasReviewerExtensionAccess = hasReviewerExtensionAccess;
 
         this.updateButtons(
             this.bbCount, this.faCount, this.getVisibleButtons().map(buttonData => buttonData.name)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5768,8 +5768,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": True,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": True,
                     "show_trial_ended_message": False,
                 },
             )
@@ -5815,8 +5814,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": True,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": True,
                     "show_trial_ended_message": False,
                 },
             )
@@ -5883,8 +5881,7 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "is_premium": False,
-                    "is_trialing": False,
+                    "has_flashcard_selector_access": False,
                     "show_trial_ended_message": show_trial_ended_message,
                 },
             )
@@ -6189,7 +6186,10 @@ def mock_using_qt5_to_return_false(mocker: MockerFixture):
 
 @pytest.fixture
 def mock_user_details(mocker: MockerFixture):
-    user_details = {"is_premium": True, "is_trialing": False}
+    user_details = {
+        "has_flashcard_selector_access": True,
+        "has_reviewer_extension_access": True,
+    }
     mocker.patch.object(AnkiHubClient, "get_user_details", return_value=user_details)
 
 
@@ -6662,7 +6662,13 @@ def test_terms_agreement_not_accepted_with_reviewer_sidebar_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6693,7 +6699,13 @@ def test_terms_agreement_not_accepted_with_flashcard_selector_dialog_instance(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_NOT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)
@@ -6724,7 +6736,13 @@ def test_terms_agreement_accepted(
 ):
     entry_point.run()
     message = TERMS_AGREEMENT_ACCEPTED
-    requests_mock.get("https://app.ankihub.net/api/users/me", json={"is_premium": True})
+    requests_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": True,
+            "has_reviewer_extension_access": True,
+        },
+    )
     with anki_session_with_addon_data.profile_loaded():
         anki_did: DeckId = DeckId(1)
         ah_did = install_ah_deck(anki_did=anki_did)


### PR DESCRIPTION
## Related issues

Reported during QA in https://ankihub.atlassian.net/browse/BUILD-1004

## Proposed changes

This fixes the fields selector dialog shown for the "Publish field" function not accepting input due to the wrong widget set as parent. This only happens on macOS.


## How to reproduce

Use the Publish Field button in Deck Management and select a note type with a new field.

