### PR TITLE
[ACTV-128] Potentially fix the "AnkiHub Sync Cancelled" bug by delaying the get_sync_status() call

### DIFF
--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -73,8 +73,12 @@ def _after_ankiweb_sync(on_done: Callable[[Future], None]) -> None:
 
         _sync_with_ankihub_inner(on_done=on_done)
 
+    @pass_exceptions_to_on_done
+    def after_delay(on_done: Callable[[Future], None]) -> None:
+        get_sync_status(aqt.mw, partial(on_sync_status, on_done=on_done))
+
     # Delay call to ensure server status is updated.
-    aqt.mw.progress.single_shot(1000, lambda: get_sync_status(aqt.mw, partial(on_sync_status, on_done=on_done)))
+    aqt.mw.progress.single_shot(1000, partial(after_delay, on_done=on_done))
 
 
 @pass_exceptions_to_on_done


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-128

## Proposed changes

This adds a one-second delay before calling get_sync_status() in _after_ankiweb_sync(). I suspect the issue is that the server status is not immediately updated after the sync is done, so Anki receives the old status (FULL_SYNC) sometimes.


## How to reproduce

I was never able to reproduce the issue, but [Datadog logs](https://app.datadoghq.com/logs?query=source%3Aanki_addon%20%40event%3A%28%22AnkiWeb%20full%20sync%20cancelled.%22%29&agg_m=count&agg_m_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1751103842960&to_ts=1753695842960&live=true) from affected users suggest the interval between the "AnkiWeb sync did finish." and "AnkiWeb full sync cancelled." messages is usually only a few milliseconds (very fast connections?). Use Datadog's View in Context option to confirm.
