### PR TITLE
[NRT-244] Adjust dialog for moving cards when changing destination deck

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -985,8 +985,12 @@ class DeckManagementDialog(QDialog):
 
     def _show_move_cards_dialog(self, new_deck_name: str) -> Optional[bool]:
         """Show a dialog asking if the user wants to move cards to the new destination deck.
-        Returns True if cards should be moved, False if skipped."""
 
+        Returns:
+            True if the user chose to move cards to the new destination deck.
+            False if the user chose not to move the cards.
+            None if the user cancelled the dialog.
+        """
         message = (
             f"The new card destination is now <b>{new_deck_name}</b>.<br><br>"
             "Some cards are still assigned to other decks.<br>"
@@ -995,7 +999,7 @@ class DeckManagementDialog(QDialog):
             f"⚠️ This action may leave some of those decks empty."
         )
 
-        return ask_user(
+        result = ask_user(
             message,
             parent=self,
             title="Move existing cards",
@@ -1004,6 +1008,15 @@ class DeckManagementDialog(QDialog):
             show_cancel_button=True,
             include_icon=False,
         )
+
+        LOGGER.info(
+            "move_cards_on_destination_deck_change_dialog_choice",
+            ah_did=self._selected_ah_did(),
+            new_deck_name=new_deck_name,
+            user_choice=result,
+        )
+
+        return result
 
     def _on_toggle_subdecks(self):
         ah_did = self._selected_ah_did()

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -936,9 +936,15 @@ class DeckManagementDialog(QDialog):
                 ):
                     should_move_cards = self._show_move_cards_dialog(new_deck_name)
 
+            if should_move_cards is None:
+                aqt.mw.taskman.run_on_main(self._on_new_cards_destination_btn_clicked)
+                return
+
             # Update the destination deck configuration
             new_destination_anki_did = aqt.mw.col.decks.id(new_deck_name)
             config.set_home_deck(ankihub_did=ah_did, anki_did=new_destination_anki_did)
+
+            self._refresh_new_cards_destination_details_label(ah_did)
 
             # Move cards if user chose to do so
             if should_move_cards:
@@ -949,8 +955,6 @@ class DeckManagementDialog(QDialog):
                     success=lambda _: on_cards_moved(anki_did=new_destination_anki_did),
                     parent=aqt.mw,
                 ).with_progress("Moving cards...").run_in_background()
-
-            self._refresh_new_cards_destination_details_label(ah_did)
 
         def on_cards_moved(anki_did: DeckId) -> None:
             refresh_anki_ui_after_moving_cards()
@@ -983,7 +987,7 @@ class DeckManagementDialog(QDialog):
             callback=on_destination_selected,
         )
 
-    def _show_move_cards_dialog(self, new_deck_name: str) -> bool:
+    def _show_move_cards_dialog(self, new_deck_name: str) -> Optional[bool]:
         """Show a dialog asking if the user wants to move cards to the new destination deck.
         Returns True if cards should be moved, False if skipped."""
 
@@ -1001,6 +1005,7 @@ class DeckManagementDialog(QDialog):
             title="Move existing cards",
             yes_button_label="Move Cards",
             no_button_label="Skip",
+            show_cancel_button=True,
             include_icon=False,
         )
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1004,7 +1004,7 @@ class DeckManagementDialog(QDialog):
             parent=self,
             title="Move existing cards",
             yes_button_label="Move Cards",
-            no_button_label="Skip",
+            no_button_label="Don't Move",
             show_cancel_button=True,
             include_icon=False,
         )

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -926,15 +926,11 @@ class DeckManagementDialog(QDialog):
             new_deck_name = note_type_selector.name
 
             should_move_cards = False
-            if (
-                not current_destination_deck_name
-                or new_deck_name != current_destination_deck_name
+            anki_nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+            if not all_notes_in_deck(
+                nids=anki_nids, anki_did=aqt.mw.col.decks.id(new_deck_name)
             ):
-                anki_nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-                if not all_notes_in_deck(
-                    nids=anki_nids, anki_did=aqt.mw.col.decks.id(new_deck_name)
-                ):
-                    should_move_cards = self._show_move_cards_dialog(new_deck_name)
+                should_move_cards = self._show_move_cards_dialog(new_deck_name)
 
             if should_move_cards is None:
                 aqt.mw.taskman.run_on_main(self._on_new_cards_destination_btn_clicked)


### PR DESCRIPTION
Adjust the dialog for moving cards when changing the destination deck according to QA feedback.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-244


## Proposed changes
- Change the copy of the “Skip” button to “Don’t Move.”
- Add a “Cancel” button 
  - So the buttons will be Cancel / Don’t Move / Move 
  - When the user presses "Cancel”, it will return to the previous dialog (Select destination for new cards)
- The dialog is now also shown when changing the destination deck to the current one, making it easier to move all cards to it, it that's what the user wants


## How to reproduce
- Install a deck
- Set up an (empty) Anki deck
- Open the Deck Management dialog, and change the Destination for New Cards to the empty deck
- Choose "Move Cards"
- The cards should be moved to the selected deck

## Screenshots and videos
<img src="https://github.com/user-attachments/assets/3e0b0a16-bb61-4653-a348-ea4bc7f5b8bf" width="500" />