### PR TITLE
[NRT-153] fix: NoneTypeError in ah_db_check.py

### DIFF
--- a/ankihub/gui/operations/db_check/ah_db_check.py
+++ b/ankihub/gui/operations/db_check/ah_db_check.py
@@ -16,7 +16,8 @@ def check_ankihub_db(on_success: Optional[Callable[[], None]] = None) -> None:
 
     ah_dids_with_missing_values = ankihub_db.ankihub_dids_of_decks_with_missing_values()
     for ah_did in ah_dids_with_missing_values:
-        config.set_download_full_deck_on_next_sync(ah_did, True)
+        if ah_did in config.deck_ids():
+            config.set_download_full_deck_on_next_sync(ah_did, True)
 
     if not _try_reinstall_decks_with_missing_deck_configs(on_success=on_success):
         on_success()


### PR DESCRIPTION
This PR fixes a `NoneTypeError` in the `ah_db_check.py` file.

Sentry: https://ankihub.sentry.io/issues/5375216652/?project=6546414&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=freq&stream_index=6

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-1102


## Proposed changes
- Check if the deck is in the private config before trying to set a config setting to avoid the `NoneTypeError` 
