### PR TITLE
fix: Exclude note types with duplicate names from publication flow

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -29,6 +29,7 @@ from .gui.errors import setup_error_handler
 from .gui.media_sync import media_sync
 from .gui.menu import menu_state, refresh_ankihub_menu, setup_ankihub_menu
 from .gui.operations.ankihub_sync import setup_full_sync_patch
+from .gui.operations.username import fetch_username_in_background
 from .main.note_deletion import handle_notes_deleted_from_webapp
 from .main.utils import modify_note_type_templates
 from .settings import (
@@ -231,8 +232,10 @@ def _general_setup():
     # If this function is called earlier, the feature flags might be fetched before the callbacks are added,
     # which would cause the callbacks to not be called.
     update_feature_flags_in_background()
+    fetch_username_in_background()
 
     config.token_change_hook.append(update_feature_flags_in_background)
+    config.token_change_hook.append(fetch_username_in_background)
 
     LOGGER.info(
         "Set up feature flag fetching (flags will be fetched in the background)."

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -40,7 +40,7 @@ from ..main.note_type_management import (
     update_note_type_templates_and_styles,
 )
 from ..main.subdecks import SUBDECK_TAG, deck_contains_subdeck_tags
-from ..main.utils import modified_ankihub_note_type_name, truncate_string
+from ..main.utils import note_type_name_without_ankihub_modifications, truncate_string
 from ..settings import (
     BehaviorOnRemoteNoteDeleted,
     SuspendNewCardsOfExistingNotes,
@@ -611,18 +611,21 @@ class DeckManagementDialog(QDialog):
             button.setToolTip("Nothing to update to AnkiHub")
 
     def _get_note_type_names_for_add_note_type_btn(self) -> List[str]:
-        deck_name = config.deck_config(self._selected_ah_did()).name
-        ankihub_note_type_names = self._get_note_type_names_for_deck(
+        ah_note_type_names = self._get_note_type_names_for_deck(
             self._selected_ah_did(), assigned_to_deck=True
         )
-        names = []
-        for name in self._get_note_type_names_for_deck(
+        other_note_type_names = self._get_note_type_names_for_deck(
             self._selected_ah_did(), assigned_to_deck=False
-        ):
-            modified_name = modified_ankihub_note_type_name(name, deck_name)
-            if modified_name not in ankihub_note_type_names:
-                names.append(name)
-
+        )
+        ah_note_type_names_without_ah_modifications = {
+            note_type_name_without_ankihub_modifications(name)
+            for name in ah_note_type_names
+        }
+        names = [
+            name
+            for name in other_note_type_names
+            if name not in ah_note_type_names_without_ah_modifications
+        ]
         return names
 
     def _update_add_note_type_btn_state(self):

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -40,7 +40,7 @@ from ..main.note_type_management import (
     update_note_type_templates_and_styles,
 )
 from ..main.subdecks import SUBDECK_TAG, deck_contains_subdeck_tags
-from ..main.utils import truncate_string
+from ..main.utils import modified_ankihub_note_type_name, truncate_string
 from ..settings import (
     BehaviorOnRemoteNoteDeleted,
     SuspendNewCardsOfExistingNotes,
@@ -611,9 +611,19 @@ class DeckManagementDialog(QDialog):
             button.setToolTip("Nothing to update to AnkiHub")
 
     def _get_note_type_names_for_add_note_type_btn(self) -> List[str]:
-        return self._get_note_type_names_for_deck(
-            self._selected_ah_did(), assigned_to_deck=False
+        deck_name = config.deck_config(self._selected_ah_did()).name
+        ankihub_note_type_names = self._get_note_type_names_for_deck(
+            self._selected_ah_did(), assigned_to_deck=True
         )
+        names = []
+        for name in self._get_note_type_names_for_deck(
+            self._selected_ah_did(), assigned_to_deck=False
+        ):
+            modified_name = modified_ankihub_note_type_name(name, deck_name)
+            if modified_name not in ankihub_note_type_names:
+                names.append(name)
+
+        return names
 
     def _update_add_note_type_btn_state(self):
         enabled = bool(self._get_note_type_names_for_add_note_type_btn())

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -144,8 +144,10 @@ def upload_logs_and_data_in_background(
 
 
 def _username_or_hash(hide_username: bool) -> str:
-    # Many users use their email address as their username and may not want to share it on a forum
     if config.user():
+        if config.username():
+            return config.username()
+        # Many users use their email address for login and may not want to share it on a forum
         return checksum(config.user())[:5] if hide_username else config.user()
     else:
         return "not_signed_in"
@@ -475,7 +477,7 @@ def _report_exception(
 
     with push_scope() as scope:
         scope.level = "error"
-        scope.user = {"id": config.user()}
+        scope.user = {"id": config.username_or_email()}
         scope.set_tag("os", sys.platform)
         scope.set_context("add-on config", dataclasses.asdict(config._private_config))
         scope.set_context("addon version", {"version": ADDON_VERSION})

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -197,6 +197,10 @@ class AnkiHubLogin(QWidget):
 
         config.save_token(token)
         config.save_user_email(username_or_email)
+        username = ""
+        if not self._is_email(username_or_email):
+            username = username_or_email
+        config.save_username(username)
         LOGGER.info("User signed into AnkiHub.", user=username_or_email)
 
         tooltip("Signed into AnkiHub!", parent=aqt.mw)

--- a/ankihub/gui/operations/username.py
+++ b/ankihub/gui/operations/username.py
@@ -14,7 +14,7 @@ def _fetch_username_in_background() -> None:
         try:
             username = client.get_user_details()["username"]
         except (AnkiHubRequestException, AnkiHubHTTPError) as exc:
-            LOGGER.error(f"Failed to fetch username: {exc}")
+            LOGGER.warning(f"Failed to fetch username: {exc}")
     config.save_username(username)
 
 

--- a/ankihub/gui/operations/username.py
+++ b/ankihub/gui/operations/username.py
@@ -1,0 +1,29 @@
+import aqt
+
+from ... import LOGGER
+from ...addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
+from ...ankihub_client import AnkiHubHTTPError, AnkiHubRequestException
+from ...gui.operations import AddonQueryOp
+from ...settings import config
+
+
+def _fetch_username_in_background() -> None:
+    username = ""
+    if config.is_logged_in() and not config.username():
+        client = AnkiHubClient()
+        try:
+            username = client.get_user_details()["username"]
+        except (AnkiHubRequestException, AnkiHubHTTPError) as exc:
+            LOGGER.error(f"Failed to fetch username: {exc}")
+    config.save_username(username)
+
+
+def fetch_username_in_background() -> None:
+    def on_done(_: None) -> None:
+        LOGGER.info("Fetched username.")
+
+    AddonQueryOp(
+        parent=aqt.mw,
+        op=lambda _: _fetch_username_in_background(),
+        success=on_done,
+    ).without_collection().run_in_background()

--- a/ankihub/main/deck_creation.py
+++ b/ankihub/main/deck_creation.py
@@ -91,7 +91,7 @@ def _create_note_types_for_deck(deck_id: DeckId) -> Dict[NotetypeId, NotetypeId]
         name_without_modifications = _note_type_name_without_ankihub_modifications(
             new_model["name"]
         )
-        name = f"{name_without_modifications} ({aqt.mw.col.decks.name(deck_id)} / {config.user()})"
+        name = f"{name_without_modifications} ({aqt.mw.col.decks.name(deck_id)} / {config.username_or_email()})"
         new_model["name"] = name
         aqt.mw.col.models.ensure_name_unique(new_model)
         new_model["id"] = 0

--- a/ankihub/main/deck_creation.py
+++ b/ankihub/main/deck_creation.py
@@ -1,6 +1,5 @@
 """Code for creating an AnkiHub deck from an existing deck in Anki."""
 
-import re
 import typing
 import uuid
 from dataclasses import dataclass
@@ -15,13 +14,14 @@ from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..ankihub_client.models import NoteInfo
 from ..db import ankihub_db
-from ..settings import ANKIHUB_NOTE_TYPE_FIELD_NAME, config
+from ..settings import ANKIHUB_NOTE_TYPE_FIELD_NAME
 from .exporting import to_note_data
 from .subdecks import add_subdeck_tags_to_notes
 from .utils import (
     change_note_types_of_notes,
     create_backup,
     get_note_types_in_deck,
+    modified_ankihub_note_type_name,
     modified_note_type,
 )
 
@@ -88,20 +88,14 @@ def _create_note_types_for_deck(deck_id: DeckId) -> Dict[NotetypeId, NotetypeId]
     model_ids = get_note_types_in_deck(deck_id)
     for mid in model_ids:
         new_model = modified_note_type(aqt.mw.col.models.get(mid))
-        name_without_modifications = _note_type_name_without_ankihub_modifications(
-            new_model["name"]
+        new_model["name"] = modified_ankihub_note_type_name(
+            new_model["name"], aqt.mw.col.decks.name(deck_id)
         )
-        name = f"{name_without_modifications} ({aqt.mw.col.decks.name(deck_id)} / {config.username_or_email()})"
-        new_model["name"] = name
         aqt.mw.col.models.ensure_name_unique(new_model)
         new_model["id"] = 0
         aqt.mw.col.models.add_dict(new_model)
         result[mid] = aqt.mw.col.models.by_name(new_model["name"])["id"]
     return result
-
-
-def _note_type_name_without_ankihub_modifications(name: str) -> str:
-    return re.sub(r" \(.*? / .*?\)", "", name)
 
 
 def _change_note_types_of_notes(

--- a/ankihub/main/note_type_management.py
+++ b/ankihub/main/note_type_management.py
@@ -16,11 +16,15 @@ def add_note_type(ah_did: uuid.UUID, note_type: NotetypeDict) -> NotetypeDict:
     new_note_type = modified_note_type(note_type)
     new_note_type["id"] = 0
     # Add note type first to get a unique ID
-    new_mid = aqt.mw.col.models.add_dict(new_note_type).id
-    new_note_type = aqt.mw.col.models.get(NotetypeId(new_mid))
+    new_mid = NotetypeId(aqt.mw.col.models.add_dict(new_note_type).id)
+    new_note_type = aqt.mw.col.models.get(new_mid)
     # Send base name to AnkiHub, as it will take care of adding the deck name and username
     new_note_type["name"] = note_type["name"]
-    new_name = client.create_note_type(ah_did, new_note_type)["name"]
+    try:
+        new_name = client.create_note_type(ah_did, new_note_type)["name"]
+    except Exception as e:
+        aqt.mw.col.models.remove(new_mid)
+        raise e
     new_note_type["name"] = new_name
     aqt.mw.col.models.update_dict(new_note_type)
     new_note_type = aqt.mw.col.models.get(NotetypeId(new_mid))

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -23,6 +23,7 @@ from ..settings import (
     ANKI_INT_VERSION,
     ANKI_VERSION_23_10_00,
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
+    config,
     url_mh_integrations_preview,
     url_view_note,
 )
@@ -324,6 +325,18 @@ def get_anki_nid_to_mid_dict(nids: Collection[NoteId]) -> Dict[NoteId, NotetypeI
 
 
 # ... note type modifications
+
+
+def note_type_name_without_ankihub_modifications(name: str) -> str:
+    return re.sub(r" \(.*? / .*?\)", "", name)
+
+
+def modified_ankihub_note_type_name(note_type_name: str, deck_name) -> str:
+    name_without_modifications = note_type_name_without_ankihub_modifications(
+        note_type_name
+    )
+    name = f"{name_without_modifications} ({deck_name} / {config.username_or_email()})"
+    return name
 
 
 def modified_note_type(note_type: NotetypeDict) -> NotetypeDict:

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -328,7 +328,7 @@ def get_anki_nid_to_mid_dict(nids: Collection[NoteId]) -> Dict[NoteId, NotetypeI
 
 
 def note_type_name_without_ankihub_modifications(name: str) -> str:
-    return re.sub(r" \(.*? / .*?\)", "", name)
+    return re.sub(r"(\s*\([^()]+ / [^()]+\))+\s*$", "", name)
 
 
 def modified_ankihub_note_type_name(note_type_name: str, deck_name) -> str:

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -168,6 +168,7 @@ class UIConfig(DataClassJSONMixin):
 
 @dataclasses.dataclass
 class PrivateConfig(DataClassJSONMixin):
+    username: Optional[str] = ""
     decks: Dict[uuid.UUID, DeckConfig] = dataclasses.field(default_factory=dict)
     deck_extensions: Dict[int, DeckExtensionConfig] = dataclasses.field(
         default_factory=dict
@@ -271,6 +272,10 @@ class _Config:
     def save_user_email(self, user_email: str):
         # aqt.mw.pm.set_ankihub_username(user_email)
         aqt.mw.pm.profile["thirdPartyAnkiHubUsername"] = user_email
+
+    def save_username(self, username: str):
+        self._private_config.username = username
+        self._update_private_config()
 
     def save_latest_deck_update(
         self, ankihub_did: uuid.UUID, latest_update: Optional[datetime]
@@ -402,6 +407,12 @@ class _Config:
     def user(self) -> Optional[str]:
         # return aqt.mw.pm.ankihub_username()
         return aqt.mw.pm.profile.get("thirdPartyAnkiHubUsername")
+
+    def username(self) -> Optional[str]:
+        return self._private_config.username
+
+    def username_or_email(self) -> Optional[str]:
+        return self.username() or self.user()
 
     def ui_config(self) -> UIConfig:
         return self._private_config.ui
@@ -806,7 +817,7 @@ class DatadogLogHandler(logging.Handler):
                 "ddtags": f"addon_version:{ADDON_VERSION},anki_version:{ANKI_VERSION}",
                 "hostname": socket.gethostname(),
                 "service": "ankihub_addon",
-                "username": config.user(),
+                "username": config.username_or_email(),
                 **json.loads(self.format(record)),
             }
             for record in records

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -109,12 +109,24 @@ def anki_session_with_addon_data(
                 _profile_setup()
 
         _mock_all_feature_flags_to_default_values(monkeypatch)
+        _mock_user_details(requests_mock)
 
         yield anki_session
 
 
 def _mock_all_feature_flags_to_default_values(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(AnkiHubClient, "get_feature_flags", lambda *args, **kwargs: {})
+
+
+def _mock_user_details(request_mock: Mocker) -> None:
+    request_mock.get(
+        "https://app.ankihub.net/api/users/me",
+        json={
+            "has_flashcard_selector_access": False,
+            "has_reviewer_extension_access": False,
+            "username": "test_user",
+        },
+    )
 
 
 @pytest.fixture

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6514,6 +6514,7 @@ def mock_user_details(mocker: MockerFixture):
     user_details = {
         "has_flashcard_selector_access": True,
         "has_reviewer_extension_access": True,
+        "username": "test_user",
     }
     mocker.patch.object(AnkiHubClient, "get_user_details", return_value=user_details)
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -119,10 +119,7 @@ from ankihub.gui.utils import (
     show_error_dialog,
 )
 from ankihub.main import suggestions
-from ankihub.main.deck_creation import (
-    DeckCreationResult,
-    _note_type_name_without_ankihub_modifications,
-)
+from ankihub.main.deck_creation import DeckCreationResult
 from ankihub.main.exporting import _prepared_field_html
 from ankihub.main.importing import _updated_tags
 from ankihub.main.note_conversion import (
@@ -153,6 +150,7 @@ from ankihub.main.utils import (
     lowest_level_common_ancestor_deck_name,
     mh_tag_to_resource,
     mids_of_notes,
+    note_type_name_without_ankihub_modifications,
     note_type_with_updated_templates_and_css,
     retain_nids_with_ah_note_type,
 )
@@ -470,13 +468,13 @@ def test_prepared_field_html():
 
 def test_remove_note_type_name_modifications():
     name = "Basic (deck_name / user_name)"
-    assert _note_type_name_without_ankihub_modifications(name) == "Basic"
+    assert note_type_name_without_ankihub_modifications(name) == "Basic"
 
     name = "Basic (deck_name / user_name) (deck_name2 / user_name2)"
-    assert _note_type_name_without_ankihub_modifications(name) == "Basic"
+    assert note_type_name_without_ankihub_modifications(name) == "Basic"
 
     name = "Basic (deck_name/user_name)"
-    assert _note_type_name_without_ankihub_modifications(name) == name
+    assert note_type_name_without_ankihub_modifications(name) == name
 
 
 class TestDeckContainsSubdeckTags:

--- a/tests/client/cassettes/TestGetUserDetails.test_get_user_details.yaml
+++ b/tests/client/cassettes/TestGetUserDetails.test_get_user_details.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"username": "test1", "password": "asdf"}'
+    headers:
+      Accept:
+      - application/json; version=22.0
+      Content-Length:
+      - '41'
+      Content-Type:
+      - application/json
+    method: POST
+    uri: http://localhost:8000/api/login/
+  response:
+    body:
+      string: '{"expiry":"2025-04-01T16:31:08.760064Z","token":"126202544fe5ad370b97b364d4146582ebf55b79b94095f21c75c59898ea40b5"}'
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Connection:
+      - close
+      Content-Language:
+      - en-us
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - unsafe-none
+      Date:
+      - Tue, 04 Mar 2025 16:31:08 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Werkzeug/3.0.1 Python/3.12.3
+      Server-Timing:
+      - TimerPanel_utime;dur=285.6089999999938;desc="User CPU time", TimerPanel_stime;dur=14.525000000000787;desc="System
+        CPU time", TimerPanel_total;dur=300.13399999999456;desc="Total CPU time",
+        TimerPanel_total_time;dur=213.18933700013076;desc="Elapsed time", SQLPanel_sql_time;dur=7.449931999872206;desc="SQL
+        16 queries", CachePanel_total_time;dur=0;desc="Cache 0 Calls"
+      Set-Cookie:
+      - csrftoken=Se8FS25NW7UfISFkCVm5FnfV9C3kKFT2; expires=Tue, 03 Mar 2026 16:31:08
+        GMT; HttpOnly; Max-Age=31449600; Path=/; SameSite=Lax
+      - sessionid=3r1szcghz7iyn808z7w6rlddlcnkn7v7; expires=Tue, 11 Mar 2025 16:31:08
+        GMT; HttpOnly; Max-Age=604800; Path=/; SameSite=Lax
+      Vary:
+      - Accept, Cookie, Accept-Language, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      djdt-store-id:
+      - e2c745e5e21848ad95c7ff30e971ea71
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json; version=22.0
+      Authorization:
+      - Token 126202544fe5ad370b97b364d4146582ebf55b79b94095f21c75c59898ea40b5
+      Content-Type:
+      - application/json
+    method: GET
+    uri: http://localhost:8000/api/users/me
+  response:
+    body:
+      string: '{"username":"test1","email":"test1@email.com","name":"","subscribed_decks":[],"created_decks":[{"id":"dda0d3ad-89cd-45fb-8ddc-fabad93c2d7b","name":"Optional
+        tangible orchestration #0","anki_id":849814700,"is_private":false,"notes_count":13,"subscribers_count":0,"description":"","updates_count":0}],"maintained_decks":[],"memberships":[{"start_date":null,"end_date":null,"status":"active","issuer":null}],"show_trial_ended_message":false,"has_flashcard_selector_access":true,"has_reviewer_extension_access":true}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Language:
+      - en-us
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - unsafe-none
+      Date:
+      - Tue, 04 Mar 2025 16:31:09 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Werkzeug/3.0.1 Python/3.12.3
+      Server-Timing:
+      - TimerPanel_utime;dur=270.55099999999754;desc="User CPU time", TimerPanel_stime;dur=4.541999999998936;desc="System
+        CPU time", TimerPanel_total;dur=275.0929999999965;desc="Total CPU time", TimerPanel_total_time;dur=278.7255749999531;desc="Elapsed
+        time", SQLPanel_sql_time;dur=11.683042000186106;desc="SQL 16 queries", CachePanel_total_time;dur=0;desc="Cache
+        0 Calls"
+      Vary:
+      - Accept, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      djdt-store-id:
+      - 5b8d908d493d449f88fe6b1019f2dfc0
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1862,6 +1862,14 @@ class TestGetFeatureFlags:
 
 
 @pytest.mark.vcr()
+class TestGetUserDetails:
+    def test_get_user_details(self, authorized_client_for_user_test1: AnkiHubClient):
+        client = authorized_client_for_user_test1
+        client.get_user_details()
+        # This test just makes sure that the method does not throw an exception
+
+
+@pytest.mark.vcr()
 class TestSendCardReviewData:
     def test_basic(
         self,


### PR DESCRIPTION


## Related issues

https://ankihub.atlassian.net/browse/BUILD-1013


## Proposed changes

Because we clone chosen note types under new names, the old ones will still be shown next time, but we show an error message when they are chosen. This PR excludes any note types with duplicate names to reduce confusion.

## How to reproduce

- Publish any new note type.
- Click "Publish field" again and notice the previously chosen note type is no longer shown.
