### PR TITLE
[NRT-87] Handle `aqt.mw.col.db is None` during sync, add logs

### DIFF
--- a/ankihub/anki_logger.py
+++ b/ankihub/anki_logger.py
@@ -1,0 +1,32 @@
+"""Sets up logging for Anki events, for example when specific hooks are called."""
+
+import traceback
+
+from aqt.gui_hooks import (
+    collection_did_temporarily_close,
+    collection_will_temporarily_close,
+    sync_did_finish,
+    sync_will_start,
+)
+
+from . import LOGGER
+
+
+def setup() -> None:
+    sync_will_start.append(lambda: LOGGER.info("AnkiWeb sync will start."))
+    sync_did_finish.append(lambda: LOGGER.info("AnkiWeb sync did finish."))
+
+    collection_will_temporarily_close.append(
+        lambda _: LOGGER.info(
+            "Collection will temporarily close.", trace=_get_current_trace()
+        )
+    )
+    collection_did_temporarily_close.append(
+        lambda _: LOGGER.info(
+            "Collection did temporarily close.", trace=_get_current_trace()
+        )
+    )
+
+
+def _get_current_trace() -> str:
+    return "".join(traceback.format_stack())

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -10,7 +10,7 @@ from anki.hooks import wrap
 from aqt.gui_hooks import profile_did_open, profile_will_close
 from aqt.main import AnkiQt
 
