### PR TITLE
[ACTV-56] Fix intermittent sidebar logout issue

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -138,7 +138,9 @@ class ReviewerSidebar:
 
         self.interceptor = AuthenticationRequestInterceptor(self.content_webview)
 
-        page = CustomWebPage(self.profile, self.content_webview._onBridgeCmd)
+        page = CustomWebPage(
+            self.content_webview, self.profile, self.content_webview._onBridgeCmd
+        )
         page.profile().setUrlRequestInterceptor(self.interceptor)
         # Prevent white flicker on dark mode
         page.setBackgroundColor(theme_manager.qcolor(colors.CANVAS))

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -11,6 +11,7 @@ from aqt.qt import (
     QUrl,
     QVBoxLayout,
     QWebEngineUrlRequestInterceptor,
+    QWidget,
     qconnect,
 )
 from aqt.theme import theme_manager
@@ -210,8 +211,13 @@ class CustomWebPage(AnkiWebPage):
     AnkiWebPage which grants the `Notifications` feature permission.
     """
 
-    def __init__(self, profile: QWebEngineProfile, onBridgeCmd: Callable[[str], Any]):
-        QWebEnginePage.__init__(self, profile, None)
+    def __init__(
+        self,
+        parent: QWidget,
+        profile: QWebEngineProfile,
+        onBridgeCmd: Callable[[str], Any],
+    ):
+        QWebEnginePage.__init__(self, profile, parent)
         self._onBridgeCmd = onBridgeCmd
         self._setupBridge()
         self.open_links_externally = False


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-56


## Proposed changes

This PR just sets a parent widget for `CustomWebPage` so it doesn't garbage collected, which was causing users to be logged out of AnkiHub in the sidebar (due to `AuthenticationRequestInterceptor` no longer running).

## How to reproduce

To reproduce the issue before this PR:
1. Open the sidebar and confirm you're logged in.
2. Close the sidebar, open [Anki's debug console](https://docs.ankiweb.net/misc.html#debug-console) and run `mw.garbage_collect_now()`.
3. Open the sidebar and notice you're prompted to log in.
4. Repeat the same steps after checking in this PR and confirm you're still logged in.

## Screenshots and videos

See video attached to JIRA issue.


