### PR TITLE
fix: Set page parent in TermsAndConditionsDialog

### DIFF
--- a/ankihub/gui/terms_dialog.py
+++ b/ankihub/gui/terms_dialog.py
@@ -22,7 +22,7 @@ class TermsAndConditionsDialog(QDialog):
         self.web = AnkiWebView(parent=self)
         self.web.set_open_links_externally(False)
         self.interceptor = AuthenticationRequestInterceptor(self.web)
-        page = AnkiWebPage(self.web._onBridgeCmd)
+        page = AnkiWebPage(self.web._onBridgeCmd, parent=self)
         page.open_links_externally = False
         self.web.setPage(page)
         self.web.page().profile().setUrlRequestInterceptor(self.interceptor)


### PR DESCRIPTION

## Proposed changes

This just sets a parent widget for AnkiWebPage in TermsAndConditionsDialog. I found the page is garbage collected when `mw.garbage_collect_now()` is called (called periodically by Anki). This is probably not an issue considering that the dialog normally only shows for a short period of time, but it's good for safety.


