### PR TITLE
[ACTV-51] Fix TermsAndConditionsDialog freezing on startup

### DIFF
--- a/ankihub/gui/addons.py
+++ b/ankihub/gui/addons.py
@@ -3,12 +3,11 @@ Handles problems with add-on updates and deletions."""
 from concurrent.futures import Future
 from typing import Any, Callable
 
-import aqt
 from anki.hooks import wrap
 from aqt import addons
 from aqt.addons import DownloaderInstaller
 
-from .. import LOGGER
+from .utils import run_with_delay_when_progress_dialog_is_open
 
 
 def setup_addons():
@@ -61,22 +60,4 @@ def _with_delay_when_progress_dialog_is_open(*args, **kwargs) -> Any:
     _old: Callable = kwargs["_old"]
     del kwargs["_old"]
 
-    def wrapper():
-        LOGGER.info("Calling with_delay_when_progress_dialog_is_open._old")
-        _old(*args, **kwargs)
-
-        # the documentation of aqt.mw.progress.timer says that the timer has to be deleted to
-        # prevent memory leaks
-        timer.deleteLater()
-
-    # aqt.mw.progress.timer is there for creating "Custom timers which avoid firing while a progress dialog is active".
-    # It's better to use a large delay value because there is a 0.5 second time window in which
-    # the func can be called even if the progress dialog is not closed yet.
-    # See https://github.com/ankitects/anki/blob/d9f1e2264804481a2549b23dbc8a530857ad57fc/qt/aqt/progress.py#L261-L277
-    timer = aqt.mw.progress.timer(
-        ms=2000,
-        func=wrapper,
-        repeat=False,
-        requiresCollection=True,
-        parent=aqt.mw,
-    )
+    run_with_delay_when_progress_dialog_is_open(_old, *args, **kwargs)

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -50,6 +50,7 @@ from .operations import AddonQueryOp
 from .utils import (
     ask_user,
     check_and_prompt_for_updates_on_main_window,
+    run_with_delay_when_progress_dialog_is_open,
     show_error_dialog,
     show_tooltip,
 )
@@ -364,7 +365,9 @@ def _maybe_handle_ankihub_http_error(error: AnkiHubHTTPError) -> bool:
             return False
 
         if response_data.get("detail") == TERMS_AGREEMENT_NOT_ACCEPTED_DETAIL:
-            TermsAndConditionsDialog.display(parent=aqt.mw)
+            run_with_delay_when_progress_dialog_is_open(
+                TermsAndConditionsDialog.display, parent=aqt.mw
+            )
             return True
 
     elif response.status_code == 406:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -786,18 +786,12 @@ def run_with_delay_when_progress_dialog_is_open(func: Callable, *args, **kwargs)
         LOGGER.info("Calling with_delay_when_progress_dialog_is_open.func")
         func(*args, **kwargs)
 
-        # the documentation of aqt.mw.progress.timer says that the timer has to be deleted to
-        # prevent memory leaks
-        timer.deleteLater()
-
-    # aqt.mw.progress.timer is there for creating "Custom timers which avoid firing while a progress dialog is active".
+    # aqt.mw.progress.single_shot is for creating "Custom timers which avoid firing while a progress dialog is active".
     # It's better to use a large delay value because there is a 0.5 second time window in which
     # the func can be called even if the progress dialog is not closed yet.
     # See https://github.com/ankitects/anki/blob/d9f1e2264804481a2549b23dbc8a530857ad57fc/qt/aqt/progress.py#L261-L277
-    timer = aqt.mw.progress.timer(
+    aqt.mw.progress.single_shot(
         ms=2000,
         func=wrapper,
-        repeat=False,
-        requiresCollection=True,
-        parent=aqt.mw,
+        requires_collection=True,
     )

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -779,3 +779,25 @@ def get_ah_did_of_deck_or_ancestor_deck(anki_did: DeckId) -> Optional[uuid.UUID]
 
 def logged_into_ankiweb() -> bool:
     return bool(aqt.mw.pm.sync_auth())
+
+
+def run_with_delay_when_progress_dialog_is_open(func: Callable, *args, **kwargs) -> Any:
+    def wrapper():
+        LOGGER.info("Calling with_delay_when_progress_dialog_is_open.func")
+        func(*args, **kwargs)
+
+        # the documentation of aqt.mw.progress.timer says that the timer has to be deleted to
+        # prevent memory leaks
+        timer.deleteLater()
+
+    # aqt.mw.progress.timer is there for creating "Custom timers which avoid firing while a progress dialog is active".
+    # It's better to use a large delay value because there is a 0.5 second time window in which
+    # the func can be called even if the progress dialog is not closed yet.
+    # See https://github.com/ankitects/anki/blob/d9f1e2264804481a2549b23dbc8a530857ad57fc/qt/aqt/progress.py#L261-L277
+    timer = aqt.mw.progress.timer(
+        ms=2000,
+        func=wrapper,
+        repeat=False,
+        requiresCollection=True,
+        parent=aqt.mw,
+    )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,6 @@ requests-mock==1.9.3
 types-requests==2.28.9
 urllib3==1.26.14
 typeguard==2.13.3
-pdbpp==0.10.3
 vcrpy==4.2.0
 pytest==8.2.2
 pytest-vcr==1.0.2


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-51


## Proposed changes

This wraps TermsAndConditionsDialog.display() call possibly ran on startup with Anki's `aqt.mw.progress.single_shot()` utility function. This delays the execution of the call while ensuring it doesn't trigger while a progress dialog is shown, which commonly causes app freezes (especially on macOS it appears).

## How to reproduce

Unfortunately we've not found a reliable way to trigger the issue yet, but you can increase the possibility of it occurring by running Anki with an AnkiWeb account with autosync enabled and a lot of changes to sync.
