### PR TITLE
[BUILD-1093] Adjust add_note_type_fields

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1079,7 +1079,6 @@ class AnkiHubClient:
             json=note_type,
         )
         if response.status_code != 200:
-            print(response.json())
             raise AnkiHubHTTPError(response)
         data = response.json()
         result = _to_anki_note_type(data)

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3281,7 +3281,7 @@ class TestAddNoteTypeFields:
             ),
         ],
     )
-    def test_basic(
+    def test_add_note_type_fields(
         self,
         anki_session_with_addon_data: AnkiSession,
         import_ah_note_type: ImportAHNoteType,


### PR DESCRIPTION
The changes ensure that `note_type_management.add_note_type_fields`…
- assigns field ords correctly
- only updates new fields and field ordering, and not the attributes of existing fields
- handles the case when the Anki note type is missing some fields which exist on the AnkiHub note type

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1093


## Proposed changes
- Update `note_type_management.add_note_type_fields`
- Add tests