### PR TITLE
[NRT-100] Store fields in json dict in AnkiHubDB, fix missing values

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -725,6 +725,7 @@ class AnkiHubClient:
         self,
         ah_did: uuid.UUID,
         since: datetime,
+        download_full_deck: bool = False,
         updates_download_progress_cb: Optional[Callable[[int], None]] = None,
         deck_download_progress_cb: Optional[Callable[[int], None]] = None,
         should_cancel: Optional[Callable[[], bool]] = None,
@@ -737,6 +738,7 @@ class AnkiHubClient:
             since: The time from which to fetch updates.
             updates_download_progress_cb: An optional callback function to report the progress of the updates download.
                 The function should take one argument: the number of notes downloaded.
+            download_full_deck: If True, the full deck will be downloaded instead of just the updates.
             deck_download_progress_cb: An optional callback function to report the progress of the deck download.
                 The function should take one argument: the percentage of the deck download progress.
             should_cancel: An optional callback function that should return True if the operation should be cancelled.
@@ -751,6 +753,7 @@ class AnkiHubClient:
         for chunk in self._get_deck_updates_inner(
             ah_did,
             since,
+            download_full_deck,
             updates_download_progress_cb,
             deck_download_progress_cb,
         ):
@@ -790,6 +793,7 @@ class AnkiHubClient:
         self,
         ah_did: uuid.UUID,
         since: datetime,
+        download_full_deck: bool,
         updates_download_progress_cb: Optional[Callable[[int], None]] = None,
         deck_download_progress_cb: Optional[Callable[[int], None]] = None,
     ) -> Iterator[DeckUpdatesChunk]:
@@ -799,10 +803,12 @@ class AnkiHubClient:
         class Params(TypedDict, total=False):
             since: str
             size: int
+            full_deck: bool
 
         params: Params = {
             "since": since.strftime(ANKIHUB_DATETIME_FORMAT_STR) if since else None,
             "size": DECK_UPDATE_PAGE_SIZE,
+            "full_deck": download_full_deck,
         }
         url_suffix = f"/decks/{ah_did}/updates"
         notes_count = 0
@@ -837,6 +843,7 @@ class AnkiHubClient:
                 yield from self._get_deck_updates_inner(
                     ah_did=ah_did,
                     since=chunk.latest_update,
+                    download_full_deck=False,
                     updates_download_progress_cb=updates_download_progress_cb,
                     deck_download_progress_cb=deck_download_progress_cb,
                 )

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -506,13 +506,17 @@ class _AnkiHubDB:
         """Returns the names of all media files which are referenced on notes in the given deck."""
         notes = AnkiHubNote.select(AnkiHubNote.fields).filter(
             NOTE_NOT_DELETED_CONDITION,
-            (DQ(fields__ilike="%<img%") | DQ(fields__ilike="%[sound:%")),
+            (
+                AnkiHubNote.fields.cast("text").ilike("%<img%")
+                | AnkiHubNote.fields.cast("text").ilike("%[sound:%")
+            ),
             ankihub_deck_id=ah_did,
         )
         return {
             media_name
             for note in notes
-            for media_name in local_media_names_from_html(note.fields)
+            for field_value in (note.fields.values() if note.fields else [])
+            for media_name in local_media_names_from_html(field_value)
         }
 
     def media_names_exist_for_ankihub_deck(

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -328,7 +328,7 @@ class _AnkiHubDB:
         self, note: AnkiHubNote, field_names_by_mid: Dict[NotetypeId, List[str]]
     ) -> NoteInfo:
         if note.fields is None:
-            raise MissingValueError(ah_did=note.ankihub_deck_id)
+            raise MissingValueError(ah_did=cast(uuid.UUID, note.ankihub_deck_id))
 
         return NoteInfo(
             ah_nid=cast(uuid.UUID, note.ankihub_note_id),

--- a/ankihub/db/exceptions.py
+++ b/ankihub/db/exceptions.py
@@ -1,3 +1,6 @@
+import uuid
+
+
 class AnkiHubDBError(Exception):
     pass
 
@@ -5,3 +8,10 @@ class AnkiHubDBError(Exception):
 class IntegrityError(AnkiHubDBError):
     def __init__(self, message):
         super().__init__(message)
+
+
+class MissingValueError(AnkiHubDBError):
+    """Is raised when an object in the DB has a missing value that is expected to be non-null."""
+
+    def __init__(self, ah_did: uuid.UUID):
+        self.ah_did = ah_did

--- a/ankihub/db/models.py
+++ b/ankihub/db/models.py
@@ -61,7 +61,7 @@ class AnkiHubNote(Model):
     anki_note_type_id = IntegerField(index=True, null=True)
     mod = IntegerField(null=True)
     guid = TextField(null=True)
-    fields = TextField(null=True)
+    fields = JSONField(null=True)
     tags = TextField(null=True)
     last_update_type = TextField(null=True)
 

--- a/ankihub/db/models.py
+++ b/ankihub/db/models.py
@@ -27,30 +27,42 @@ class UUIDField(Field):
 
     field_type = "TEXT"
 
-    def db_value(self, value: uuid.UUID) -> str:
+    def db_value(self, value: Optional[uuid.UUID]) -> str:
+        if value is None:
+            return None
         return str(value)
 
-    def python_value(self, value: str) -> uuid.UUID:
+    def python_value(self, value: Optional[str]) -> uuid.UUID:
+        if value is None:
+            return None
         return uuid.UUID(value)
 
 
 class DateTimeField(Field):
     field_type = "TEXT"
 
-    def db_value(self, value: datetime) -> str:
+    def db_value(self, value: Optional[datetime]) -> str:
+        if value is None:
+            return None
         return value.isoformat()
 
-    def python_value(self, value: str) -> datetime:
+    def python_value(self, value: Optional[str]) -> datetime:
+        if value is None:
+            return None
         return datetime.fromisoformat(value)
 
 
 class JSONField(Field):
     field_type = "TEXT"
 
-    def db_value(self, value: dict) -> str:
+    def db_value(self, value: Optional[dict]) -> str:
+        if value is None:
+            return None
         return json.dumps(value)
 
-    def python_value(self, value: str) -> dict:
+    def python_value(self, value: Optional[str]) -> dict:
+        if value is None:
+            return None
         return json.loads(value)
 
 

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -124,6 +124,7 @@ class _AnkiHubDeckUpdater:
         deck_updates = self._client.get_deck_updates(
             ankihub_did,
             since=deck_config.latest_update,
+            download_full_deck=deck_config.download_full_deck_on_next_sync,
             updates_download_progress_cb=lambda notes_count: _update_deck_updates_download_progress_cb(
                 notes_count, ankihub_did=ankihub_did
             ),
@@ -160,6 +161,8 @@ class _AnkiHubDeckUpdater:
         if deck_updates.latest_update:
             # latest_update is None if there were no notes in the updates
             config.save_latest_deck_update(ankihub_did, deck_updates.latest_update)
+
+        config.set_download_full_deck_on_next_sync(ankihub_did, False)
 
         return True
 

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -317,11 +317,11 @@ def _try_handle_exception(
         return True
 
     if isinstance(exc_value, MissingValueError):
+        config.set_download_full_deck_on_next_sync(exc_value.ah_did, True)
         LOGGER.warning(
-            "NoteHasNoFieldsError was handled",
+            "MissingValueError was handled",
             ankihub_did=exc_value.ah_did,
         )
-        config.set_download_full_deck_on_next_sync(exc_value.ah_did, True)
         show_error_dialog(
             "There is an issue with the AnkiHub deck.<br>"
             "Please sync with AnkiHub to resolve it.",

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -124,6 +124,7 @@ class DeckConfig(DataClassJSONMixin):
         ),
         default=None,
     )
+    download_full_deck_on_next_sync: bool = False
     subdecks_enabled: bool = (
         False  # whether deck is organized into subdecks by the add-on
     )
@@ -287,6 +288,14 @@ class _Config:
         self, ankihub_did: uuid.UUID, latest_media_update: Optional[datetime]
     ):
         self.deck_config(ankihub_did).latest_media_update = latest_media_update
+        self._update_private_config()
+
+    def set_download_full_deck_on_next_sync(
+        self, ankihub_did: uuid.UUID, download_full_deck: bool
+    ):
+        self.deck_config(
+            ankihub_did
+        ).download_full_deck_on_next_sync = download_full_deck
         self._update_private_config()
 
     def save_last_sent_summary_date(self, last_summary_sent_date: Optional[date]):

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -71,9 +71,10 @@ from ankihub.ankihub_client.models import (  # type: ignore
     CardReviewData,
     DailyCardReviewSummary,
     UserDeckExtensionRelation,
+    UserDeckRelation,
 )
 from ankihub.db.db import _AnkiHubDB
-from ankihub.db.exceptions import IntegrityError
+from ankihub.db.exceptions import IntegrityError, MissingValueError
 from ankihub.db.models import AnkiHubNote, DeckMedia, get_peewee_database
 from ankihub.feature_flags import (
     _feature_flags_update_callbacks,
@@ -156,7 +157,13 @@ from ankihub.main.utils import (
     note_type_with_updated_templates_and_css,
     retain_nids_with_ah_note_type,
 )
-from ankihub.settings import ANKIWEB_ID, DatadogLogHandler, config, log_file_path
+from ankihub.settings import (
+    ANKIWEB_ID,
+    BehaviorOnRemoteNoteDeleted,
+    DatadogLogHandler,
+    config,
+    log_file_path,
+)
 
 
 @pytest.fixture
@@ -1291,6 +1298,26 @@ class TestAnkiHubDBIntegrityError:
             )
 
 
+class TestAnkiHubDBMissingValueError:
+    def test_getting_note_data_raises_error_when_fields_is_none(
+        self,
+        ankihub_db: _AnkiHubDB,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        ah_did = next_deterministic_uuid()
+        anki_note_id = 1
+        note = NoteInfoFactory.create(anki_note_id=anki_note_id, fields=None)
+        ankihub_db.upsert_notes_data(
+            ankihub_did=ah_did,
+            notes_data=[note],
+        )
+
+        with pytest.raises(MissingValueError) as exception:
+            ankihub_db.note_data(anki_note_id)
+
+        assert exception.ah_did == ah_did
+
+
 class TestAnkiHubDBMediaNamesForAnkiHubDeck:
     @pytest.fixture(autouse=True)
     def setup_method_fixture(
@@ -1619,6 +1646,25 @@ class TestErrorHandling:
         )
         assert handled
         show_tooltip_mock.assert_called_once()
+
+    def test_handle_missing_value_error(self, next_deterministic_uuid):
+        ah_did = next_deterministic_uuid()
+        config.add_deck(
+            ankihub_did=ah_did,
+            # The values here are not important for this test.
+            name="test_deck",
+            anki_did=1,
+            user_relation=UserDeckRelation.SUBSCRIBER,
+            behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+        )
+
+        handled = _try_handle_exception(
+            exc_value=MissingValueError(ah_did=ah_did), tb=None
+        )
+
+        # The exception should be handled, and the deck should be marked for full download.
+        assert handled
+        assert config.deck_config(ah_did).download_full_deck_on_next_sync
 
 
 def test_show_error_dialog(


### PR DESCRIPTION
After adding new fields to note types via the “Publish fields” feature, some users are reporting that fields contents are in the wrong fields.
The cause of the issue is that we are storing the field values as one string with the field values joined by a delimiter. When a new field gets added to the note type, the field values are off.

Related web app PR: https://github.com/AnkiHubSoftware/ankihub/pull/2645

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-100


## Proposed changes
We will start storing the fields as a json dict in the AnkiHubDB. This way, when new fields are added to the note type, we will still be able to tell which field value belongs to which field.
Incorrect values in the DB will be corrected by setting a flag to download the full deck on the next sync for the affected deck.
- Add migration for the AnkiHubDB to convert field values to json dicts
  - When the amount of fields doesn't match up with the amount of field values, `AnkiHubNote.fields` will be set to `None` for this note
    - This will happen for decks where note type fields were added
- Adjust `AnkiHubDB` methods to store and retrieve data in/from the new format (json dict)
  - When `AnkiHubNote.fields` is `None` when retrieving note data from the DB, a `MissingValueError` exception is raised, this will be handled by the error handler (see below)
- Update the code in `ah_db_check.py` to set the `download_full_deck_on_next_sync` flag when values are missing from the deck
- Update code in `deck_updater.py` and `ankihub_client.py` to download the full deck when `download_full_deck_on_next_sync` is set to `True` for the deck
- Update the error handler to handle `MissingValueError` by setting `download_full_deck_on_next_sync=True` for the deck and showing this dialog:
  <img src="https://github.com/user-attachments/assets/708014e4-acf8-41bd-bafd-16db2d740665" width="700" />
  Notes are retrieved from the AnkiHubDB when making suggestions and when resetting local changes, so that's when this dialog can be shown.

In sum, for many users the full deck will be simply re-imported during sync, solving the issues with the wrong field values.
Users that make suggestions for an affected deck will see the dialog shown above. After syncing, the issue will be resolved for them as well.

## How to reproduce
### `MissingValueError`, error dialog, sync
You can open the AnkiHub DB (in a DB browser) and set the `fields` value of a note to `None`.
Then, when you try to make a suggestion for the note, or reset local changes to it, the dialog shown above should open. 
When you sync after that, the whole deck should be downloaded from S3, which fixes the issue of the missing value.

### Migration, ankihub db check, sync
Before running the migration to `schema_version=13`, open the AnkiHub DB (in a DB browser) and modify the fields value of a note so that the amount of fields doesn't match up with the amount of fields of the note type (you can also just delete everything from the field). Then open Anki while on the PR branch. The migration should set the fields value of the modified note to `None`.
Sync with AnkiHub. After the sync (only after the first sync after starting Anki), the DB check will be run (`ah_db_check.py`). The check will set `download_full_deck_on_next_sync=True` for the deck of the note.
Sync with AnkiHub. The sync will download the full deck and fix the issue with the missing fields value.