### PR TITLE
[NRT-103] Drag and drop for file selector in smart search doesn't work consistently

### DIFF
--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -134,6 +134,8 @@ class AnkiHubWebViewDialog(QDialog):
 
     def _load_page(self) -> None:
         self.web.load_url(QUrl(self._get_embed_url()))
+        # Allow drag and drop event
+        self.web.allow_drops = True
         qconnect(self.web.loadFinished, self._on_web_load_finished)
 
     def _on_web_load_finished(self, ok: bool) -> None:


### PR DESCRIPTION
## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes #[NRT-103](https://ankihub.atlassian.net/browse/NRT-103)


## Proposed changes
- Set allow_drops as true to allow drag and drop


## How to reproduce

In Anki Desktop:
- Open the Smart Search
- Click "Files" to search using file

From your file explorer:
- Drag a supported file into the file input area
- Make sure file appears in preview
- Make sure it shows upload confirmation




## Screenshots and videos

https://github.com/user-attachments/assets/5a1af6c9-bad7-4274-b5ce-d094bdae5d0b





[NRT-103]: https://ankihub.atlassian.net/browse/NRT-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