### PR TITLE
[NRT-181] Only show smart search button in browser if feature flag is enabled

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -943,6 +943,9 @@ def _on_dialog_manager_did_open_dialog(
 
 
 def add_smart_search_button_to_sidebar():
+    if not config.get_feature_flags().get("show_flashcards_selector_button", False):
+        return
+
     if not config.public_config.get("ankihub_smart_search"):
         return
 


### PR DESCRIPTION
We forgot to add a feature flag check when adding the smart search button to the browser sidebar. This PR adds the feature flag check.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-181


## Proposed changes
- Add the feature flag check
 - It uses the same feature flag as for showing the smart search button in the deck overview:
   https://github.com/AnkiHubSoftware/ankihub_addon/blob/b9128cff321bde6b2b44652c19e46803611fdce1/ankihub/gui/overview.py#L68