### PR TITLE
[BUILD-1079] Support importing notes with subset of fields

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -136,7 +136,7 @@ class _AnkiHubDB:
         for note_data in notes_data:
             # Prepare fields and tags for insertion
             field_values = []
-            for (_, field_name) in self.note_type_field_ords_and_names(
+            for field_name in self.note_type_field_names(
                 ankihub_did=ankihub_did, anki_note_type_id=NotetypeId(note_data.mid)
             ):
                 field = next(
@@ -640,26 +640,16 @@ class _AnkiHubDB:
         """Returns the names of the fields of the note type."""
         result = [
             field["name"]
-            for field in self.note_type_dict(
-                ankihub_did=ankihub_did, note_type_id=anki_note_type_id
-            )["flds"]
+            for field in sorted(
+                (
+                    field
+                    for field in self.note_type_dict(
+                        ankihub_did=ankihub_did, note_type_id=anki_note_type_id
+                    )["flds"]
+                ),
+                key=lambda f: f["ord"],
+            )
         ]
-        return result
-
-    def note_type_field_ords_and_names(
-        self, ankihub_did: uuid.UUID, anki_note_type_id: NotetypeId
-    ) -> List[Tuple[int, str]]:
-        """Returns a sorted list of (ord, name) tuples of the fields of the note type."""
-        result = sorted(
-            (
-                (field["ord"], field["name"])
-                for field in self.note_type_dict(
-                    ankihub_did=ankihub_did, note_type_id=anki_note_type_id
-                )["flds"]
-            ),
-            key=lambda f: f[0],
-        )
-
         return result
 
 

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -40,6 +40,7 @@ from ..ankihub_client import Field, NoteInfo, suggestion_type_from_str
 from ..ankihub_client.models import DeckMedia as DeckMediaClientModel
 from ..ankihub_client.models import SuggestionType
 from ..common_utils import local_media_names_from_html
+from ..settings import ANKIHUB_NOTE_TYPE_FIELD_NAME
 from .exceptions import IntegrityError
 from .models import (
     AnkiHubNote,
@@ -139,6 +140,8 @@ class _AnkiHubDB:
             for field_name in self.note_type_field_names(
                 ankihub_did=ankihub_did, anki_note_type_id=NotetypeId(note_data.mid)
             ):
+                if field_name == ANKIHUB_NOTE_TYPE_FIELD_NAME:
+                    continue
                 field = next(
                     (f for f in note_data.fields if f.name == field_name), None
                 )

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -796,6 +796,8 @@ class AnkiHubImporter:
         changed = False
         fields_protected_by_tags = get_fields_protected_by_tags(note)
         for field_name in note.keys():
+            if field_name == settings.ANKIHUB_NOTE_TYPE_FIELD_NAME:
+                continue
             field = next(
                 (f for f in fields if f.name == field_name),
                 Field(name=field_name, order=0, value=""),

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -795,7 +795,11 @@ class AnkiHubImporter:
 
         changed = False
         fields_protected_by_tags = get_fields_protected_by_tags(note)
-        for field in fields:
+        for field_name in note.keys():
+            field = next(
+                (f for f in fields if f.name == field_name),
+                Field(name=field_name, order=0, value=""),
+            )
             protected_fields_for_model = protected_fields.get(
                 aqt.mw.col.models.get(note.mid)["id"], []
             )

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -2690,6 +2690,39 @@ class TestAnkiHubImporter:
                 assert len(import_result.updated_nids) == 0
                 assert len(import_result.deleted_nids) == 0
 
+    def test_import_note_with_missing_fields(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        ankihub_basic_note_type: NotetypeDict,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            anki_nid = NoteId(1)
+            mid = ankihub_basic_note_type["id"]
+            ah_did = next_deterministic_uuid()
+            note_info = NoteInfoFactory.create(
+                anki_nid=anki_nid,
+                mid=mid,
+                fields=[Field(name="Front", value="f", order=0)],
+            )
+            self._import_notes(
+                [note_info],
+                is_first_import_of_deck=True,
+                ah_did=ah_did,
+                note_types={mid: ankihub_basic_note_type},
+            )
+            # Fields missing from source note are treated as empty fields
+            expected_note_info = NoteInfoFactory.create(
+                ah_nid=note_info.ah_nid,
+                anki_nid=anki_nid,
+                mid=mid,
+                fields=[
+                    Field(name="Front", value="f", order=0),
+                    Field(name="Back", value="", order=1),
+                ],
+            )
+            assert ankihub_db.note_data(anki_nid) == expected_note_info
+
     def _import_notes(
         self,
         ah_notes: List[NoteInfo],

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3202,6 +3202,13 @@ def prepare_note(
     if guid is None:
         guid = note.guid
 
+    # Treat missing fields as unchanged
+    for field_name in note.keys():
+        field = next((f for f in fields if f.name == field_name), None)
+        if not field:
+            field = Field(name=field_name, order=0, value=note[field_name])
+            fields.append(field)
+
     note_data = NoteInfo(
         ah_nid=ankihub_nid,
         anki_nid=note.id,


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/BUILD-1079
https://ankihub.atlassian.net/browse/BUILD-1078


## Proposed changes

After BUILD-1078, the web app can return notes with missing fields (indicating empty fields). This PR implements the necessary add-on changes to handle this correctly.

## How to reproduce

- Add a new field to an AnkiHub note type then publish the field from the Deck Management screen.
- Log in and sync with AnkiHub in a new Anki profile.
- Make any change to the new field in an existing note then sync again.
- Notice your changes are cleared after sync.
- Same process can be done with the Reset local changes option to confirm missing fields are cleared.
