### PR TITLE
fix+ref: note_types_with_template_changes_for_deck

### DIFF
--- a/ankihub/main/note_type_management.py
+++ b/ankihub/main/note_type_management.py
@@ -34,12 +34,12 @@ def add_note_type_fields(
 ) -> NotetypeDict:
     client = AddonAnkiHubClient()
 
-    db_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
+    ah_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
     new_fields = [
         field for field in note_type["flds"] if field["name"] in new_field_names
     ]
-    db_note_type["flds"].extend(new_fields)
-    for db_field in db_note_type["flds"]:
+    ah_note_type["flds"].extend(new_fields)
+    for db_field in ah_note_type["flds"]:
         field = next(
             (field for field in note_type["flds"] if field["name"] == db_field["name"]),
             None,
@@ -49,21 +49,21 @@ def add_note_type_fields(
     ankihub_id_field_idx = next(
         (
             idx
-            for idx, field in enumerate(db_note_type["flds"])
+            for idx, field in enumerate(ah_note_type["flds"])
             if field["name"] == ANKIHUB_NOTE_TYPE_FIELD_NAME
         ),
         None,
     )
     if ankihub_id_field_idx is not None:
-        db_note_type["flds"][ankihub_id_field_idx]["ord"] = (
-            len(db_note_type["flds"]) - 1
+        ah_note_type["flds"][ankihub_id_field_idx]["ord"] = (
+            len(ah_note_type["flds"]) - 1
         )
-        ankihub_id_field = db_note_type["flds"].pop(ankihub_id_field_idx)
-        db_note_type["flds"].append(ankihub_id_field)
-    db_note_type = client.update_note_type(ah_did, db_note_type, ["flds"])
-    ankihub_db.upsert_note_type(ankihub_did=ah_did, note_type=db_note_type)
+        ankihub_id_field = ah_note_type["flds"].pop(ankihub_id_field_idx)
+        ah_note_type["flds"].append(ankihub_id_field)
+    ah_note_type = client.update_note_type(ah_did, ah_note_type, ["flds"])
+    ankihub_db.upsert_note_type(ankihub_did=ah_did, note_type=ah_note_type)
 
-    return db_note_type
+    return ah_note_type
 
 
 def note_types_with_template_changes_for_deck(ah_did: uuid.UUID) -> List[NotetypeId]:
@@ -104,12 +104,12 @@ def update_note_type_templates_and_styles(
 ) -> NotetypeDict:
     client = AddonAnkiHubClient()
     note_type = note_type_without_ankihub_modifications(note_type)
-    db_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
+    ah_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
 
-    db_note_type["tmpls"] = note_type["tmpls"]
-    db_note_type["css"] = note_type["css"]
+    ah_note_type["tmpls"] = note_type["tmpls"]
+    ah_note_type["css"] = note_type["css"]
 
-    db_note_type = client.update_note_type(ah_did, db_note_type, ["css", "tmpls"])
-    ankihub_db.upsert_note_type(ankihub_did=ah_did, note_type=db_note_type)
+    ah_note_type = client.update_note_type(ah_did, ah_note_type, ["css", "tmpls"])
+    ankihub_db.upsert_note_type(ankihub_did=ah_did, note_type=ah_note_type)
 
-    return db_note_type
+    return ah_note_type

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -880,21 +880,6 @@ url_mh_integrations_preview = (
 url_login = lambda: f"{config.app_url}/accounts/login"  # noqa: E731
 
 ANKIHUB_NOTE_TYPE_FIELD_NAME = "ankihub_id"
-ANKIHUB_NOTE_TYPE_MODIFICATION_STRING = "ANKIHUB MODFICATIONS"
-ANKIHUB_HTML_END_COMMENT = (
-    "<!--\n"
-    "ANKIHUB_END\n"
-    "Text below this comment will not be modified by AnkiHub or AnKing add-ons.\n"
-    "Do not edit or remove this comment if you want to protect the content below.\n"
-    "-->"
-)
-ANKIHUB_CSS_END_COMMENT = (
-    "/*\n"
-    "ANKIHUB_END\n"
-    "Text below this comment will not be modified by AnkiHub or AnKing add-ons.\n"
-    "Do not edit or remove this comment if you want to protect the content below.\n"
-    "*/"
-)
 ADDON_PACKAGE = __name__.split(".")[0]
 ICONS_PATH = ADDON_PATH / "gui/icons"
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -146,6 +146,8 @@ from ankihub.main.subdecks import (
 )
 from ankihub.main.suggestions import ChangeSuggestionResult
 from ankihub.main.utils import (
+    ANKIHUB_CSS_END_COMMENT,
+    ANKIHUB_HTML_END_COMMENT,
     Resource,
     clear_empty_cards,
     lowest_level_common_ancestor_deck_name,
@@ -154,14 +156,7 @@ from ankihub.main.utils import (
     note_type_with_updated_templates_and_css,
     retain_nids_with_ah_note_type,
 )
-from ankihub.settings import (
-    ANKIHUB_CSS_END_COMMENT,
-    ANKIHUB_HTML_END_COMMENT,
-    ANKIWEB_ID,
-    DatadogLogHandler,
-    config,
-    log_file_path,
-)
+from ankihub.settings import ANKIWEB_ID, DatadogLogHandler, config, log_file_path
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes `ankihub.main.note_type_management.note_types_with_template_changes_for_deck`, by fixing the removal of note type modifications.
This fixes the issue where note types were available for selection in the "Publish style/template updates" flow after being published.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1025

## Proposed changes
- Combine code from `note_type_management.note_type_with_ankihub_end_comment_removed` and `main.utils.undo_template_modification` into `main.utils.note_type_without_template_and_style_modifications`
  - Previously we were not removing all template modifications, which caused problems with the ""Publish style/template updates" flow
  - `note_type_without_template_and_style_modifications` now removes all modifications from the templates:
    - ankihub end comment
    - ankihub snippet
  - `note_type_without_template_and_style_modifications` is now used in `note_type_management` and in `main.utils.undo_note_type_modfications`   
- ref: Moved all constants related to note type modifications into `main.utils` and renamed some
- [ref: Rename db_note_type to ah_note_type](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1111/commits/598c0568f9844c10f471ea1bf7e55ce3c9ef2d65)
  - `ah_note_type` makes it more clear that it's the AnkiHub version of the note type