### PR TITLE
Fix client tests on CI

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -400,17 +400,6 @@ def _remove_generated_media_files():
 
 
 @pytest.mark.vcr()
-def test_client_login_and_signout_with_username(client_with_server_setup):
-    credentials_data = {"username": "test1", "password": "asdf"}
-    token = client_with_server_setup.login(credentials=credentials_data)
-    assert len(token) == 64
-    assert client_with_server_setup.token == token
-
-    client_with_server_setup.signout()
-    assert client_with_server_setup.token is None
-
-
-@pytest.mark.vcr()
 def test_client_login_and_signout_with_email(client_with_server_setup):
     credentials_data = {"email": "test1@email.com", "password": "asdf"}
     token = client_with_server_setup.login(credentials=credentials_data)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -175,7 +175,7 @@ def _wait_for_server(api_url: str, timeout: float = 30.0, interval: float = 0.5)
         except requests.exceptions.RequestException:
             pass
         time.sleep(interval)
-    pytest.skip(f"Could not connect to {api_url} after {timeout:.0f}s")
+    pytest.fail(f"Could not connect to {api_url} after {timeout:.0f}s")
 
 
 def is_playback_mode(vcr: VCR, request: FixtureRequest) -> bool:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -421,6 +421,17 @@ def _remove_generated_media_files():
 
 
 @pytest.mark.vcr()
+def test_client_login_and_signout_with_username(client_with_server_setup):
+    credentials_data = {"username": "test1", "password": "asdf"}
+    token = client_with_server_setup.login(credentials=credentials_data)
+    assert len(token) == 64
+    assert client_with_server_setup.token == token
+
+    client_with_server_setup.signout()
+    assert client_with_server_setup.token is None
+
+
+@pytest.mark.vcr()
 def test_client_login_and_signout_with_email(client_with_server_setup):
     credentials_data = {"email": "test1@email.com", "password": "asdf"}
     token = client_with_server_setup.login(credentials=credentials_data)


### PR DESCRIPTION
This PR fixes client tests on CI by waiting for the server to become responsive before running a test.
