### PR TITLE
[NRT-95] Allow passing search string to ankihub_open_browser pycmd, fix smart search theme

### DIFF
--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -83,9 +83,8 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
 
     elif message.startswith(OPEN_BROWSER_PYCMD):
         kwargs = parse_js_message_kwargs(message)
+        search_string = kwargs.get("searchString", "")
         ah_nids = kwargs.get("noteIds", [])
-
-        browser: Browser = aqt.dialogs.open("Browser", aqt.mw)
 
         if ah_nids:
             ah_nids_to_anki_nids = ankihub_db.ankihub_nids_to_anki_nids(ah_nids)
@@ -93,7 +92,9 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
                 anki_nid for anki_nid in ah_nids_to_anki_nids.values() if anki_nid
             ]
             search_string = f"nid:{','.join(map(str, anki_nids))}"
-            browser.search_for(search_string)
+
+        browser: Browser = aqt.dialogs.open("Browser", aqt.mw)
+        browser.search_for(search_string)
 
         return (True, None)
     elif message.startswith(SUSPEND_NOTES_PYCMD):

--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -94,7 +94,8 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
             search_string = f"nid:{','.join(map(str, anki_nids))}"
 
         browser: Browser = aqt.dialogs.open("Browser", aqt.mw)
-        browser.search_for(search_string)
+        if search_string:
+            browser.search_for(search_string)
 
         return (True, None)
     elif message.startswith(SUSPEND_NOTES_PYCMD):


### PR DESCRIPTION
Related web app PR: https://github.com/AnkiHubSoftware/ankihub/pull/2655

This PR adds a `searchString` parameter to the `ankihub_open_browser` pycmd. This allows the web app to pass various search strings to the Anki browser.

It also fixes an issue with the theme of the smart search dialog being off from Anki's theme.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-95


## Proposed changes
- [Allow passing search string to OPEN_BROWSER_PYCMD](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1139/commits/6ed27c82d1b264852564b6b54a1c4a4466f76581)
- [Fix smart search page and dialog theme](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1139/commits/f08b58f74ca57ff83a135d5dd348e02ec8b27989)

## How to reproduce
- Checkout the web app PR: https://github.com/AnkiHubSoftware/ankihub/pull/2655
- Open the smart search dialog from Anki and go to the Study Aids tab
- Select some tags, and select/unselect some results
- Click the "Open in Browser" button

## Screenshots
**Before**
<img src="https://github.com/user-attachments/assets/eec3d353-dd34-4f73-b933-560b29cf2f51" width="500" />

**After**
<img src="https://github.com/user-attachments/assets/8f5c5196-b4cb-4704-bccc-32b66b69619c" width="500" />