### PR TITLE
[NRT-213] Enable users to move cards when changing destination deck

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1004,15 +1004,6 @@ class DeckManagementDialog(QDialog):
             callback=on_destination_selected,
         )
 
-    def _count_cards_in_deck(self, ah_did: uuid.UUID) -> int:
-        """Count the total number of cards in the deck associated with the given AnkiHub deck ID."""
-        deck = get_deck_for_ah_did(ah_did)
-        if not deck:
-            return 0
-
-        anki_did = DeckId(deck["id"])
-        return aqt.mw.col.decks.card_count(anki_did, include_subdecks=True)
-
     def _show_move_cards_dialog(
         self, old_deck_name: Optional[str], new_deck_name: str
     ) -> bool:

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -799,7 +799,7 @@ class DeckManagementDialog(QDialog):
 
     def _on_update_templates_btn_clicked(self) -> None:
         def on_note_type_selected(
-            note_type_selector: SearchableSelectionDialog,
+            note_type_selector: SearchableSelectionDialog, MODEL_NAME="en_core_sci_lg"
         ) -> None:
             if not note_type_selector.name:
                 return
@@ -937,16 +937,16 @@ class DeckManagementDialog(QDialog):
                     should_move_cards = self._show_move_cards_dialog(new_deck_name)
 
             # Update the destination deck configuration
-            anki_did = aqt.mw.col.decks.id(new_deck_name)
-            config.set_home_deck(ankihub_did=ah_did, anki_did=anki_did)
+            new_destination_anki_did = aqt.mw.col.decks.id(new_deck_name)
+            config.set_home_deck(ankihub_did=ah_did, anki_did=new_destination_anki_did)
 
             # Move cards if user chose to do so
             if should_move_cards:
                 AddonQueryOp(
                     op=lambda _: move_ankihub_cards_to_deck(
-                        ah_did=ah_did, anki_did=anki_did
+                        ah_did=ah_did, anki_did=new_destination_anki_did
                     ),
-                    success=lambda _: on_cards_moved(anki_did=anki_did),
+                    success=lambda _: on_cards_moved(anki_did=new_destination_anki_did),
                     parent=aqt.mw,
                 ).with_progress("Moving cards...").run_in_background()
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -934,9 +934,7 @@ class DeckManagementDialog(QDialog):
                 if not all_notes_in_deck(
                     nids=anki_nids, anki_did=aqt.mw.col.decks.id(new_deck_name)
                 ):
-                    should_move_cards = self._show_move_cards_dialog(
-                        current_destination_deck_name, new_deck_name
-                    )
+                    should_move_cards = self._show_move_cards_dialog(new_deck_name)
 
             # Update the destination deck configuration
             anki_did = aqt.mw.col.decks.id(new_deck_name)
@@ -985,21 +983,16 @@ class DeckManagementDialog(QDialog):
             callback=on_destination_selected,
         )
 
-    def _show_move_cards_dialog(
-        self, old_deck_name: Optional[str], new_deck_name: str
-    ) -> bool:
+    def _show_move_cards_dialog(self, new_deck_name: str) -> bool:
         """Show a dialog asking if the user wants to move cards to the new destination deck.
         Returns True if cards should be moved, False if skipped."""
 
         message = (
             f"The new card destination is now <b>{new_deck_name}</b>.<br><br>"
-            + (
-                f"You still have cards in <b>{old_deck_name}</b>.<br><br>"
-                if old_deck_name
-                else ""
-            )
-            + f"Do you want to move them to <b>{new_deck_name}</b>?<br><br>"
-            + (f"⚠️ <b>{old_deck_name}</b> may become empty." if old_deck_name else "")
+            "Some cards are still assigned to other decks.<br>"
+            "Would you like to move all of them to "
+            f"<b>{new_deck_name}</b>?<br><br>"
+            f"⚠️ This action may leave some of those decks empty."
         )
 
         return ask_user(
@@ -1008,6 +1001,7 @@ class DeckManagementDialog(QDialog):
             title="Move existing cards",
             yes_button_label="Move Cards",
             no_button_label="Skip",
+            include_icon=False,
         )
 
     def _on_toggle_subdecks(self):

