### PR TITLE
fix: Disable note type buttons if not applicable

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -35,6 +35,7 @@ from ..main.deck_unsubscribtion import unsubscribe_from_deck_and_uninstall
 from ..main.note_type_management import (
     add_note_type,
     add_note_type_fields,
+    new_fields_for_note_type,
     note_types_with_template_changes_for_deck,
     update_deck_templates,
 )
@@ -589,13 +590,15 @@ class DeckManagementDialog(QDialog):
         self.note_types_label = QLabel("<b>📝 Note Types</b>")
         self.add_note_type_btn = QPushButton("Publish note type")
         qconnect(self.add_note_type_btn.clicked, self._on_add_note_type_btn_clicked)
+        self._update_add_note_type_btn_state()
         self.add_field_btn = QPushButton("Publish field")
         qconnect(self.add_field_btn.clicked, self._on_add_field_btn_clicked)
+        self._update_add_field_btn_state()
         self.update_templates_btn = QPushButton("Publish style/template updates")
-        self._update_templates_btn_state()
         qconnect(
             self.update_templates_btn.clicked, self._on_update_templates_btn_clicked
         )
+        self._update_templates_btn_state()
         box.addWidget(self.note_types_label)
         box.addWidget(self.add_note_type_btn)
         box.addWidget(self.add_field_btn)
@@ -603,10 +606,53 @@ class DeckManagementDialog(QDialog):
 
         return box
 