-from . import LOGGER
+from . import LOGGER, anki_logger
 from .db import ankihub_db
 from .feature_flags import update_feature_flags_in_background
 from .gui import (
@@ -70,6 +70,8 @@ def run():
 
     _setup_on_profile_did_open()
     profile_will_close.append(_on_profile_will_close)
+
+    anki_logger.setup()
 
 
 def _setup_on_profile_did_open() -> None:

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -129,6 +129,7 @@ def _on_profile_did_open():
 
 def _on_profile_will_close():
     media_sync.stop_background_threads()
+    LOGGER.info("Profile will close, stopping background threads.")
 
 
 def _profile_setup() -> bool:

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -332,6 +332,7 @@ def _upload_if_full_sync_triggered_by_ankihub(
 ) -> None:
     if aqt.mw.col.db is None:
         LOGGER.warning("Collection is closed, skipping custom full sync.")
+        config.set_schema_to_do_full_upload_for_once(None)
         _old(mw, out, on_done)
         return
 

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -326,6 +326,11 @@ def _upload_if_full_sync_triggered_by_ankihub(
     on_done: Callable[[], None],
     _old: Callable[[aqt.main.AnkiQt, SyncOutput, Callable[[], None]], None],
 ) -> None:
+    if aqt.mw.col.db is None:
+        LOGGER.warning("Collection is closed, skipping custom full sync.")
+        _old(mw, out, on_done)
+        return
+
     if config.schema_to_do_full_upload_for_once() == collection_schema():
         LOGGER.info(
             "Full sync triggered by AnkiHub. Uploading changes.",

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -88,25 +88,29 @@ def _sync_with_ankihub_inner(on_done: Callable[[Future], None]) -> None:
 
         return subscribed_decks
 
-    def on_subscriptions_fetched(subscribed_decks: List[Deck]) -> None:
-        sync_state.schema_before_new_decks_installation = collection_schema()
-
-        check_and_install_new_deck_subscriptions(
-            subscribed_decks=subscribed_decks,
-            on_done=partial(
-                _on_new_deck_subscriptions_done,
-                subscribed_decks=subscribed_decks,
-                on_done=on_done,
-            ),
-        )
-
     AddonQueryOp(
         op=lambda _: get_subscriptions_and_clean_up(),
-        success=on_subscriptions_fetched,
+        success=partial(_on_subscriptions_fetched, on_done=on_done),
         parent=aqt.mw,
     ).failure(
         lambda e: on_done(future_with_exception(e))
     ).with_progress().run_in_background()
+
+
+@pass_exceptions_to_on_done
+def _on_subscriptions_fetched(
+    subscribed_decks: List[Deck], on_done: Callable[[Future], None]
+) -> None:
+    sync_state.schema_before_new_decks_installation = collection_schema()
+
+    check_and_install_new_deck_subscriptions(
+        subscribed_decks=subscribed_decks,
+        on_done=partial(
+            _on_new_deck_subscriptions_done,
+            subscribed_decks=subscribed_decks,
+            on_done=on_done,
+        ),
+    )
 
 
 @pass_exceptions_to_on_done


### PR DESCRIPTION
We have some errors that are caused by `aqt.mw.col.db` being `None` during the AnkiHub sync:
- https://ankihub.sentry.io/issues/5392204953/?project=6546414&referrer=issue-stream&stream_index=0
- https://ankihub.sentry.io/issues/6417858275/?project=6546414&query=%27NoneType%27%20object%20has%20no%20attribute%20%27scalar%27&referrer=issue-stream&stream_index=0

When these happen during the auto sync when Anki is closing, the errors prevent Anki from closing.

This PR applies a fix to handle the case when `aqt.mw.col.db is None`, so that Anki is closed.

I don't know why `aqt.mw.col.db is None` sometimes during the sync, so this PR also adds some logs to get more information about this.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-87

## Proposed changes
- Don't do a custom full upload (in `_upload_if_full_sync_triggered_by_ankihub`) if `aqt.mw.col.db is None`
  - This makes Anki close itself when you try to close Anki, but `aqt.mw.col.db. is None`, and a full sync is necessary
  - When the DB is unloaded, trying to do the custom full upload calls `collection_schema()` which causes an error
  - Going ahead with Anki's `aqt.sync.full_sync` instead, doesn't cause an error
    - Also, when this happens during `maybe_sync_on_open_close`, Anki still closes, unlike with the custom full upload
- [Apply @pass_exceptions_to_on_done to on_subscriptions_fetched](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1128/commits/da513b38f90283303cf8e03d12a29064d350df6a)
  - This makes Anki close itself when you try to close Anki, but `aqt.mw.col.db. is None`, and a full sync is  **not** necessary
  - In general, if there is an exception during the `gui.operations.ankihub_sync.sync_with_ankihub` flow, we want this exception to be be passed to the `on_done` function passed to `sync_with_ankihub`.
  - This wasn't the case for `_on_subscriptions_fetched`, now it is
  - This change has the effect that, when `collection_schema()` is called in `_on_subscriptions_fetched` during an auto sync, and this causes an error because the DB is unloaded, the exception is caught here:
    https://github.com/AnkiHubSoftware/ankihub_addon/blob/da513b38f90283303cf8e03d12a29064d350df6a/ankihub/gui/auto_sync.py#L103-L107
    Then, in `new_after_sync`, the original `after_sync` function which was passed by Anki is called, which closes Anki, if the sync was triggered by the user wanting to close Anki
- Attach log calls to Anki's hooks that have to do with full sync and closing the collection to get more information about the error

## How to reproduce
- Start Anki
- Log in to AnkiWeb, enable AnkiHub auto sync
- Open Anki's debug console and run this:
  ```python
  import aqt
  aqt.mw.col.close_for_full_sync()
  ```
- Click Anki's close button
- Anki should close

Without the changes in this PR, Anki doesn't close.

You can try the same with a pending full sync, by adding a field to a note type to make a full sync necessary, then calling `close_for_full_sync` from the debug console, and clicking Anki's close button. 

## Notes about the error
- The error happens because `aqt.mw.col.db is None`
    - maybe because `anki.Collection.close_for_full_sync` was called?
        - the backend is still connected to the DB, otherwise getting the sync status wouldn't work (and it works, according to logs)
- It happens in different places in the code
    - https://ankihub.sentry.io/issues/?project=6546414&query=%27NoneType%27%20object%20has%20no%20attribute%20%27scalar%27&referrer=issue-list&statsPeriod=30d
- It already happens since at least 11 months, but lately it happens more
    - probably has to do with full syncs
    - more people need to do full syncs now, after the note type features and the scripts which fixed notes types getting used by multiple decks
- A typical situation is that the user clicks on Anki's close button, which triggers an AnkiWeb full sync, then there is an error in `_upload_if_full_sync_triggered_by_ankihub`. The error interrupts the sync, the add-ons error dialog opens and Anki doesn't close. Then the user tries that multiple times, but with the same result