--- a/ankihub/gui/operations/subdecks.py
+++ b/ankihub/gui/operations/subdecks.py
@@ -4,13 +4,11 @@ from typing import List, Optional
 
 import aqt
 from anki.notes import NoteId
-from aqt import dialogs
-from aqt.browser import Browser
 
 from ... import LOGGER
 from ...main.subdecks import build_subdecks_and_move_cards_to_them, flatten_deck
 from ...settings import config
-from ..utils import ask_user, tooltip
+from ..utils import ask_user, refresh_anki_ui_after_moving_cards, tooltip
 
 
 def build_subdecks_and_move_cards_to_them_in_background(
@@ -78,7 +76,4 @@ def _on_subdecks_updated(future: Future[None]) -> None:
     LOGGER.info("Subdecks updated.")
     tooltip("Subdecks updated.", parent=aqt.mw)
 
-    aqt.mw.deckBrowser.refresh()
-    browser: Optional[Browser] = dialogs._dialogs["Browser"][1]
-    if browser is not None:
-        browser.sidebar.refresh()
+    refresh_anki_ui_after_moving_cards()

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -7,8 +7,9 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
 import aqt
 from anki.decks import DeckId
 from anki.utils import is_mac
-from aqt import QCheckBox, sync
+from aqt import QCheckBox, dialogs, sync
 from aqt.addons import check_and_prompt_for_updates
+from aqt.browser import Browser
 from aqt.progress import ProgressDialog
 from aqt.qt import (
     QAbstractAnimation,
@@ -846,3 +847,10 @@ def robust_filter(filter: Callable[..., T]) -> Callable[..., T]:
             return first
 
     return wrapper
+
+
+def refresh_anki_ui_after_moving_cards() -> None:
+    aqt.mw.deckBrowser.refresh()
+    browser: Optional[Browser] = dialogs._dialogs["Browser"][1]
+    if browser is not None:
+        browser.sidebar.refresh()

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -505,6 +505,7 @@ def ask_user(
     show_cancel_button: bool = False,
     yes_button_label: str = "Yes",
     no_button_label: str = "No",
+    include_icon: bool = True,
 ) -> Optional[bool]:
     "Show a yes/no question. Return true if yes. Return false if no. Return None if cancelled."
 
@@ -529,7 +530,7 @@ def ask_user(
         buttons=buttons,
         default_button_idx=1 if default_no else 0,
         callback=None,
-        icon=question_icon(),
+        icon=question_icon() if include_icon else None,
     )
     dialog.exec()
 

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -167,6 +167,25 @@ def exclude_descendant_decks(deck_ids: List[DeckId]) -> List[DeckId]:
     return independent_dids
 
 
+def all_notes_in_deck(nids: Sequence[NoteId], anki_did: DeckId) -> bool:
+    """Check if all notes in the given list of note IDs are in the specified Anki deck or its subdecks."""
+    descendant_ids = [id_ for _, id_ in aqt.mw.col.decks.children(anki_did)]
+    deck_ids = [anki_did] + descendant_ids
+    if not nids:
+        return True
+    else:
+        # If there is no note outside the deck, all notes are inside
+        return not aqt.mw.col.db.scalar(
+            f"""
+            SELECT EXISTS(
+                SELECT 1 FROM cards
+                WHERE NOT (did IN {ids2str(deck_ids)} OR odid IN {ids2str(deck_ids)})
+                AND nid IN {ids2str(nids)}
+            )
+            """
+        )
+
+
 def note_types_with_ankihub_id_field() -> List[NotetypeId]:
     return [
         mid

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -214,6 +214,14 @@ def get_deck_for_ah_did(ah_did: UUID) -> Optional[DeckDict]:
     return aqt.mw.col.decks.get(deck_config.anki_id, default=False)
 
 
+def move_ankihub_cards_to_deck(ah_did: UUID, anki_did: DeckId) -> None:
+    """Move all AnkiHub cards in the AnkiHub deck with the given ID to the Anki deck with the given ID.
+    Cards in filtered decks are not moved, but their original deck ID is updated."""
+    nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+    nid_to_did = {NoteId(nid): DeckId(anki_did) for nid in nids}
+    move_notes_to_decks_while_respecting_odid(nid_to_did)
+
+
 # notes
 
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -145,7 +145,7 @@ from ankihub.ankihub_client.models import (
 from ankihub.common_utils import local_media_names_from_html
 from ankihub.db import ankihub_db
 from ankihub.db.models import AnkiHubNote
-from ankihub.gui import decks_dialog, editor, utils
+from ankihub.gui import editor, utils
 from ankihub.gui.auto_sync import (
     SYNC_RATE_LIMIT_SECONDS,
     _setup_ankihub_sync_on_ankiweb_sync,
@@ -4737,7 +4737,6 @@ class TestDeckManagementDialog:
             (
                 mock_ask_user,
                 mock_subdeck_operation,
-                mock_refresh_anki_ui_after_moving_cards,
             ) = self._setup_move_cards_test_mocks(
                 mocker,
                 user_accepts_move,
@@ -4864,7 +4863,7 @@ class TestDeckManagementDialog:
         original_anki_did: DeckId,
         original_deck_name: str,
         mock_study_deck_dialog_with_cb: MockStudyDeckDialogWithCB,
-    ) -> tuple[Mock, Mock, Mock]:
+    ) -> tuple[Mock, Mock]:
         """Setup all mocks for move cards test."""
         # Mock destination selection dialog
         mock_study_deck_dialog_with_cb(
@@ -4895,14 +4894,9 @@ class TestDeckManagementDialog:
             ],
         )
 
-        mock_refresh_anki_ui_after_moving_cards = mocker.spy(
-            decks_dialog, "refresh_anki_ui_after_moving_cards"
-        )
-
         return (
             mock_ask_user,
             mock_subdeck_operation,
-            mock_refresh_anki_ui_after_moving_cards,
         )
 
     def _mock_dependencies(self, mocker: MockerFixture) -> None:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -145,7 +145,7 @@ from ankihub.ankihub_client.models import (
 from ankihub.common_utils import local_media_names_from_html
 from ankihub.db import ankihub_db
 from ankihub.db.models import AnkiHubNote
-from ankihub.gui import editor, utils
+from ankihub.gui import decks_dialog, editor, utils
 from ankihub.gui.auto_sync import (
     SYNC_RATE_LIMIT_SECONDS,
     _setup_ankihub_sync_on_ankiweb_sync,
@@ -4844,8 +4844,8 @@ class TestDeckManagementDialog:
             mock_ask_user.return_value = user_accepts_move
 
         # Mock subdeck operation
-        mock_subdeck_operation = mocker.patch(
-            "ankihub.gui.decks_dialog.build_subdecks_and_move_cards_to_them_in_background"
+        mock_subdeck_operation = mocker.spy(
+            decks_dialog, "build_subdecks_and_move_cards_to_them_in_background"
         )
 
         # Mock get_deck_subscriptions

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4588,9 +4588,9 @@ class TestDeckManagementDialog:
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
         anki_did: int = None,
-    ) -> Tuple[str, int, uuid.UUID]:
+    ) -> Tuple[str, DeckId, uuid.UUID]:
         """Install a deck with a subdeck tag and return the full subdeck name."""
-        ah_did = install_ah_deck(anki_did=anki_did)
+        ah_did = install_ah_deck(anki_did=DeckId(anki_did))
         subdeck_name = "Subdeck"
         deck_name = config.deck_config(ah_did).name
         deck_name_as_tag = deck_name.replace(" ", "_")
@@ -4717,63 +4717,32 @@ class TestDeckManagementDialog:
         with anki_session_with_addon_data.profile_loaded():
             self._mock_dependencies(mocker)
 
-            # Setup deck based on scenario
-            original_anki_did = next_deterministic_id()
-            if has_cards and subdecks_enabled:
-                # Use deck with subdeck tags for subdeck scenarios
-                _, original_anki_did, ah_did = self._install_deck_with_subdeck_tag(
-                    install_ah_deck, import_ah_note, anki_did=original_anki_did
-                )
-                config.set_subdecks(ah_did, True)
-                expected_note_count = 2  # 1 from subdeck tag + 1 from install_ah_deck
-            elif has_cards:
-                # Regular deck with cards
-                ah_did = install_ah_deck(anki_did=original_anki_did)
-                expected_note_count = 1
-            else:
-                ah_did = install_ah_deck(anki_did=original_anki_did)
-                # Remove note
-                nids = aqt.mw.col.find_notes("")
-                aqt.mw.col.remove_notes(nids)
-                expected_note_count = 0
-
-            # Determine destination deck
-            original_deck_name = config.deck_config(ah_did).name
-            if same_destination:
-                destination_deck_name = original_deck_name
-                new_anki_did = original_anki_did
-            else:
-                destination_deck_name = "New Destination Deck"
-                install_ah_deck(anki_deck_name=destination_deck_name)
-                new_anki_did = aqt.mw.col.decks.id_for_name(destination_deck_name)
-
-            # Mock destination selection dialog
-            mock_study_deck_dialog_with_cb(
-                "ankihub.gui.decks_dialog.SearchableSelectionDialog",
-                deck_name=destination_deck_name,
+            # Setup test scenario (decks, cards, destinations)
+            (
+                ah_did,
+                original_anki_did,
+                new_anki_did,
+                original_deck_name,
+                destination_deck_name,
+                expected_note_count,
+            ) = self._setup_move_cards_when_changing_destination_test_scenario(
+                has_cards,
+                subdecks_enabled,
+                same_destination,
+                install_ah_deck,
+                import_ah_note,
+                next_deterministic_id,
             )
 
-            # Mock user response to move dialog
-            mock_ask_user = mocker.patch("ankihub.gui.decks_dialog.ask_user")
-            if user_accepts_move is not None:
-                mock_ask_user.return_value = user_accepts_move
-
-            # Mock subdeck operation
-            mock_subdeck_operation = mocker.patch(
-                "ankihub.gui.decks_dialog.build_subdecks_and_move_cards_to_them_in_background"
-            )
-
-            # Mock get_deck_subscriptions
-            mocker.patch.object(
-                AnkiHubClient,
-                "get_deck_subscriptions",
-                return_value=[
-                    DeckFactory.create(
-                        ah_did=ah_did,
-                        anki_did=original_anki_did,
-                        name=original_deck_name,
-                    )
-                ],
+            # Setup all mocks
+            mock_ask_user, mock_subdeck_operation = self._setup_move_test_mocks(
+                mocker,
+                user_accepts_move,
+                destination_deck_name,
+                ah_did,
+                original_anki_did,
+                original_deck_name,
+                mock_study_deck_dialog_with_cb,
             )
 
             # Open dialog and select deck
@@ -4832,6 +4801,97 @@ class TestDeckManagementDialog:
                 assert len(call_args[1]["nids"]) == expected_note_count
             else:
                 mock_subdeck_operation.assert_not_called()
+
+    def _setup_move_cards_when_changing_destination_test_scenario(
+        self,
+        has_cards: bool,
+        subdecks_enabled: bool,
+        same_destination: bool,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        next_deterministic_id: Callable[[], int],
+    ) -> tuple[uuid.UUID, DeckId, DeckId, str, str, int]:
+        """Setup deck scenario for move cards test."""
+        original_anki_did = DeckId(next_deterministic_id())
+
+        if has_cards and subdecks_enabled:
+            # Use deck with subdeck tags for subdeck scenarios
+            _, original_anki_did, ah_did = self._install_deck_with_subdeck_tag(
+                install_ah_deck, import_ah_note, anki_did=original_anki_did
+            )
+            config.set_subdecks(ah_did, True)
+            expected_note_count = 2  # 1 from subdeck tag + 1 from install_ah_deck
+        elif has_cards:
+            # Regular deck with cards
+            ah_did = install_ah_deck(anki_did=original_anki_did)
+            expected_note_count = 1
+        else:
+            ah_did = install_ah_deck(anki_did=original_anki_did)
+            # Remove note to create empty deck
+            nids = aqt.mw.col.find_notes("")
+            aqt.mw.col.remove_notes(nids)
+            expected_note_count = 0
+
+        # Determine destination deck
+        original_deck_name = config.deck_config(ah_did).name
+        if same_destination:
+            destination_deck_name = original_deck_name
+            new_anki_did = original_anki_did
+        else:
+            destination_deck_name = "New Destination Deck"
+            install_ah_deck(anki_deck_name=destination_deck_name)
+            new_anki_did = aqt.mw.col.decks.id_for_name(destination_deck_name)
+
+        return (
+            ah_did,
+            original_anki_did,
+            new_anki_did,
+            original_deck_name,
+            destination_deck_name,
+            expected_note_count,
+        )
+
+    def _setup_move_test_mocks(
+        self,
+        mocker: MockerFixture,
+        user_accepts_move: Optional[bool],
+        destination_deck_name: str,
+        ah_did: uuid.UUID,
+        original_anki_did: DeckId,
+        original_deck_name: str,
+        mock_study_deck_dialog_with_cb: MockStudyDeckDialogWithCB,
+    ) -> tuple[Mock, Mock]:
+        """Setup all mocks for move cards test."""
+        # Mock destination selection dialog
+        mock_study_deck_dialog_with_cb(
+            "ankihub.gui.decks_dialog.SearchableSelectionDialog",
+            deck_name=destination_deck_name,
+        )
+
+        # Mock user response to move dialog
+        mock_ask_user = mocker.patch("ankihub.gui.decks_dialog.ask_user")
+        if user_accepts_move is not None:
+            mock_ask_user.return_value = user_accepts_move
+
+        # Mock subdeck operation
+        mock_subdeck_operation = mocker.patch(
+            "ankihub.gui.decks_dialog.build_subdecks_and_move_cards_to_them_in_background"
+        )
+
+        # Mock get_deck_subscriptions
+        mocker.patch.object(
+            AnkiHubClient,
+            "get_deck_subscriptions",
+            return_value=[
+                DeckFactory.create(
+                    ah_did=ah_did,
+                    anki_did=original_anki_did,
+                    name=original_deck_name,
+                )
+            ],
+        )
+
+        return mock_ask_user, mock_subdeck_operation
 
     def _mock_dependencies(self, mocker: MockerFixture) -> None:
         # Mock the config to return that the user is logged in

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4746,14 +4746,8 @@ class TestDeckManagementDialog:
                     new_count = aqt.mw.col.decks.card_count(
                         new_anki_did, include_subdecks=True
                     )
-
                     expected_original = 0
-                    expected_new = (
-                        (new_deck_card_count_before + expected_note_count)
-                        if user_accepts_move
-                        else new_deck_card_count_before
-                    )
-
+                    expected_new = new_deck_card_count_before + expected_note_count
                     assert original_count == expected_original
                     assert new_count == expected_new
             else:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4640,15 +4640,12 @@ class TestDeckManagementDialog:
             # Mock ask_user to not confirm moving cards
             mocker.patch("ankihub.gui.decks_dialog.ask_user", return_value=False)
 
-            # Open the dialog
+            # Open the dialog and selec the deck
             dialog = DeckManagementDialog()
             dialog.display_subscribe_window()
-            qtbot.wait(200)
-
-            # Select the deck and click the Set Updates Destination button
             dialog.decks_list.setCurrentRow(0)
-            qtbot.wait(200)
 
+            # Click the Set Updates Destination button
             dialog.set_new_cards_destination_btn.click()
             qtbot.wait(200)
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4637,6 +4637,9 @@ class TestDeckManagementDialog:
                 deck_name=new_destination_deck_name,
             )
 
+            # Mock ask_user to not confirm moving cards
+            mocker.patch("ankihub.gui.decks_dialog.ask_user", return_value=False)
+
             # Open the dialog
             dialog = DeckManagementDialog()
             dialog.display_subscribe_window()
@@ -4651,36 +4654,6 @@ class TestDeckManagementDialog:
 
             # Assert that the destination deck was updated
             assert config.deck_config(ah_did).anki_id == new_home_deck_anki_id
-
-    def test_with_deck_not_installed(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        qtbot: QtBot,
-        mocker: MockerFixture,
-        next_deterministic_uuid: Callable[[], uuid.UUID],
-        next_deterministic_id: Callable[[], int],
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            self._mock_dependencies(mocker)
-
-            ah_did = next_deterministic_uuid()
-            anki_did = next_deterministic_id()
-            mocker.patch.object(
-                AnkiHubClient,
-                "get_deck_subscriptions",
-                return_value=[DeckFactory.create(ah_did=ah_did, anki_did=anki_did)],
-            )
-
-            dialog = DeckManagementDialog()
-            dialog.display_subscribe_window()
-
-            assert dialog.decks_list.count() == 1
-
-            # Select the deck from the list
-            dialog.decks_list.setCurrentRow(0)
-            qtbot.wait(200)
-
-            assert hasattr(dialog, "deck_not_installed_label")
 
     @pytest.mark.parametrize(
         "user_accepts_move,subdecks_enabled,has_cards,same_destination",
@@ -4898,6 +4871,36 @@ class TestDeckManagementDialog:
             mock_ask_user,
             mock_subdeck_operation,
         )
+
+    def test_with_deck_not_installed(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+        next_deterministic_id: Callable[[], int],
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            ah_did = next_deterministic_uuid()
+            anki_did = next_deterministic_id()
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_subscriptions",
+                return_value=[DeckFactory.create(ah_did=ah_did, anki_did=anki_did)],
+            )
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+
+            assert dialog.decks_list.count() == 1
+
+            # Select the deck from the list
+            dialog.decks_list.setCurrentRow(0)
+            qtbot.wait(200)
+
+            assert hasattr(dialog, "deck_not_installed_label")
 
     def _mock_dependencies(self, mocker: MockerFixture) -> None:
         # Mock the config to return that the user is logged in

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4660,12 +4660,9 @@ class TestDeckManagementDialog:
             (True, True, True, False),  # Accept move with subdecks enabled
             # User declines move scenarios
             (False, False, True, False),  # Decline move
-            (False, True, True, False),  # Decline move with subdecks enabled
             # No dialog scenarios
             (None, False, False, False),  # No cards exist
-            (None, True, False, False),  # No cards exist with subdecks
             (None, False, True, True),  # Same destination selected
-            (None, True, True, True),  # Same destination with subdecks
         ],
     )
     def test_move_cards_when_changing_destination(


### PR DESCRIPTION
Enable users to move cards directly from the Deck Management dialog when they change the destination deck.
When the user changes the destination deck, if the original deck contains notes, a new pop-up will trigger to move the cards or skip this suggestion.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-213


## Proposed changes
* **Enhanced Deck Management**: When a user changes the destination deck for an AnkiHub deck, the system now detects if there are cards outside this deck, which should potentially get moved to the new destination deck.
* **User Prompt for Card Movement**: If cards are found outside the new destination deck, a new pop-up dialog is triggered, asking the user if they wish to move these existing cards to the newly selected destination deck.
* **Card Relocation**: Upon user confirmation, all notes of the AnkiHub deck are  moved to the new destination deck. This includes re-organizing cards into subdecks if the subdeck feature is enabled for that AnkiHub deck.
* **UI Refresh Refactoring**: The logic for refreshing the Anki UI (deck browser and sidebar) after cards were moved between deckshas been centralized into a new utility function for improved maintainability and consistency.
* **Comprehensive Testing**: Extensive parameterized integration tests have been added to validate the new card movement functionality across various scenarios, including user acceptance/rejection, presence of cards, and subdeck configurations.

## How to reproduce
- Install a deck
- Set up an (empty) Anki deck
- Open the Deck Management dialog, and change the Destination for New Cards to the empty deck
- The cards should be moved to the selected deck

https://github.com/user-attachments/assets/ce8b5233-562c-4540-8ab2-7bb76b75e7d8

