### PR TITLE
fix: Make flashcard selector non-modal to allow interaction with browser

### DIFF
--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -9,7 +9,6 @@ from aqt.qt import (
     QDialog,
     QHBoxLayout,
     QPushButton,
-    Qt,
     QUrl,
     QVBoxLayout,
     QWebEngineUrlRequestInterceptor,
@@ -46,7 +45,6 @@ class AnkiHubWebViewDialog(QDialog):
         return True
 
     def _setup_ui(self) -> None:
-        self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.web = AnkiWebView(parent=self)
         self.web.set_open_links_externally(False)
 


### PR DESCRIPTION
Fixes an issue reported here: https://ankihubllc.slack.com/archives/C08DWTDEDK8/p1742476753144639

> When I click on “Open in browser,” the browser window opens but always stays behind the Smart Search window, making it impossible to view the flashcards in the browser unless I close the Smart Search window.


## Proposed changes
- Make flashcard selector dialog non-modal
  - This makes it possible to interact with the browser while the flashcard selector is open
