### PR TITLE
[NRT-229] Update skipped-notes warning on Deck Import Summary dialog

### DIFF
--- a/ankihub/gui/messages/templates/deck_import_summary.html
+++ b/ankihub/gui/messages/templates/deck_import_summary.html
@@ -103,14 +103,21 @@
     {% endif %}
 {% endif %}
 
+{# Handle skipped‑notes warnings #}
+{% for ankihub_deck_name, import_result in zip(ankihub_deck_names, import_results) %}
+    {% if import_result.skipped_nids %}
+        <p style="margin-top:12px;">
+            ⚠️ Some notes{% if ankihub_deck_names|length > 1 %} in <b>{{ ankihub_deck_name }}</b>{% endif %} were skipped
+            because they share the same ID as notes in another AnkiHub deck.<br>
+            For more details,
+            <a href='https://community.ankihub.net/t/draft-why-are-notes-skipped-after-subscribing-to-a-deck/934'>
+                see this topic
+            </a>.
+        </p>
+    {% endif %}
+{% endfor %}
+
 {# AnkiWeb sync warning – appears at the end for all scenarios #}
 {% if logged_to_ankiweb %}
 <p style="margin-top:12px;">⚠️ To access decks on other devices, go to those devices, sync, and choose <b>Download from AnkiWeb</b> if prompted.</p>
 {% endif %}
-
-{# Handle skipped‑notes warnings #}
-{% for ankihub_deck_name, import_result in zip(ankihub_deck_names, import_results) %}
-    {% if import_result.skipped_nids %}
-        <p style="margin-top:12px;">⚠️ Some notes in <b>{{ ankihub_deck_name }}</b> were skipped because they have the same ID as notes in another AnkiHub deck. See <a href='https://community.ankihub.net/t/draft-why-are-notes-skipped-after-subscribing-to-a-deck/934'>this forum topic</a> for details.</p>
-    {% endif %}
-{% endfor %}

--- a/ankihub/gui/messages/templates/deck_import_summary.html
+++ b/ankihub/gui/messages/templates/deck_import_summary.html
@@ -111,7 +111,7 @@
             because they share the same ID as notes in another AnkiHub deck.<br>
             For more details,
             <a href='https://community.ankihub.net/t/draft-why-are-notes-skipped-after-subscribing-to-a-deck/934'>
-                see this topic
+                see this topic.
             </a>.
         </p>
     {% endif %}

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3671,6 +3671,6 @@ class TestDeckImportSummaryDialog:
             qtbot.wait(self.wait)
 
         message = self.get_dialog_message(mock_dependencies)
-        assert "Some notes in <b>Pathology Deck</b> were skipped" in message
-        assert "have the same ID as notes in another AnkiHub deck" in message
-        assert "this forum topic</a> for details" in message
+        assert "Some notes were skipped" in message
+        assert "share the same ID as notes in another AnkiHub deck" in message
+        assert "see this topic" in message


### PR DESCRIPTION
Adjustment to the Deck Import Summary dialog, specifically to the warning about skipped notes.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-229


## Proposed changes
- Move the skipped-notes warning before the AnkiWeb warning
- Adjust copy


## How to reproduce
You can run these scripts in Anki's debug console to show the dialog.

### One deck
```python
import uuid

import ankihub

ankihub_deck_names = ["Pathology Deck"]
anki_deck_names   = ["Pathology Deck"]

import_result = ankihub.main.importing.AnkiHubImportResult(
    ankihub_did=uuid.uuid4(),
    anki_did=1,
    updated_nids=[],
    created_nids=[1, 2],
    deleted_nids=[],
    marked_as_deleted_nids=[],
    skipped_nids=[100, 101, 102, 103, 104],
    first_import_of_deck=True,
    merged_with_existing_deck=False,
)

ankihub.gui.operations.deck_installation._show_deck_import_summary_dialog_inner(
    ankihub_deck_names=ankihub_deck_names,
    anki_deck_names=anki_deck_names,
    import_results=[import_result],
)
```
### Multiple decks
```python
import uuid

import ankihub

ankihub_deck_names = ["Deck name A", "Deck name B", "Deck name C"]
anki_deck_names   = ankihub_deck_names.copy()

import_results = [
    ankihub.main.importing.AnkiHubImportResult(
        ankihub_did=uuid.uuid4(),
        anki_did=i + 1,
        updated_nids=[],
        created_nids=[1, 2],
        deleted_nids=[],
        marked_as_deleted_nids=[],
        skipped_nids=[1],
        first_import_of_deck=False,
        merged_with_existing_deck=True,
    )
    for i in range(len(ankihub_deck_names))
]

ankihub.gui.operations.deck_installation._show_deck_import_summary_dialog_inner(
    ankihub_deck_names=ankihub_deck_names,
    anki_deck_names=anki_deck_names,
    import_results=import_results,
)
```

## Screenshots
### One deck
<img src="https://github.com/user-attachments/assets/e4811cfa-c264-43db-ad50-492cf966040d" width="500" />

### Multiple decks
<img src="https://github.com/user-attachments/assets/2ed2192e-3819-43f9-b45b-0026a2fdbada" width="500" />
