### PR TITLE
[NRT-98] Fix suggestion fields being mixed up

### DIFF
--- a/ankihub/main/suggestions.py
+++ b/ankihub/main/suggestions.py
@@ -338,7 +338,7 @@ def _new_note_suggestion(
 def _change_note_suggestion(
     note: Note, change_type: SuggestionType, comment: str
 ) -> Optional[ChangeNoteSuggestion]:
-    note_from_anki_db = to_note_data(note)
+    note_from_anki_db = to_note_data(note, include_empty_fields=True)
     assert isinstance(note_from_anki_db, NoteInfo)
     assert note_from_anki_db.ah_nid is not None
     assert note_from_anki_db.tags is not None
@@ -383,11 +383,13 @@ def _added_and_removed_tags(
 def _fields_that_changed(
     prev_fields: List[Field], cur_fields: List[Field]
 ) -> List[Field]:
-    result = [
-        cur_field
-        for cur_field, prev_field in zip(cur_fields, prev_fields)
-        if cur_field.value != prev_field.value
-    ]
+    result = []
+    for prev_field in prev_fields:
+        cur_field = next(
+            (field for field in cur_fields if field.name == prev_field.name), None
+        )
+        if cur_field and cur_field.value != prev_field.value:
+            result.append(cur_field)
     return result
 
 


### PR DESCRIPTION
`_fields_that_changed()` compares different fields in some cases because `to_note_data()` doesn't include empty fields.

## Related issues

https://ankihub.atlassian.net/browse/NRT-98


## Proposed changes

- Fix `_fields_that_changed()` so that it matches fields by their names.
- Add the `include_empty_fields` parameter to `to_note_data()` and use it in `_change_note_suggestion()`

## How to reproduce

The issue can be reproduced by making changes to a field that has empty fields before it. Because empty fields were removed from the fields list before comparison and `_fields_that_changed()` doesn't expect that, it was resulting in the wrong fields being reported as changed.
