### PR TITLE
[NRT-212] Update the Import Summary dialog

### DIFF
--- a/ankihub/gui/messages/templates/deck_import_summary.html
+++ b/ankihub/gui/messages/templates/deck_import_summary.html
@@ -1,28 +1,116 @@
-{% if ankihub_deck_names|length > 1 %}
-Your AnkiHub decks are ready to study!
+{# Categorize decks into different scenarios #}
+{% set new_decks = [] %}
+{% set merged_same_name = [] %}
+{% set merged_different_name = [] %}
+
+{% for i in range(ankihub_deck_names|length) %}
+    {% if not import_results[i].merged_with_existing_deck %}
+        {% set _ = new_decks.append(ankihub_deck_names[i]) %}
+    {% elif ankihub_deck_names[i] == anki_deck_names[i] %}
+        {% set _ = merged_same_name.append(ankihub_deck_names[i]) %}
+    {% else %}
+        {% set _ = merged_different_name.append({'ankihub': ankihub_deck_names[i], 'anki': anki_deck_names[i]}) %}
+    {% endif %}
+{% endfor %}
+
+{#-------------------------------
+   Shared list‑style helpers
+-------------------------------#}
+{% set outer_ul_style  = "-qt-list-indent:1; margin:0 0 10px -18px; padding-left:0; list-style-position:inside;" %}
+{% set inner_ul_style  = "-qt-list-indent:1; margin:5px 0 10px 30px; padding:0; list-style-position:inside;" %}
+{% set single_ul_style = "-qt-list-indent:1; margin:0 0 0 -18px; padding-left:0; list-style-position:inside;" %}
+
+{# Handle single‑deck scenarios #}
+{% if ankihub_deck_names|length == 1 %}
+    {% if new_decks %}
+        <p>The deck <b>{{ new_decks[0] }}</b> is ready to study.</p>
+    {% elif merged_same_name %}
+        <p>You already have the deck <b>{{ merged_same_name[0] }}</b>! We've merged the new deck into the existing one.</p>
+    {% elif merged_different_name %}
+        <p>
+            <b>{{ merged_different_name[0].ankihub }}</b> was merged into <b>{{ merged_different_name[0].anki }}</b> due to overlapping content.
+            &nbsp;All your notes are now in one place.
+        </p>
+    {% endif %}
 {% else %}
-Your AnkiHub deck is ready to study!
-{% endif %}
-<br>
+    {#---------------------------
+       Multiple‑deck scenarios
+    ---------------------------#}
+    {% if new_decks|length == ankihub_deck_names|length %}
+        <p>The following decks are ready to study:</p>
+        <ul style="{{ single_ul_style }}">
+        {% for deck in new_decks %}
+            <li><b>{{ deck }}</b></li>
+        {% endfor %}
+        </ul>
 
+    {% elif merged_same_name|length == ankihub_deck_names|length %}
+        <p>New decks were merged into existing decks with matching names:</p>
+        <ul style="{{ single_ul_style }}">
+        {% for deck in merged_same_name %}
+            <li><b>{{ deck }}</b></li>
+        {% endfor %}
+        </ul>
+
+    {% elif merged_different_name|length == ankihub_deck_names|length %}
+        <p>
+            Some of the decks you subscribed to matched ones you already had.<br>
+            We've merged them to avoid duplicates:
+        </p>
+        <ul style="{{ single_ul_style }}">
+        {% for mapping in merged_different_name %}
+            <li><b>{{ mapping.ankihub }}</b> → <b>{{ mapping.anki }}</b></li>
+        {% endfor %}
+        </ul>
+
+    {% else %}
+        <p><b>Success!</b> Your decks are ready:</p>
+
+        <ul style="{{ outer_ul_style }}">
+          {% if new_decks %}
+          <li>
+            New deck(s) created ({{ new_decks|length }} deck{% if new_decks|length > 1 %}s{% endif %}):
+            <ul style="{{ inner_ul_style }}">
+              {% for deck in new_decks %}
+              <li><b>{{ deck }}</b></li>
+              {% endfor %}
+            </ul>
+          </li>
+          {% endif %}
+
+          {% if merged_same_name %}
+          <li>
+            Merged into existing deck(s) with matching names ({{ merged_same_name|length }} deck{% if merged_same_name|length > 1 %}s{% endif %}):
+            <ul style="{{ inner_ul_style }}">
+              {% for deck in merged_same_name %}
+              <li><b>{{ deck }}</b></li>
+              {% endfor %}
+            </ul>
+          </li>
+          {% endif %}
+
+          {% if merged_different_name %}
+          <li>
+            Merged into existing deck(s) due to overlapping content ({{ merged_different_name|length }} deck{% if merged_different_name|length > 1 %}s{% endif %}):
+            <ul style="{{ inner_ul_style }}">
+              {% for mapping in merged_different_name %}
+              <li><b>{{ mapping.ankihub }}</b> → <b>{{ mapping.anki }}</b></li>
+              {% endfor %}
+            </ul>
+          </li>
+          {% endif %}
+        </ul>
+    {% endif %}
+{% endif %}
+
+{# AnkiWeb sync warning – appears at the end for all scenarios #}
 {% if logged_to_ankiweb %}
-To access your decks on other devices, you’ll need to go to those devices and sync.
-If prompted, choose <b>Download from AnkiWeb</b>.
-<br>
+<p style="margin-top:12px;">⚠️ To access decks on other devices, go to those devices, sync, and choose <b>Download from AnkiWeb</b> if prompted.</p>
 {% endif %}
 
-{% for ankihub_deck_name, anki_deck_name, import_result in zip(ankihub_deck_names, anki_deck_names, import_results) %}
-{% if ankihub_deck_name != anki_deck_name %}
-The deck <b>{{ankihub_deck_name}}</b> was imported as <b>{{anki_deck_name}}</b>.<br>
-<br>
-{% endif %}
-
-{% if import_result.skipped_nids %}
-Notes in the deck <b>{{ankihub_deck_name}}</b> with the same ID as notes in another AnkiHub deck you have installed were skipped.<br>
-If you have any questions about this, see <a
-    href='https://community.ankihub.net/t/draft-why-are-notes-skipped-after-subscribing-to-a-deck/934'>this forum
-    topic</a> for details.
-<br>
-{% endif %}
-
+{# Handle skipped‑notes warnings #}
+{% for ankihub_deck_name, import_result in zip(ankihub_deck_names, import_results) %}
+    {% if import_result.skipped_nids %}
+        <p style="margin-top:12px;">⚠️ Some notes in <b>{{ ankihub_deck_name }}</b> were skipped because they have the same ID as notes in another AnkiHub deck. See <a href='https://community.ankihub.net/t/draft-why-are-notes-skipped-after-subscribing-to-a-deck/934'>this forum topic</a> for details.</p>
+    {% endif %}
 {% endfor %}

--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -168,6 +168,7 @@ def _show_deck_import_summary_dialog_inner(
         default_button_idx=1,
         scrollable=True,
         callback=on_button_clicked,
+        use_show=True,
     )
 
 

--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -106,7 +106,7 @@ def _on_install_done(
         if deck_contains_subdeck_tags(ah_did):
             build_subdecks_and_move_cards_to_them_in_background(ah_did)
 
-    _show_deck_import_summary_dialog_inner(import_results)
+    _show_deck_import_summary_dialog(import_results)
 
     on_done(future_with_result(None))
 
@@ -136,7 +136,7 @@ def _show_deck_import_summary_dialog(
         aqt.mw.col.decks.name(config.deck_config(ah_did).anki_id)
         for ah_did in ankihub_dids
     ]
-    _show_deck_import_summary_dialog(
+    _show_deck_import_summary_dialog_inner(
         ankihub_deck_names=ankihub_deck_names,
         anki_deck_names=anki_deck_names,
         import_results=import_results,

--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -31,12 +31,7 @@ from ...settings import (
 from ..exceptions import DeckDownloadAndInstallError, RemoteDeckNotFoundError
 from ..media_sync import media_sync
 from ..messages import messages
-from ..utils import (
-    deck_download_progress_cb,
-    logged_into_ankiweb,
-    show_dialog,
-    tooltip_icon,
-)
+from ..utils import deck_download_progress_cb, logged_into_ankiweb, show_dialog
 from .subdecks import build_subdecks_and_move_cards_to_them_in_background
 from .utils import future_with_result, pass_exceptions_to_on_done
 
@@ -111,7 +106,7 @@ def _on_install_done(
         if deck_contains_subdeck_tags(ah_did):
             build_subdecks_and_move_cards_to_them_in_background(ah_did)
 
-    _show_deck_import_summary_dialog(import_results)
+    _show_deck_import_summary_dialog_inner(import_results)
 
     on_done(future_with_result(None))
 
@@ -141,6 +136,18 @@ def _show_deck_import_summary_dialog(
         aqt.mw.col.decks.name(config.deck_config(ah_did).anki_id)
         for ah_did in ankihub_dids
     ]
+    _show_deck_import_summary_dialog(
+        ankihub_deck_names=ankihub_deck_names,
+        anki_deck_names=anki_deck_names,
+        import_results=import_results,
+    )
+
+
+def _show_deck_import_summary_dialog_inner(
+    ankihub_deck_names: List[str],
+    anki_deck_names: List[str],
+    import_results: List[AnkiHubImportResult],
+) -> None:
     message = messages.deck_import_summary(
         ankihub_deck_names=ankihub_deck_names,
         anki_deck_names=anki_deck_names,
@@ -160,7 +167,6 @@ def _show_deck_import_summary_dialog(
         buttons=["Go to Deck Management", QDialogButtonBox.StandardButton.Ok],
         default_button_idx=1,
         scrollable=True,
-        icon=tooltip_icon(),
         callback=on_button_clicked,
     )
 

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -455,6 +455,7 @@ def show_dialog(
     scrollable: bool = False,
     callback: Optional[Callable[[int], None]] = None,
     icon: Optional[QIcon] = None,
+    use_show: bool = False,
     open_dialog: bool = True,
     add_title_to_body_on_mac: bool = True,
     checkbox: Optional[QCheckBox] = None,
@@ -467,7 +468,7 @@ def show_dialog(
     # MacOS has dialogs without a title bar when using .open(). They have title bars when using .show().
     # The .strip() is used because some callers pass " " as title to avoid the default title "AnkiHub",
     # in this case we don't want to add the title to the text.
-    if is_mac and title.strip() and add_title_to_body_on_mac:
+    if not use_show and is_mac and title.strip() and add_title_to_body_on_mac:
         if text_format == Qt.TextFormat.PlainText:
             text = f"{title}\n\n{text}"
         else:
@@ -487,7 +488,9 @@ def show_dialog(
         checkbox=checkbox,
     )
 
-    if open_dialog:
+    if use_show:
+        dialog.show()
+    elif open_dialog:
         dialog.open()
 
     return dialog

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -649,6 +649,7 @@ class AnkiHubImporter:
             LOGGER.info(
                 "Moved new cards to existing deck.",
                 existing_deck_did=existing_deck_id,
+                is_anking_deck=self._ankihub_did == config.anking_deck_id,
             )
 
             if created_did != existing_deck_id:
@@ -656,6 +657,12 @@ class AnkiHubImporter:
                 LOGGER.info("Removed created deck.", created_did=created_did)
 
             return existing_deck_id
+        else:
+            LOGGER.info(
+                "No existing deck found, keeping the newly created deck.",
+                created_did=created_did,
+                is_anking_deck=self._ankihub_did == config.anking_deck_id,
+            )
 
         return created_did
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3360,7 +3360,8 @@ class TestAddNoteTypeFields:
 class TestDeckImportSummaryDialog:
     """Test suite for deck import summary dialog scenarios."""
 
-    wait = 5000
+    # Set to x to wait x milliseconds after showing the dialog - useful to look at the dialog
+    wait = None
 
     @pytest.fixture
     def mock_dependencies(self, mocker: MockerFixture) -> Dict[str, Any]:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3471,12 +3471,10 @@ class TestDeckImportSummaryDialog:
 
         message = self.get_dialog_message(mock_dependencies)
         assert (
-            "The deck <b>MCAT Biology</b> was merged into <b>My Custom Biology Deck</b>"
+            "<b>MCAT Biology</b> was merged into <b>My Custom Biology Deck</b>"
             in message
         )
         assert "due to overlapping content" in message
-
-        # qtbot.wait(1000000)
 
     def test_multiple_decks_all_created(
         self, mock_dependencies: Dict[str, Any], qtbot: QtBot
@@ -3629,10 +3627,8 @@ class TestDeckImportSummaryDialog:
 
         message = self.get_dialog_message(mock_dependencies)
 
-        # qtbot.wait(1000000)
-
         # Check header
-        assert "<b>Success!</b> Your decks are ready." in message
+        assert "<b>Success!</b> Your decks are ready:" in message
 
         # Check new decks section
         assert "New deck(s) created (4 decks):" in message

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -105,8 +105,8 @@ class AnkiHubImportResultFactory(BaseFactory[AnkiHubImportResult]):
     class Meta:
         model = AnkiHubImportResult
 
-    ankihub_did: uuid.UUID = factory.LazyFunction(uuid.uuid4)
-    anki_did: int = factory.Sequence(lambda n: n + 1)
+    ankihub_did: uuid.UUID = factory.LazyFunction(uuid.uuid4)  # type: ignore
+    anki_did: int = factory.Sequence(lambda n: n + 1)  # type: ignore
     updated_nids: List[int] = []
     created_nids: List[int] = [1, 2, 3]
     deleted_nids: List[int] = []

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,6 +18,7 @@ from ankihub.ankihub_client.models import (
     UserDeckExtensionRelation,
     UserDeckRelation,
 )
+from ankihub.main.importing import AnkiHubImportResult
 
 fake = Faker()
 
@@ -98,3 +99,18 @@ class DeckExtensionFactory(BaseFactory[DeckExtension]):
     tag_group_name: str = factory.LazyAttribute(lambda _: fake.word())  # type: ignore
     description: str = factory.LazyAttribute(lambda _: fake.sentence())  # type: ignore
     user_relation: UserDeckExtensionRelation = UserDeckExtensionRelation.SUBSCRIBER
+
+
+class AnkiHubImportResultFactory(BaseFactory[AnkiHubImportResult]):
+    class Meta:
+        model = AnkiHubImportResult
+
+    ankihub_did: uuid.UUID = factory.LazyFunction(uuid.uuid4)
+    anki_did: int = factory.Sequence(lambda n: n + 1)
+    updated_nids: List[int] = []
+    created_nids: List[int] = [1, 2, 3]
+    deleted_nids: List[int] = []
+    marked_as_deleted_nids: List[int] = []
+    skipped_nids: List[int] = []
+    first_import_of_deck: bool = False
+    merged_with_existing_deck: bool = False


### PR DESCRIPTION
The 'Import Summary' dialog has been significantly updated to provide much more detailed and context-specific information to users after importing decks.

The scenarios are described in the table in the Jira issue description: https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-212

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-212


## Proposed changes
* **Enhanced User Feedback**: The 'Import Summary' dialog has been significantly updated to provide much more detailed and context-specific information to users after importing decks, moving beyond generic success messages.
* **Categorized Deck Import Results**: Imported decks are now intelligently categorized into newly created, merged with existing decks (same name), or merged with existing decks (different name due to content overlap), offering clearer insights into the import outcome.

## How to reproduce
To show the dialog for some specific scenario, you can use the tests:
- Change `wait_ms` to 5000 here: 
  - https://github.com/AnkiHubSoftware/ankihub_addon/blob/2b913e58d0b3b77ef87998b61d143a7da46a2d72/tests/addon/test_unit.py#L3364
  - This will cause the test to wait for 5 seconds after showing the dialog
- Run a test case with `--no-xvfb`
  - e.g. `pytest tests/addon -n 0 -k "DeckImportSummary and test_single_deck_merged_same_name" --no-xvfb`
- The test will run and the dialog will show up for the scenario covered by the test

Of course you can also subscribe to a deck, then sync and install the deck to see the dialog. But it would take a lot of time to go through all scenarios this way.

## Screenshots and videos
### New deck(s)
![image](https://github.com/user-attachments/assets/65c9e846-e953-4a11-ab9a-6d7f5451f564)

![image](https://github.com/user-attachments/assets/3487bee6-d063-4f42-b2ba-7a2294d29693)

### Existing deck(s) with same name
![image](https://github.com/user-attachments/assets/961f2cef-6cd5-4451-b970-bac5a66c893b)

![image](https://github.com/user-attachments/assets/dbd64dc2-6e71-45e1-af7d-3478656ac427)


### Existing deck(s) with different name
![image](https://github.com/user-attachments/assets/77169c0e-f042-44d1-9711-188bd747036b)

![image](https://github.com/user-attachments/assets/c761758a-b5df-4783-93fb-f6757cefed3f)

### Mixed decks
![image](https://github.com/user-attachments/assets/547730cc-5d55-4110-b2ee-2446dc1c1a86)

### With skipped notes
![image](https://github.com/user-attachments/assets/396f36f7-83fe-4b0e-bf15-14654f3f3bfb)
