### PR TITLE
[NRT-113] chore: Update staging deck id, make it configurable

### DIFF
--- a/ankihub/config.json
+++ b/ankihub/config.json
@@ -5,6 +5,7 @@
     "auto_sync": "on_ankiweb_sync",
     "debug_level_logs": false,
     "use_staging": false,
+    "staging_anking_deck_id": null,
     "ankihub_ai_chatbot": true,
     "boards_and_beyond_step_1": true,
     "boards_and_beyond_step_2": true,

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -204,7 +204,12 @@ class _Config:
             self.app_url = STAGING_APP_URL
             self.api_url = STAGING_API_URL
             self.s3_bucket_url = STAGING_S3_BUCKET_URL
-            self.anking_deck_id = uuid.UUID("86652268-45a8-4832-bde1-8d9c48e9acc4")
+            if staging_anking_deck_id := self.public_config.get(
+                "staging_anking_deck_id"
+            ):
+                self.anking_deck_id = staging_anking_deck_id
+            else:
+                self.anking_deck_id = uuid.UUID("86652268-45a8-4832-bde1-8d9c48e9acc4")
         else:
             self.app_url = DEFAULT_APP_URL
             self.api_url = DEFAULT_API_URL

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -209,7 +209,7 @@ class _Config:
             ):
                 self.anking_deck_id = staging_anking_deck_id
             else:
-                self.anking_deck_id = uuid.UUID("86652268-45a8-4832-bde1-8d9c48e9acc4")
+                self.anking_deck_id = uuid.UUID("dfe7f548-f66e-4277-932b-c7a63db3223a")
         else:
             self.app_url = DEFAULT_APP_URL
             self.api_url = DEFAULT_API_URL


### PR DESCRIPTION
This PR addresses the need to update the staging deck ID and make it configurable. Currently, the staging environment uses a hardcoded deck ID, which is used when the `use_staging` setting is set to `true`. This PR introduces a change to allow the `staging_anking_deck_id` to be configurable. If a `staging_anking_deck_id` is not provided in the config, it will fallback to a default UUID.
(If the `STAGING_ANKING_DECK_ID` env var is provided, it will take precedence.)

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-113

## Proposed changes
- [Add staging_anking_deck_id to config](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1136/commits/4ad957e0e4ddf271510cb6395b890e980941337f)
- [Update hardcoded staging anking deck id](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1136/commits/01bd72f6505de1de627525a6ed9968473e3d1f42)

## Screenshots

<img src="https://github.com/user-attachments/assets/4e5d4656-104b-44a7-a5cb-cd1afcff0ef8" width="500" />