### PR TITLE
[NRT-185] Improve logic for identifying previously existing decks during import

### DIFF
--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -690,7 +690,7 @@ class AnkiHubImporter:
                 dids_cards_were_imported_into, created_did
             )
 
-    def _get_existing_anking_deck_id(self, created_did) -> Optional[DeckId]:
+    def _get_existing_anking_deck_id(self, created_did: DeckId) -> Optional[DeckId]:
         """Find an existing AnKing deck based on the deck name and the number of AnKing cards in it."""
         # The candidates are all decks with "anking" in the name which aren't descendants of each other,
         # and aren't the deck that was just created.

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -749,6 +749,9 @@ class AnkiHubImporter:
         }
 
         dids_without_created = dids_cards_were_imported_into - set([created_did])
+        if not dids_without_created:
+            return None
+
         common_ancestor_did = lowest_level_common_ancestor_did(dids_without_created)
         return common_ancestor_did
 

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -107,12 +107,23 @@ def lowest_level_common_ancestor_deck_name(deck_names: Iterable[str]) -> Optiona
         return result
 
 
-def dids_of_notes(notes: List[Note]) -> Set[DeckId]:
-    result: Set[DeckId] = set()
-    for note in notes:
-        dids_for_note = set(c.did for c in note.cards())
-        result |= dids_for_note
-    return result
+def get_original_dids_for_nids(nids: List[NoteId]) -> Set[DeckId]:
+    """Get the original deck IDs for the given note IDs.
+
+    Returns the original deck ID (odid) if the card is in a filtered deck,
+    otherwise returns the current deck ID (did).
+    """
+    query_results = aqt.mw.col.db.list(
+        f"""
+        SELECT DISTINCT CASE
+            WHEN odid != 0 THEN odid
+            ELSE did
+        END as deck_id
+        FROM cards
+        WHERE nid IN {ids2str(nids)}
+        """
+    )
+    return {DeckId(did) for did in query_results}
 
 
 def get_unique_ankihub_deck_name(deck_name: str) -> str:

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -131,6 +131,31 @@ def highest_level_did(dids: Iterable[DeckId]) -> DeckId:
     return min(dids, key=lambda did: aqt.mw.col.decks.name(did).count("::"))
 
 
+def exclude_descendant_decks(deck_ids: List[DeckId]) -> List[DeckId]:
+    """Return only deck IDs that are not descendants of other decks in the list.
+
+    These decks may still be children of other decks outside this list, but within
+    the provided list, they have no ancestors.
+
+    Args:
+        deck_ids: List of deck IDs to filter
+
+    Returns:
+        List of deck IDs that are not children/descendants of any other deck in the input list
+    """
+    deck_id_set = set(deck_ids)
+    independent_dids = []
+
+    for did in deck_ids:
+        parent_ids = [deck["id"] for deck in aqt.mw.col.decks.parents(did)]
+        # Check if any parent is in our original list
+        has_parent_in_list = any(pid in deck_id_set for pid in parent_ids)
+        if not has_parent_in_list:
+            independent_dids.append(did)
+
+    return independent_dids
+
+
 def note_types_with_ankihub_id_field() -> List[NotetypeId]:
     return [
         mid

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -390,6 +390,8 @@ def add_anki_note() -> AddAnkiNote:
             aqt.mw.col.db.execute(
                 f"UPDATE cards SET nid = {anki_nid} WHERE nid = {note.id};"
             )
+            note = aqt.mw.col.get_note(NoteId(anki_nid))
+
         return note
 
     return add_note_inner


### PR DESCRIPTION
Refine the logic in `AnkiHubImporter`  so that it auto-selects the correct existing AnKing deck more often.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-185

## Proposed changes
- Update `AnkiHubImporter._cleanup_first_time_deck_import` to merge the newly created AnKing deck into an existing deck if it:
  - has "anking" in its name (case-insensitive)
  - had 1000+ AnKing cards in it
  - is the only such deck
- Refactor code for finding existing deck for other decks (non-AnKing)
  - Previously `AnkiHubImporter.import_notes()`  returned the dids the notes were imported into. Now `import_notes()` returns `None` and we are querying for the deck ids in `_get_existing_regular_deck_id()`

## How to reproduce
- Unsubscribe from AnKing deck
- Make sure the AnKing deck in the Anki collection has "anking" in its name (case-insensitively)
- Subscribe to the AnKing deck
- Sync with AnkiHub
- The installed deck should be merged into the existing AnKing deck, because the requirements are met

You can try the same with the local deck not having "anking" in the name, then a separate deck should be created