### PR TITLE
Send platform as a Datadog tag

### DIFF
--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -7,6 +7,7 @@ import gzip
 import json
 import logging
 import os
+import platform
 import re
 import socket
 import sys
@@ -898,7 +899,7 @@ class DatadogLogHandler(logging.Handler):
         body = [
             {
                 "ddsource": "anki_addon",
-                "ddtags": f"addon_version:{ADDON_VERSION},anki_version:{ANKI_VERSION}",
+                "ddtags": f"addon_version:{ADDON_VERSION},anki_version:{ANKI_VERSION},platform:{platform.platform()}",
                 "hostname": socket.gethostname(),
                 "service": "ankihub_addon",
                 "username": config.username_or_email(),


### PR DESCRIPTION
## Proposed changes

This adds `platform.platform()` as a Datadog tag.


## Related issues

Useful to debug issues such as https://ankihub.atlassian.net/browse/TRIAGE-47

