### PR TITLE
[ACTV-123] Fix chatbot open in external browser

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -236,6 +236,7 @@ class ReviewerSidebar:
             self.header_webview.setFixedHeight(88)
 
         self.header_webview.setHtml(html)
+        self.header_webview.set_open_links_externally(False)
 
     def open_sidebar(self) -> bool:
         """Opens the sidebar if it's not already open.
@@ -289,6 +290,7 @@ class ReviewerSidebar:
                 resource_type=self.get_page_type().value,
             )
             self.content_webview.setHtml(html)
+            self.content_webview.set_open_links_externally(False)
 
     def refresh_page_content(self):
         self.content_webview.reload()


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-123


## Proposed changes

This adds `AnkiWebView.set_open_links_externally(False)` calls after each `AnkiWebView.setHtml()` call to fix the issue. `setHtml()` internally calls `self.set_open_links_externally(True)`, so this is needed.


## How to reproduce

To reproduce the issue before this PR, open the AnKing deck and switch between the sidebar buttons. You should see that the sidebar buttons open the web page in an external browser.

Interestingly, the issue doesn’t seem to appear in my dev environment. I had to install the add-on from AnkiWeb to a separate profile and test there. I'm not sure why this is the case.
