### PR TITLE
fix: Fix some issues with field selector UI

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -724,14 +724,13 @@ class DeckManagementDialog(QDialog):
             note_type = aqt.mw.col.models.by_name(note_type_selector.name)
             new_fields = new_fields_for_note_type(self._selected_ah_did(), note_type)
             new_fields = choose_subset(
-                "",
+                prompt="Select fields to publish",
                 choices=new_fields,
                 current=[],
                 buttons=[
                     ("Proceed", QDialogButtonBox.ButtonRole.AcceptRole),
                     ("Cancel", QDialogButtonBox.ButtonRole.RejectRole),
                 ],
-                title="Select fields to publish",
                 parent=note_type_selector,
                 require_at_least_one=True,
             )

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -733,6 +733,7 @@ class DeckManagementDialog(QDialog):
                 ],
                 title="Select fields to publish",
                 parent=note_type_selector,
+                require_at_least_one=True,
             )
             if new_fields:
                 confirm = ask_user(

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -98,6 +98,7 @@ def choose_subset(
     buttons: Optional[Sequence[ButtonParam]] = None,
     title: str = "AnkiHub",
     parent: Any = None,
+    require_at_least_one: bool = False,
 ) -> Optional[List[str]]:
     if not parent:
         parent = active_window_or_mw()
@@ -161,6 +162,30 @@ def choose_subset(
         list_widget.setMinimumHeight(
             list_widget.sizeHintForRow(0) * list_widget.count() + 20
         )
+
+    def update_accept_button_state():
+        accept_button = next(
+            (
+                button
+                for button in button_box.buttons()
+                if button_box.buttonRole(button)
+                == QDialogButtonBox.ButtonRole.AcceptRole
+            ),
+            None,
+        )
+        if not accept_button:
+            return
+        for i in range(list_widget.count()):
+            item = list_widget.item(i)
+            if item.checkState() == Qt.CheckState.Checked:
+                accept_button.setEnabled(True)
+                return
+
+        accept_button.setEnabled(False)
+
+    if require_at_least_one:
+        qconnect(list_widget.itemChanged, lambda _: update_accept_button_state())
+        update_accept_button_state()
 
     if dialog.exec() != QDialog.DialogCode.Accepted:
         return None

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -154,6 +154,7 @@ def choose_subset(
     else:
         button_box.addButton(QDialogButtonBox.StandardButton.Ok)
     qconnect(button_box.accepted, dialog.accept)
+    qconnect(button_box.rejected, dialog.reject)
     layout.addWidget(button_box)
 
     if adjust_height_to_content:


### PR DESCRIPTION
## Related issues

Fix a few issues reported in QA of https://ankihub.atlassian.net/browse/BUILD-1020


## Proposed changes

- Make Cancel button work
-  Disable Proceed button if nothing is selected 
- Add a prompt for fields dialog instead of a title

## How to reproduce

- Add a new field to an AnkiHub note type
- Go to the Deck Management screen and click "Publish field".
- Notice the changes in the fields dialog.


## Screenshots and videos

![image](https://github.com/user-attachments/assets/cb483969-7e0d-450f-a8a6-c163c794466c)


