### PR TITLE
Do not modify user's Learn Ahead Limit

### DIFF
--- a/ankihub/main/deck_options.py
+++ b/ankihub/main/deck_options.py
@@ -100,9 +100,3 @@ def set_ankihub_config_for_deck(deck_id: DeckId) -> None:
     conf = _create_deck_preset_if_not_exists()
     deck["conf"] = conf["id"]
     aqt.mw.col.decks.update(deck)
-
-
-def set_recommended_preferences() -> None:
-    preferences = aqt.mw.col.get_preferences()
-    preferences.scheduling.learn_ahead_secs = 0
-    aqt.mw.col.set_preferences(preferences)

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -29,7 +29,7 @@ from ..settings import (
     is_anking_note_types_addon_installed,
     is_projektanki_note_types_addon_installed,
 )
-from .deck_options import set_ankihub_config_for_deck, set_recommended_preferences
+from .deck_options import set_ankihub_config_for_deck
 from .exceptions import ChangesRequireFullSyncError
 from .note_conversion import (
     TAG_FOR_PROTECTING_ALL_FIELDS,
@@ -165,7 +165,6 @@ class AnkiHubImporter:
             )
             if recommended_deck_settings:
                 set_ankihub_config_for_deck(self._local_did)
-                set_recommended_preferences()
 
         if subdecks or subdecks_for_new_notes_only:
             if subdecks_for_new_notes_only:


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-39

## Proposed changes

The user's Learn Ahead limit was being modified as part of the recommended deck settings offered to the user when installing a new deck. We decided to revert this change after discussions and user complaints.

## How to reproduce

- Go to _Tools > Preferences > Review_ and set the _Learn ahead limit_ option to a non-zero value.
- Install a new AnkiHub deck with the _Use recommended deck settings_ option checked.
- Go back to the preferences screen and confirm the _Learn ahead limit_ option is unchanged.


## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