-    def _update_templates_btn_state(self):
-        self.update_templates_btn.setEnabled(
-            bool(note_types_with_template_changes_for_deck(self._selected_ah_did()))
+    def _update_note_type_btn_state(self, button: QPushButton, enabled: bool):
+        button.setEnabled(enabled)
+        if enabled:
+            button.setToolTip("")
+        else:
+            button.setToolTip("Nothing to update to AnkiHub")
+
+    def _get_note_type_names_for_add_note_type_btn(self) -> List[str]:
+        return self._get_note_type_names_for_deck(
+            self._selected_ah_did(), assigned_to_deck=False
         )
+
+    def _update_add_note_type_btn_state(self):
+        enabled = bool(self._get_note_type_names_for_add_note_type_btn())
+        self._update_note_type_btn_state(self.add_note_type_btn, enabled)
+
+    def _get_note_type_names_for_add_field_type_btn(self) -> List[str]:
+        names_and_ids = self._get_note_type_names_and_ids_for_deck(
+            self._selected_ah_did(), assigned_to_deck=True
+        )
+        filtered_names = []
+        for name_and_id in names_and_ids:
+            note_type = aqt.mw.col.models.get(NotetypeId(name_and_id.id))
+            if new_fields_for_note_type(self._selected_ah_did(), note_type):
+                filtered_names.append(name_and_id.name)
+
+        return filtered_names
+
+    def _update_add_field_btn_state(self):
+        enabled = bool(self._get_note_type_names_for_add_field_type_btn())
+        self._update_note_type_btn_state(self.add_field_btn, enabled)
+
+    def _get_note_type_names_for_update_templates_btn(self) -> List[str]:
+        mids_with_updates = note_types_with_template_changes_for_deck(
+            self._selected_ah_did()
+        )
+        return [
+            n.name
+            for n in self._get_note_type_names_and_ids_for_deck(
+                self._selected_ah_did(), assigned_to_deck=True
+            )
+            if n.id in mids_with_updates
+        ]
+
+    def _update_templates_btn_state(self):
+        enabled = bool(self._get_note_type_names_for_update_templates_btn())
+        self._update_note_type_btn_state(self.update_templates_btn, enabled)
 
     def _get_note_type_names_and_ids_for_deck(
         self, deck_id: UUID, assigned_to_deck: bool
@@ -656,12 +702,11 @@ class DeckManagementDialog(QDialog):
             add_note_type(self._selected_ah_did(), note_type)
 
             tooltip("Note type published", parent=aqt.mw)
+            self._update_add_note_type_btn_state()
 
         SearchableSelectionDialog(
             aqt.mw,
-            names=lambda: self._get_note_type_names_for_deck(
-                self._selected_ah_did(), assigned_to_deck=False
-            ),
+            names=self._get_note_type_names_for_add_note_type_btn,
             accept="Choose",
             title="Choose note type to publish",
             parent=self,
@@ -672,18 +717,8 @@ class DeckManagementDialog(QDialog):
         def on_note_type_selected(ret: SearchableSelectionDialog) -> None:
             if not ret.name:
                 return
-
             note_type = aqt.mw.col.models.by_name(ret.name)
-            field_names = aqt.mw.col.models.field_names(note_type)
-            ankihub_field_names = ankihub_db.note_type_field_names(
-                self._selected_ah_did(), note_type["id"]
-            )
-            new_fields = [
-                name for name in field_names if name not in ankihub_field_names
-            ]
-            if not new_fields:
-                tooltip("No new fields to publish", parent=aqt.mw)
-                return
+            new_fields = new_fields_for_note_type(self._selected_ah_did(), note_type)
             new_fields = choose_subset(
                 "",
                 choices=new_fields,
@@ -708,12 +743,11 @@ class DeckManagementDialog(QDialog):
 
                 add_note_type_fields(self._selected_ah_did(), note_type, new_fields)
                 tooltip("Fields published", parent=aqt.mw)
+                self._update_add_field_btn_state()
 
         SearchableSelectionDialog(
             aqt.mw,
-            names=lambda: self._get_note_type_names_for_deck(
-                self._selected_ah_did(), assigned_to_deck=True
-            ),
+            names=self._get_note_type_names_for_add_field_type_btn,
             accept="Choose",
             title="Choose note type to edit",
             parent=self,
@@ -741,18 +775,9 @@ class DeckManagementDialog(QDialog):
             tooltip("Templates updated", parent=aqt.mw)
             self._update_templates_btn_state()
 
-        mids_with_updates = note_types_with_template_changes_for_deck(
-            self._selected_ah_did()
-        )
         SearchableSelectionDialog(
             aqt.mw,
-            names=lambda: [
-                n.name
-                for n in self._get_note_type_names_and_ids_for_deck(
-                    self._selected_ah_did(), assigned_to_deck=True
-                )
-                if n.id in mids_with_updates
-            ],
+            names=self._get_note_type_names_for_update_templates_btn,
             accept="Choose",
             title="Choose note type to update",
             parent=self,

--- a/ankihub/main/note_type_management.py
+++ b/ankihub/main/note_type_management.py
@@ -106,5 +106,12 @@ def note_types_with_template_changes_for_deck(ah_did: uuid.UUID) -> List[Notetyp
     return ids
 
 
+def new_fields_for_note_type(ah_did: uuid.UUID, note_type: NotetypeDict) -> List[str]:
+    field_names = aqt.mw.col.models.field_names(note_type)
+    ankihub_field_names = ankihub_db.note_type_field_names(ah_did, note_type["id"])
+    new_fields = [name for name in field_names if name not in ankihub_field_names]
+    return new_fields
+
+
 def update_deck_templates(ah_did: uuid.UUID, note_type: NotetypeDict) -> None:
     print("update_deck_templates", ah_did)


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/BUILD-1013

## Proposed changes

This updates the UI to disable the buttons if they are not applicable, according to the Figma updates.

## How to reproduce

1. Go to the Deck Management screen.
2. Select a deck you own and notice the state of the buttons.
3. The "Publish note type" button should be disabled if you have no note types to upload to AnkiHub. This is unlikely because most of the time you'll have Anki's standard types there. But you can confirm this is working by deleting all non-AnkiHub types from _Tools > Mange Note Types_.
4. The "Publish field" button should be disabled if there are no new fields in any types associated with the deck. This button will probably show as disabled most of the time. You can confirm it's working by adding a new field to any relevant AnkiHub note type from _Tools > Manage Note Types_.
5. The "Publish style/template updates" button should be disabled if you made no changes to templates/styling sections of the note types. You can confirm it's working by making changes to the templates from _Tools > Manage Note Types > Cards_ (make sure your changes are above the ANKIHUB_END comment).

## Screenshots and videos

![image](https://github.com/user-attachments/assets/8668a01f-6656-4c3c-8322-786fb5ce9c66)

