### PR TITLE
chore: Install the `libxcb-cursor-dev` package in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     libxi6 \
     libxkbcommon-x11-0 \
     libxkbcommon0 \
+    libxcb-cursor-dev \
     libxkbfile1	\
     libxrandr2 \
     libxrender1 \


### PR DESCRIPTION
## Proposed changes

This just adds the `libxcb-cursor-dev` package to the list of installed packages in the dev container as it appears to be required in recent Anki versions.

## How to reproduce

I was getting this error while trying to run Anki in GitHub Codespaces:
```
xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin
```

Installing `libxcb-cursor-dev` fixed the issue and made Anki run normally.

You can confirm that by running this PR in a new codespace.
