### PR TITLE
[BUILD-1076] fix: Add on-freezes when server unreachable

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -347,6 +347,7 @@ class AnkiHubClient:
                 "anki_id": anki_deck_id,
                 "is_private": private,
             },
+            is_long_running=True,
         )
         if response.status_code != 201:
             raise AnkiHubHTTPError(response)
@@ -546,6 +547,7 @@ class AnkiHubClient:
                 url_suffix=url_suffix,
                 data=s3_presigned_info["fields"],
                 files={"file": (filepath.name, data)},
+                is_long_running=True,
             )
 
         if s3_response.status_code != 204:
@@ -676,7 +678,9 @@ class AnkiHubClient:
                 s3_url_suffix, download_progress_cb
             )
         else:
-            s3_response = self._send_request("GET", API.S3, s3_url_suffix)
+            s3_response = self._send_request(
+                "GET", API.S3, s3_url_suffix, is_long_running=True
+            )
             if s3_response.status_code != 200:
                 raise AnkiHubHTTPError(s3_response)
             s3_response_content = s3_response.content
@@ -700,7 +704,9 @@ class AnkiHubClient:
     def _download_with_progress_cb(
         self, s3_url_suffix: str, progress_cb: Callable[[int], None]
     ) -> bytes:
-        with self._send_request("GET", API.S3, s3_url_suffix, stream=True) as response:
+        with self._send_request(
+            "GET", API.S3, s3_url_suffix, stream=True, is_long_running=True
+        ) as response:
             if response.status_code != 200:
                 raise AnkiHubHTTPError(response)
 
@@ -811,6 +817,7 @@ class AnkiHubClient:
                 API.ANKIHUB,
                 url_suffix,
                 params=params if first_request else None,
+                is_long_running=True,
             )
             if response.status_code != 200:
                 raise AnkiHubHTTPError(response)
@@ -878,6 +885,7 @@ class AnkiHubClient:
                 API.ANKIHUB,
                 url_suffix,
                 params=params if first_request else None,
+                is_long_running=True,
             )
             if response.status_code != 200:
                 raise AnkiHubHTTPError(response)
@@ -896,7 +904,10 @@ class AnkiHubClient:
         self, ah_did: uuid.UUID
     ) -> List[NotesAction]:
         response = self._send_request(
-            "GET", API.ANKIHUB, f"/decks/{ah_did}/notes-actions/"
+            "GET",
+            API.ANKIHUB,
+            f"/decks/{ah_did}/notes-actions/",
+            is_long_running=True,
         )
         if response.status_code != 200:
             raise AnkiHubHTTPError(response)
@@ -996,6 +1007,7 @@ class AnkiHubClient:
                 "suggestions": [d.to_dict() for d in suggestions],
                 "auto_accept": auto_accept,
             },
+            is_long_running=True,
         )
         if response.status_code != 200:
             raise AnkiHubHTTPError(response)
@@ -1209,6 +1221,7 @@ class AnkiHubClient:
                 API.ANKIHUB,
                 url,
                 params=params if i == 0 else None,
+                is_long_running=True,
             )
             if response.status_code != 200:
                 raise AnkiHubHTTPError(response)
@@ -1282,6 +1295,7 @@ class AnkiHubClient:
                 "auto_accept": auto_accept,
                 "suggestions": [suggestion.to_dict() for suggestion in suggestions],
             },
+            is_long_running=True,
         )
 
         if response.status_code != 201:
@@ -1339,6 +1353,7 @@ class AnkiHubClient:
             API.ANKIHUB,
             "/users/card-review-data/",
             json=[review.to_dict() for review in card_review_data],
+            is_long_running=True,
         )
         if response.status_code != 200:
             raise AnkiHubHTTPError(response)
@@ -1351,6 +1366,7 @@ class AnkiHubClient:
             API.ANKIHUB,
             "/users/daily-card-review-summary/",
             json=[summary.to_dict() for summary in daily_card_review_summaries],
+            is_long_running=True,
         )
         if response.status_code != 201:
             raise AnkiHubHTTPError(response)

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -119,7 +119,7 @@ def upload_logs_in_background(
 
 
 def upload_logs_and_data_in_background(
-    on_done: Optional[Callable[[str], None]] = None
+    on_done: Optional[Callable[[str], None]] = None,
 ) -> str:
     """Upload the data dir and logs to S3 in the background.
     Returns the S3 key of the uploaded file."""
@@ -279,15 +279,8 @@ def _try_handle_exception(
             )
         else:
             message = (
-                (
-                    "🚧 We're having trouble connecting to AnkiHub. Please try again later.<br>"
-                    "Visit community.ankihub.net and check your email for details."
-                )
-                if isinstance(exc_value, ReadTimeout)
-                else (
-                    "🚧 AnkiHub is undergoing routine maintenance.<br>"
-                    "Please check your email for details."
-                )
+                "🚧 We’re unable to reach AnkiHub due to planned maintenance or an unexpected issue.<br> "
+                "For details, see https://community.ankihub.net/c/announcements."
             )
             show_tooltip(message, period=5000)
         return True

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -286,7 +286,7 @@ def _try_handle_exception(
                 if isinstance(exc_value, ReadTimeout)
                 else (
                     "🚧 AnkiHub is undergoing routine maintenance.<br>"
-                    "Please visit ankihub.net/status and check your email for details."
+                    "Please check your email for details."
                 )
             )
             show_tooltip(message, period=5000)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4797,7 +4797,10 @@ class TestSyncWithAnkiHub:
                 assert not cards_of_note_are_unsuspended()
 
     def test_exception_is_not_backpropagated_to_caller(
-        self, anki_session_with_addon_data: AnkiSession, mocker: MockerFixture
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
     ):
         with anki_session_with_addon_data.profile_loaded():
             # Mock a client function which is called in sync_with_ankihub to raise an exception.
@@ -4818,6 +4821,8 @@ class TestSyncWithAnkiHub:
 
             # Call sync_with_ankihub. This shouldn't raise an exception.
             ankihub_sync.sync_with_ankihub(on_done=on_done)
+
+            qtbot.wait_until(lambda: future is not None)
 
             # Assert that the future contains the exception and that it contains the expected message.
             assert future.exception().args[0] == exception_message


### PR DESCRIPTION
This PR enhances the AnkiHub client to provide a more responsive user experience and better handling of server connectivity issues. It introduces separate connection/read timeouts and categorizes operations as standard or long-running to reduce UI freezing during network operations, particularly when the server is unreachable or under heavy load.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1076


## Proposed changes
- Fetch deck subscriptions in background during sync to not freeze the UI
- [Update maintenance message](https://github.com/AnkiHubSoftware/ankihub_addon/commit/8c9ca395bbd211106ef16909ca859e6afc763b6b)
- Change client timeout and max retries logic
  - Now the connection timeout is configured separately from the read timeout. We have a short connection timeout so that the client gives up relatively quickly when the server is down.
  - Requests done by the client are now categorized into "standard" requests and "long-running" requests
    - Long-running requests have a longer timeout and use more retries