### PR TITLE
[ACTV-95] Fix Upload Logs getting stuck in case of errors

### DIFF
--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -114,6 +114,7 @@ def upload_logs_in_background(
         )
         .failure(_on_upload_logs_failure)
         .without_collection()
+        .with_progress("Uploading logs...")
     )
     aqt.mw.taskman.run_on_main(op.run_in_background)
 
@@ -139,6 +140,7 @@ def upload_logs_and_data_in_background(
         )
         .failure(_on_upload_logs_failure)
         .without_collection()
+        .with_progress("Uploading logs and data...")
     )
     aqt.mw.taskman.run_on_main(op.run_in_background)
 

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -234,12 +234,18 @@ def _setup_excepthook():
     sys.excepthook = excepthook
 
 
+def _show_feedback_dialog(
+    exception: BaseException, sentry_event_id: Optional[str] = None
+) -> None:
+    ErrorDialog(exception, sentry_event_id=sentry_event_id).exec()
+
+
 def _show_feedback_dialog_and_maybe_report_exception(exception: BaseException) -> None:
     sentry_event_id: Optional[str] = None
     if _error_reporting_enabled():
         sentry_event_id = report_exception_and_upload_logs(exception=exception)
 
-    ErrorDialog(exception, sentry_event_id=sentry_event_id).exec()
+    _show_feedback_dialog(exception=exception, sentry_event_id=sentry_event_id)
 
 
 def _try_handle_exception(
@@ -631,12 +637,15 @@ def _upload_logs(key: str) -> str:
 
 
 def _on_upload_logs_failure(exc: Exception) -> None:
+    sentry_id: Optional[str] = None
     if isinstance(exc, AnkiHubHTTPError):
         # Don't report outdated client errors that happen when uploading logs,
         # because they are handled by the add-on when they happen in other places
         # and we don't want to see them in Sentry.
         if exc.response.status_code == 401 or exc.response.status_code == 406:
             return
-        _report_exception(exc)
+        sentry_id = _report_exception(exc)
     else:
-        _report_exception(exc)
+        sentry_id = _report_exception(exc)
+
+    _show_feedback_dialog(exception=exc, sentry_event_id=sentry_id)

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -290,7 +290,6 @@ def _upload_logs_action() -> None:
     ):
         return
 
-    aqt.mw.progress.start(label="Uploading logs...", parent=aqt.mw, immediate=True)
     upload_logs_in_background(on_done=_on_logs_uploaded, hide_username=True)
 
 
@@ -301,9 +300,6 @@ def _upload_logs_and_data_action() -> None:
     ):
         return
 
-    aqt.mw.progress.start(
-        label="Uploading logs and data...", parent=aqt.mw, immediate=True
-    )
     upload_logs_and_data_in_background(on_done=_on_logs_uploaded)
 
 


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-95


## Proposed changes

This fixes the Upload Logs functions getting stuck on the progress dialog if an exception is thrown.


## How to reproduce

To reproduce the freeze issue _before_ this PR:
1. Disconnect from the internet.
2. Use _AnkiHub > Help > Upload logs_ and notice it's stuck forever.

After this PR you should immediately see an error dialog instead.
