### PR TITLE
[BUILD-1090] Disallow updating note type with added/removed templates

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -36,6 +36,7 @@ from ..main.note_type_management import (
     add_note_type,
     add_note_type_fields,
     new_fields_for_note_type,
+    note_type_had_templates_added_or_removed,
     note_types_with_template_changes_for_deck,
     update_note_type_templates_and_styles,
 )
@@ -56,6 +57,7 @@ from .utils import (
     choose_subset,
     clear_layout,
     set_styled_tooltip,
+    show_dialog,
     tooltip_icon,
     tooltip_stylesheet,
 )
@@ -764,6 +766,22 @@ class DeckManagementDialog(QDialog):
                 return
 
             note_type = aqt.mw.col.models.by_name(note_type_selector.name)
+
+            if note_type_had_templates_added_or_removed(
+                ah_did=self._selected_ah_did(), note_type=note_type
+            ):
+                show_dialog(
+                    (
+                        "<h3>Issue with note type templates</h3>"
+                        "⚠️ <b>Adding or removing templates is not supported</b> in this publishing flow.<br><br>"
+                        "If you've recently created or deleted a template, sync with AnkiHub to reset "
+                        "the templates before publishing any style or template updates."
+                    ),
+                    title=" ",
+                    buttons=[("Close", QDialogButtonBox.ButtonRole.AcceptRole)],
+                )
+                return
+
             confirm = ask_user(
                 "<b>Proceed?</b><br><br>"
                 "Confirm to update note styling and templates for all AnkiHub users of your deck.<br><br>"

--- a/ankihub/main/note_type_management.py
+++ b/ankihub/main/note_type_management.py
@@ -104,7 +104,7 @@ def note_type_had_templates_added_or_removed(
 ) -> bool:
     ah_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
 
-    if len(ah_note_type["tmpls"]) != len(note_type["tmpls"]):
+    if len(note_type["tmpls"]) != len(ah_note_type["tmpls"]):
         return True
 
     for anki_tmpl, ah_tmpl in zip(note_type["tmpls"], ah_note_type["tmpls"]):

--- a/ankihub/main/note_type_management.py
+++ b/ankihub/main/note_type_management.py
@@ -99,6 +99,29 @@ def new_fields_for_note_type(ah_did: uuid.UUID, note_type: NotetypeDict) -> List
     return new_fields
 
 
+def note_type_had_templates_added_or_removed(
+    ah_did: uuid.UUID, note_type: NotetypeDict
+) -> bool:
+    ah_note_type = ankihub_db.note_type_dict(ah_did, note_type["id"])
+
+    if len(ah_note_type["tmpls"]) != len(note_type["tmpls"]):
+        return True
+
+    for anki_tmpl, ah_tmpl in zip(note_type["tmpls"], ah_note_type["tmpls"]):
+        if anki_tmpl["name"] != ah_tmpl["name"]:
+            return True
+
+        # Ids were added in a recent Anki version, so we need to check if they exist
+        if (
+            anki_tmpl.get("id")
+            and ah_tmpl.get("id")
+            and anki_tmpl["id"] != ah_tmpl["id"]
+        ):
+            return True
+
+    return False
+
+
 def update_note_type_templates_and_styles(
     ah_did: uuid.UUID, note_type: NotetypeDict
 ) -> NotetypeDict:


### PR DESCRIPTION
When an user tries to publish updates to note styling and templates of a note type that had templates added/removed, this dialog should be shown:
<img src="https://github.com/user-attachments/assets/50b1bcd7-ab81-4a03-9b12-d76ad0ac4385" width="500" />


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1090


## Proposed changes
- Add `note_type_had_templates_added_or_removed()` to `note_type_management.py`
- Use `note_type_had_templates_added_or_removed()` in `decks_dialog.py` when user selected note type to publish updates for, show message if templates were added or removed 

## How to reproduce
- Add/remove template of a note type which belongs to an AnkiHub deck you are the owner of
- Try to publish style and template updates for it
- The dialog should show up

## Screenshots
<img src="https://github.com/user-attachments/assets/a2bd9c62-80f0-468b-9df8-98554c0d5bb7" width="500" />