### PR TITLE
Fix FSRS optimization error in 25.07

### DIFF
--- a/ankihub/gui/optimize_fsrs_dialog.py
+++ b/ankihub/gui/optimize_fsrs_dialog.py
@@ -133,6 +133,8 @@ def _optimize_fsrs_parameters(conf_id: DeckConfigId, on_done: Optional[Callable[
             extra_kwargs["num_of_relearning_steps"] = _get_amount_relearning_steps_in_day(
                 deck_config,
             )
+        if ANKI_INT_VERSION >= 250700:
+            extra_kwargs["health_check"] = False
 
         return aqt.mw.col.backend.compute_fsrs_params(
             search=deck_config.get("paramSearch", deck_config.get("weightSearch", default_search)),


### PR DESCRIPTION

## Related issues
 
https://ankihubllc.slack.com/archives/C08DWTDEDK8/p1755685165305279

## Proposed changes

The compute_fsrs_params() backend method has a new argument (health_check) in Anki 25.07, which we need to explicitly specify.

## How to reproduce

Run this code in Anki's debug console to trigger FSRS optimization and confirm the fix is working on Anki 25.07+:
```python
from ankihub.gui.optimize_fsrs_dialog import _optimize_fsrs_parameters
from anki.decks import  DeckConfigId

_optimize_fsrs_parameters(DeckConfigId(1), None)
```


