### PR TITLE
chore: Allow to disable media download using env var

### DIFF
--- a/.envrc.dev
+++ b/.envrc.dev
@@ -3,6 +3,7 @@ export GOOGLE_API_KEY=<CHANGE ME>
 export REPORT_ERRORS=0
 export ANKIHUB_APP_URL=http://localhost:8000
 export S3_BUCKET_URL=https://ankihubbucket.s3.us-east-2.amazonaws.com
+# export DISABLE_MEDIA_DOWNLOAD=1
 export DISABLE_QT5_COMPAT=1
 export QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox"
 export QTWEBENGINE_REMOTE_DEBUGGING=8080

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import datetime
 from functools import cached_property
@@ -39,6 +40,10 @@ class _AnkiHubMediaSync:
         """Download missing media for all subscribed decks from AnkiHub in the background.
         Does nothing if a download is already in progress.
         """
+        if os.getenv("DISABLE_MEDIA_DOWNLOAD", None) == "1":
+            LOGGER.info("Media download disabled, skipping...")
+            return
+
         if self._download_in_progress:
             LOGGER.info("Media download already in progress, skipping...")
             return


### PR DESCRIPTION
During development its sometimes convenient to disable media downloads.
This PR adds an env var to disable them.


## Proposed changes
- Add mechanism to disable media downloads by setting the `DISABLE_MEDIA_DOWNLOADS` env var to `1`
- Add the env var to the `.envc.dev` file