### PR TITLE
[NRT-172] Fix issues with new smart search buttons

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -30,7 +30,7 @@ from aqt.gui_hooks import (
     browser_will_show_context_menu,
     dialog_manager_did_open_dialog,
 )
-from aqt.qt import QAction, QMenu, QSize, Qt, QToolButton, QWidget, qconnect
+from aqt.qt import QAction, QMenu, QSize, Qt, QToolBar, QToolButton, QWidget, qconnect
 from aqt.theme import theme_manager
 from aqt.utils import showInfo, showWarning, tooltip, tr
 
@@ -945,12 +945,23 @@ def add_smart_search_button_to_sidebar():
     if not config.public_config.get("ankihub_smart_search"):
         return
 
+    # We wrap the smart search button in a toolbar so that it doesn't show a frame on MacOS
+    smart_search_button_toolbar = QToolBar()
+    smart_search_button_toolbar.setIconSize(QSize(16, 16))
+    smart_search_button_toolbar.setMovable(False)
+    smart_search_button_toolbar.setFloatable(False)
+    smart_search_button_toolbar.setStyleSheet(
+        "QToolBar { border: none; padding: 0px; }"
+    )
+
     smart_search_button = QToolButton()
     smart_search_button.setIcon(sparkles_icon(theme_manager.night_mode))
     smart_search_button.setIconSize(QSize(16, 16))
     smart_search_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
     smart_search_button.setAutoRaise(True)
     smart_search_button.setToolTip("AnkiHub Smart Search")
+
+    smart_search_button_toolbar.addWidget(smart_search_button)
 
     def on_deck_selected(dialog: SearchableSelectionDialog) -> None:
         if not dialog.name:
@@ -981,7 +992,7 @@ def add_smart_search_button_to_sidebar():
     qconnect(smart_search_button.clicked, on_smart_search_button_clicked)
 
     grid = browser.sidebarDockWidget.widget().layout()
-    grid.addWidget(smart_search_button, 0, 3)  # type: ignore
+    grid.addWidget(smart_search_button_toolbar, 0, 3)  # type: ignore
 
     # Make sidebar span 4 columns so that it includes the smart search button column
     grid.removeWidget(browser.sidebar)

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -8,6 +8,7 @@ import aqt
 from anki.collection import SearchNode
 from anki.hooks import wrap
 from anki.notes import NoteId
+from anki.utils import is_mac
 from aqt.addcards import AddCards
 from aqt.browser import (
     Browser,
@@ -953,6 +954,8 @@ def add_smart_search_button_to_sidebar():
     smart_search_button_toolbar.setStyleSheet(
         "QToolBar { border: none; padding: 0px; }"
     )
+    if is_mac:
+        smart_search_button_toolbar.setContentsMargins(0, 0, 5, 0)
 
     smart_search_button = QToolButton()
     smart_search_button.setIcon(sparkles_icon(theme_manager.night_mode))

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -946,6 +946,14 @@ def add_smart_search_button_to_sidebar():
     if not config.public_config.get("ankihub_smart_search"):
         return
 
+    def names_of_decks_with_note_embeddings() -> List[str]:
+        names = [
+            deck_config.name
+            for ah_did in config.deck_ids()
+            if (deck_config := config.deck_config(ah_did)).has_note_embeddings
+        ]
+        return list(sorted(names))
+
     # We wrap the smart search button in a toolbar so that it doesn't show a frame on MacOS
     smart_search_button_toolbar = QToolBar()
     smart_search_button_toolbar.setIconSize(QSize(16, 16))
@@ -955,7 +963,7 @@ def add_smart_search_button_to_sidebar():
         "QToolBar { border: none; padding: 0px; }"
     )
     if is_mac:
-        smart_search_button_toolbar.setContentsMargins(0, 0, 5, 0)
+        smart_search_button_toolbar.setContentsMargins(0, 0, 8, 0)
 
     smart_search_button = QToolButton()
     smart_search_button.setIcon(sparkles_icon(theme_manager.night_mode))
@@ -963,6 +971,12 @@ def add_smart_search_button_to_sidebar():
     smart_search_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
     smart_search_button.setAutoRaise(True)
     smart_search_button.setToolTip("AnkiHub Smart Search")
+
+    if not names_of_decks_with_note_embeddings():
+        smart_search_button.setEnabled(False)
+        smart_search_button.setToolTip(
+            "No installed AnkiHub decks support Smart Search"
+        )
 
     smart_search_button_toolbar.addWidget(smart_search_button)
 
@@ -973,14 +987,6 @@ def add_smart_search_button_to_sidebar():
         aqt.mw.taskman.run_on_main(
             lambda: show_flashcard_selector(ah_did=ah_did, parent=browser)
         )
-
-    def names_of_decks_with_note_embeddings() -> List[str]:
-        names = [
-            deck_config.name
-            for ah_did in config.deck_ids()
-            if (deck_config := config.deck_config(ah_did)).has_note_embeddings
-        ]
-        return list(sorted(names))
 
     def on_smart_search_button_clicked() -> None:
         SearchableSelectionDialog(

--- a/ankihub/gui/config_dialog.py
+++ b/ankihub/gui/config_dialog.py
@@ -57,7 +57,7 @@ def _general_tab(conf_window) -> None:
     tab.space(8)
 
     if config.get_feature_flags().get("mh_integration"):
-        tab.text("Sidebar", bold=True)
+        tab.text("Feature Preferences", bold=True)
         tab.checkbox("ankihub_smart_search", "AnkiHub Smart Search")
         tab.checkbox("ankihub_ai_chatbot", "AnkiHub AI Chatbot")
 

--- a/ankihub/gui/flashcard_selector_dialog.py
+++ b/ankihub/gui/flashcard_selector_dialog.py
@@ -35,7 +35,7 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
         """Display the flashcard selector dialog for the given deck.
         Reuses the dialog if it is already open for the same deck.
         Otherwise, closes the existing dialog and opens a new one."""
-        if cls.dialog and cls.dialog.ah_did != ah_did:
+        if cls.dialog and cls.dialog.ah_did != ah_did and not sip.isdeleted(cls.dialog):
             cls.dialog.close()
             cls.dialog = None
 

--- a/ankihub/gui/overview.py
+++ b/ankihub/gui/overview.py
@@ -58,7 +58,8 @@ def _maybe_add_flashcard_selector_button() -> None:
         return
     ah_did = get_ah_did_of_deck_or_ancestor_deck(aqt.mw.col.decks.current()["id"])
     if (
-        not config.deck_config(ah_did)
+        not config.public_config.get("ankihub_smart_search")
+        or not config.deck_config(ah_did)
         or not config.deck_config(ah_did).has_note_embeddings
     ):
         return


### PR DESCRIPTION
This fixes the issue found during QA for the new smart search buttons: https://ankihub.atlassian.net/browse/NRT-145?focusedCommentId=19899

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-172

## Proposed changes
- [Update config dialog section label](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/5527e7ee0caf41adcd72a5804bdac70e97dee738)
- [Fix button frame showing on MacOS](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/4e31a967bdf977413302135e543c53ead93dad34)
- [Add margin to browser button on mac](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/67a03f8a80b73511403e876a78ede889d38ee7be)
- [Fix error because of deleted dialog](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/31b5501eb882b0ea340f6e295b14e5c51365b0ef)
- [Don't show button on overview when smart search disabled in config](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/bef2769013fee1533e1fc1c64fbc5681acc807dd)
- [Disable browser button when no relevant decks present](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1147/commits/888483b4f5821f1186371142fb7e87606b7b1630)