### PR TITLE
[NRT-250] Adjust chatbot dialog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
           - id: no_absolute_imports_from_ankihub
             name: no_absolute_imports_from_ankihub
             types: [python]
-            exclude: ^tests/*
+            exclude: ^tests/
             entry: "from ankihub([.]| import )"
             language: pygrep

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -316,7 +316,7 @@ def _on_open_chatbot_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         return
 
     dialog = ChatbotDialog(parent=browser, ah_nid=ah_nid)
-    dialog.display(use_open=True)
+    dialog.display(Qt.WindowModality.ApplicationModal)
 
 
 def _on_copy_anki_nid_action(browser: Browser, nids: Sequence[NoteId]) -> None:

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -100,16 +100,7 @@ class ContextMenuAction:
     name: str
     function: Callable
     enabled: bool
-    mac_shortcut: Optional[str] = None
-    other_shortcut: Optional[str] = None
-
-    def get_shortcut(self) -> Optional[str]:
-        """Get the appropriate shortcut for the current platform."""
-        if is_mac and self.mac_shortcut:
-            return self.mac_shortcut
-        elif not is_mac and self.other_shortcut:
-            return self.other_shortcut
-        return None
+    shortcut: Optional[str] = None
 
 
 # Maximum number of notes that can be selected for bulk suggestions.
@@ -165,12 +156,11 @@ def _setup_global_shortcuts(browser: Browser) -> None:
     actions = _get_context_menu_actions(browser, selected_nids)
 
     for action_config in actions:
-        shortcut = action_config.get_shortcut()
-        if not shortcut:
+        if not action_config.shortcut:
             continue
 
         global_action = QAction(action_config.name, browser)
-        global_action.setShortcut(shortcut)
+        global_action.setShortcut(action_config.shortcut)
         qconnect(
             global_action.triggered,
             _create_shortcut_trigger(browser, action_config.name),
@@ -257,8 +247,7 @@ def _get_context_menu_actions(
                 exactly_one_ah_note_selected
                 and _related_ah_deck_has_note_embeddings(selected_nids[0])
             ),
-            mac_shortcut="Option+K",
-            other_shortcut="Shift+Alt+K",
+            shortcut="Shift+Alt+K",
         ),
     ]
 
@@ -292,7 +281,7 @@ def _on_browser_will_show_context_menu(browser: Browser, context_menu: QMenu) ->
     for action_config in actions:
         action = context_menu.addAction(action_config.name, action_config.function)
         action.setEnabled(action_config.enabled)
-        shortcut = action_config.get_shortcut()
+        shortcut = action_config.shortcut
         if shortcut:
             action.setShortcut(shortcut)
 

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -316,7 +316,7 @@ class ChatbotDialog(AnkiHubWebViewDialog):
         return f"{config.app_url}/ai/chatbot/{self.ah_nid}/"
 
     @classmethod
-    def display_for_ah_nid(cls, ah_nid: uuid.UUID, parent) -> "ChatbotDialog":
+    def display_for_ah_nid(cls, ah_nid: uuid.UUID, parent) -> Optional["ChatbotDialog"]:
         """Display the chatbot dialog for the given note ID."""
         cls._instance = cls(ah_nid=ah_nid, parent=parent)
 

--- a/ankihub/gui/flashcard_selector_dialog.py
+++ b/ankihub/gui/flashcard_selector_dialog.py
@@ -14,7 +14,6 @@ from ..settings import (
     url_flashcard_selector_embed,
     url_plans_page,
 )
-from .menu import AnkiHubLogin
 from .operations import AddonQueryOp
 from .utils import show_dialog
 
@@ -58,16 +57,6 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
 
     def _get_non_embed_url(self) -> str:
         return url_flashcard_selector(self.ah_did)
-
-    def _handle_auth_failure(self) -> None:
-        # Close the flashcard selector dialog and prompt them to log in,
-        # then they can open the dialog again
-        self.close()
-
-        AnkiHubLogin.display_login()
-        LOGGER.info(
-            "Prompted user to log in to AnkiHub, after failed authentication in flashcard selector."
-        )
 
 
 def _show_upsell(user_details: dict) -> None:

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -65,7 +65,7 @@ class AnkiHubWebViewDialog(QDialog):
         theme_did_change.append(self._update_page_theme)
 
         self.layout_ = QVBoxLayout()
-        self.layout_.setContentsMargins(0, 0, 0, 5)
+        self.layout_.setContentsMargins(0, 0, 0, 0)
         self.layout_.addWidget(self.web)
 
         if self.show_footer:

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -100,10 +100,18 @@ class AnkiHubWebViewDialog(QDialog):
         """Return the URL to load in the default browser."""
         ...  # pragma: no cover
 
-    @abstractmethod
     def _handle_auth_failure(self) -> None:
         """Handle an authentication failure, e.g. prompt the user to log in."""
-        ...  # pragma: no cover
+        # Close the dialog and prompt them to log in,
+        # then they can open the dialog again
+        self.close()
+
+        from .menu import AnkiHubLogin  # Lazy import to avoid circular dependency
+
+        AnkiHubLogin.display_login()
+        LOGGER.info(
+            f"Prompted user to log in to AnkiHub, after failed authentication in {self.__class__.__name__}."
+        )
 
     def _on_successful_page_load(self) -> None:
         ...  # pragma: no cover

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -4,7 +4,6 @@ from typing import Any, Callable
 from aqt import QWebEnginePage, QWebEngineProfile, pyqtSlot
 from aqt.gui_hooks import theme_did_change
 from aqt.qt import (
-    QColor,
     QDialog,
     QHBoxLayout,
     QPushButton,
@@ -58,7 +57,6 @@ class AnkiHubWebViewDialog(QDialog):
 
         self.interceptor = AuthenticationRequestInterceptor()
         self.web.page().profile().setUrlRequestInterceptor(self.interceptor)
-        self.web.page().setBackgroundColor(QColor("white"))
 
         # Set the context to self so that self gets passed as context to the webview_did_receive_js_message hook
         # when a pycmd is called from the web view.

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import Any, Callable
 
-from aqt import QWebEnginePage, QWebEngineProfile, pyqtSlot
+from aqt import Qt, QWebEnginePage, QWebEngineProfile, pyqtSlot
 from aqt.gui_hooks import theme_did_change
 from aqt.qt import (
     QDialog,
@@ -34,7 +34,7 @@ class AnkiHubWebViewDialog(QDialog):
 
         self._setup_ui()
 
-    def display(self, use_open=False) -> bool:
+    def display(self, modality: Qt.WindowModality = Qt.WindowModality.NonModal) -> bool:
         """Display the dialog. Return True if the initialization was successful, False otherwise."""
         if not config.token():
             self._handle_auth_failure()
@@ -43,11 +43,8 @@ class AnkiHubWebViewDialog(QDialog):
         self._load_page()
         self.activateWindow()
         self.raise_()
-
-        if use_open:
-            self.open()
-        else:
-            self.show()
+        self.setWindowModality(modality)
+        self.show()
 
         return True
 

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -89,6 +89,7 @@ class AnkiHubWebViewDialog(QDialog):
             self.button_layout.addSpacing(20)
 
             self.layout_.addLayout(self.button_layout)
+            self.layout_.addSpacing(2)
 
         self.setLayout(self.layout_)
 


### PR DESCRIPTION
Fixes some issues with the chatbot dialog you can open from the browser.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-250

## Proposed changes
* **AI Chatbot Availability**: The 'AI Chatbot' context menu option in the browser is now only enabled if exactly one AnkiHub note is selected AND the related AnkiHub deck has note embeddings. A new helper function `_related_ah_deck_has_note_embeddings` was introduced to facilitate this check.
* **Generalized Dialog Display**: The `AnkiHubWebViewDialog.display` method was refactored to accept a `Qt.WindowModality` argument, making the dialog display behavior more flexible and standard across different dialogs, replacing the specific `use_open` flag.
  - Using `Qt.WindowModality.ApplicationModal` fixes an issue where the dialog had no title on MacOS
* **UI Layout Adjustments**: Minor UI adjustments were made to `AnkiHubWebViewDialog`, including removing a hardcoded background color, setting content margins to zero, and adding a small spacing below the footer buttons.
* **Fixed shortcut for opening the chatbot on Mac**
* **Chatbot Dialog Management**: The `ChatbotDialog` now uses a new class method `display_for_ah_nid` to manage its display, ensuring it opens as an application modal dialog and potentially managing a single instance. 
  - This ensures that we keep a reference to the dialog instance so it doesn't get prematurely gargabe collected 
* **Centralized Authentication Failure Handling**: The `_handle_auth_failure` method, previously an abstract method, has been given a concrete implementation in the base `AnkiHubWebViewDialog` class. This centralizes the logic for prompting users to log in upon authentication failure, removing the need for subclasses like `FlashcardSelectorDialog` to implement it individually.

## How to reproduce
- Open the browser
- Select an AnkiHub note from a deck that has AI features enabled
- You can open the chatbot dialog for this note using the context menu or the shortcut

## Video
https://github.com/user-attachments/assets/5196ce90-f9c5-40b5-bad4-a599f94700a1

