### PR TITLE
[NRT-403] Fix notes getting deleted when deleting subdeck that has subdeck

### DIFF
--- a/ankihub/main/block_exam_subdecks.py
+++ b/ankihub/main/block_exam_subdecks.py
@@ -10,7 +10,7 @@ from anki.notes import NoteId
 
 from .. import LOGGER
 from ..settings import BlockExamSubdeckConfig, config
-from .utils import move_notes_to_decks_while_respecting_odid
+from .utils import move_notes_to_decks_while_respecting_odid, note_ids_in_deck_hierarchy
 
 
 def create_block_exam_subdeck(
@@ -134,7 +134,7 @@ def move_subdeck_to_main_deck(subdeck_config: BlockExamSubdeckConfig) -> None:
 
     parent_deck_id = deck_config.anki_id
 
-    note_ids = aqt.mw.col.db.list("SELECT DISTINCT nid FROM cards WHERE did=? OR odid=?", subdeck_id, subdeck_id)
+    note_ids = note_ids_in_deck_hierarchy(subdeck_id)
     if note_ids:
         move_notes_to_decks_while_respecting_odid({nid: parent_deck_id for nid in note_ids})
         LOGGER.info("Moved notes from subdeck to main deck", subdeck_name=subdeck["name"], note_count=len(note_ids))

--- a/ankihub/main/subdecks.py
+++ b/ankihub/main/subdecks.py
@@ -21,6 +21,7 @@ from ..settings import config
 from .utils import (
     move_notes_to_decks_while_respecting_odid,
     nids_in_deck_but_not_in_subdeck,
+    note_ids_in_deck_hierarchy,
 )
 
 # root tag for tags that indicate which subdeck a note belongs to
@@ -169,10 +170,9 @@ def flatten_deck(ankihub_did: uuid.UUID) -> None:
     """
     # Get the root deck ID and name
     root_deck_id = config.deck_config(ankihub_did).anki_id
-    root_deck_name = aqt.mw.col.decks.name(root_deck_id)
 
     # Find all notes in subdecks and move them to the root deck
-    nids = aqt.mw.col.find_notes(f'"deck:{root_deck_name}::*"')
+    nids = note_ids_in_deck_hierarchy(root_deck_id, include_self=False)
     nid_to_did = {nid: root_deck_id for nid in nids}
     move_notes_to_decks_while_respecting_odid(nid_to_did=nid_to_did)
 

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -231,7 +231,7 @@ def note_ids_in_deck_hierarchy(
     *,
     include_self: bool = True,
     include_filtered: bool = True,
-) -> list[int]:
+) -> list[NoteId]:
     """
     Return distinct note IDs for cards under `deck_id`'s hierarchy.
     - If `include_self` is True, include `deck_id` itself; otherwise only its subdecks.
@@ -248,7 +248,7 @@ def note_ids_in_deck_hierarchy(
     if include_filtered:
         sql += f" OR odid IN {dids_str}"
 
-    return aqt.mw.col.db.list(sql)
+    return [NoteId(nid) for nid in aqt.mw.col.db.list(sql)]
 
 
 def move_notes_to_decks_while_respecting_odid(nid_to_did: Dict[NoteId, DeckId]) -> None:

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -226,6 +226,31 @@ def add_notes(notes: Collection[Note], deck_id: DeckId) -> None:
         aqt.mw.col.save()
 
 
+def note_ids_in_deck_hierarchy(
+    deck_id: DeckId,
+    *,
+    include_self: bool = True,
+    include_filtered: bool = True,
+) -> list[int]:
+    """
+    Return distinct note IDs for cards under `deck_id`'s hierarchy.
+    - If `include_self` is True, include `deck_id` itself; otherwise only its subdecks.
+    - If `include_filtered` is True, also include notes whose cards are currently in a filtered deck
+      but whose original deck (`odid`) is in that hierarchy.
+    """
+    descendant_ids = [id_ for _, id_ in aqt.mw.col.decks.children(deck_id)]
+    dids = ([deck_id] if include_self else []) + descendant_ids
+    if not dids:
+        return []
+
+    dids_str = ids2str(dids)
+    sql = f"SELECT DISTINCT nid FROM cards WHERE did IN {dids_str}"
+    if include_filtered:
+        sql += f" OR odid IN {dids_str}"
+
+    return aqt.mw.col.db.list(sql)
+
+
 def move_notes_to_decks_while_respecting_odid(nid_to_did: Dict[NoteId, DeckId]) -> None:
     """Moves the cards of notes to the decks specified in nid_to_did.
     If a card is in a filtered deck it is not moved and only its original deck id value gets changed.

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -10,19 +10,7 @@ from concurrent.futures import Future
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from time import sleep, time
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Protocol,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Set, Tuple, Union, cast
 from unittest.mock import Mock
 from zipfile import ZipFile
 
@@ -69,10 +57,7 @@ from requests import Response  # type: ignore
 from requests_mock import Mocker
 
 from ankihub.gui.block_exam_dialog import BlockExamSubdeckDialog
-from ankihub.gui.enable_fsrs_dialog import (
-    ENABLE_FSRS_REMINDER_INTERVAL_DAYS,
-    maybe_show_enable_fsrs_reminder,
-)
+from ankihub.gui.enable_fsrs_dialog import ENABLE_FSRS_REMINDER_INTERVAL_DAYS, maybe_show_enable_fsrs_reminder
 from ankihub.gui.optimize_fsrs_dialog import (
     FSRS_OPTIMIZATION_REMINDER_INTERVAL_DAYS,
     _optimize_fsrs_parameters,
@@ -84,14 +69,10 @@ from ankihub.main.block_exam_subdecks import (
     add_notes_to_block_exam_subdeck,
     check_block_exam_subdeck_due_dates,
     create_block_exam_subdeck,
+    move_subdeck_to_main_deck,
 )
 
-from ..factories import (
-    DeckExtensionFactory,
-    DeckFactory,
-    DeckMediaFactory,
-    NoteInfoFactory,
-)
+from ..factories import DeckExtensionFactory, DeckFactory, DeckMediaFactory, NoteInfoFactory
 from ..fixtures import (
     AddAnkiNote,
     ImportAHNote,
@@ -153,10 +134,7 @@ from ankihub.common_utils import local_media_names_from_html
 from ankihub.db import ankihub_db
 from ankihub.db.models import AnkiHubNote
 from ankihub.gui import decks_dialog, editor, utils
-from ankihub.gui.auto_sync import (
-    SYNC_RATE_LIMIT_SECONDS,
-    _setup_ankihub_sync_on_ankiweb_sync,
-)
+from ankihub.gui.auto_sync import SYNC_RATE_LIMIT_SECONDS, _setup_ankihub_sync_on_ankiweb_sync
 from ankihub.gui.browser import custom_columns
 from ankihub.gui.browser import setup as setup_browser
 from ankihub.gui.browser.browser import (
@@ -167,19 +145,10 @@ from ankihub.gui.browser.browser import (
     _on_protect_fields_action,
     _on_reset_optional_tags_action,
 )
-from ankihub.gui.browser.custom_search_nodes import (
-    AnkiHubNoteSearchNode,
-    UpdatedSinceLastReviewSearchNode,
-)
+from ankihub.gui.browser.custom_search_nodes import AnkiHubNoteSearchNode, UpdatedSinceLastReviewSearchNode
 from ankihub.gui.changes_require_full_sync_dialog import ChangesRequireFullSyncDialog
-from ankihub.gui.config_dialog import (
-    get_config_dialog_manager,
-    setup_config_dialog_manager,
-)
-from ankihub.gui.deck_options import (
-    _backup_fsrs_parameters,
-    _can_revert_from_fsrs_parameters,
-)
+from ankihub.gui.config_dialog import get_config_dialog_manager, setup_config_dialog_manager
+from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_fsrs_parameters
 from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import SUGGESTION_BTN_ID
@@ -202,15 +171,10 @@ from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
 from ankihub.gui.operations.deck_installation import download_and_install_decks
-from ankihub.gui.operations.new_deck_subscriptions import (
-    check_and_install_new_deck_subscriptions,
-)
+from ankihub.gui.operations.new_deck_subscriptions import check_and_install_new_deck_subscriptions
 from ankihub.gui.operations.utils import future_with_result
 from ankihub.gui.optional_tag_suggestion_dialog import OptionalTagsSuggestionDialog
-from ankihub.gui.overview import (
-    FLASHCARD_SELECTOR_OPEN_BUTTON_ID,
-    FLASHCARD_SELECTOR_SYNC_NOTES_ACTIONS_PYCMD,
-)
+from ankihub.gui.overview import FLASHCARD_SELECTOR_OPEN_BUTTON_ID, FLASHCARD_SELECTOR_SYNC_NOTES_ACTIONS_PYCMD
 from ankihub.gui.suggestion_dialog import SuggestionDialog
 from ankihub.gui.utils import _Dialog, robust_filter
 from ankihub.main.deck_creation import create_ankihub_deck, modified_note_type
@@ -218,11 +182,7 @@ from ankihub.main.deck_options import ANKIHUB_PRESET_NAME, get_fsrs_parameters
 from ankihub.main.deck_unsubscribtion import uninstall_deck
 from ankihub.main.exceptions import ChangesRequireFullSyncError
 from ankihub.main.exporting import to_note_data
-from ankihub.main.importing import (
-    AnkiHubImporter,
-    AnkiHubImportResult,
-    change_note_types_of_notes,
-)
+from ankihub.main.importing import AnkiHubImporter, AnkiHubImportResult, change_note_types_of_notes
 from ankihub.main.note_conversion import (
     ADDON_INTERNAL_TAGS,
     ANKI_INTERNAL_TAGS,
@@ -231,17 +191,9 @@ from ankihub.main.note_conversion import (
     TAG_FOR_PROTECTING_FIELDS,
 )
 from ankihub.main.note_deletion import TAG_FOR_DELETED_NOTES
-from ankihub.main.note_type_management import (
-    add_note_type,
-    add_note_type_fields,
-    update_note_type_templates_and_styles,
-)
+from ankihub.main.note_type_management import add_note_type, add_note_type_fields, update_note_type_templates_and_styles
 from ankihub.main.reset_local_changes import reset_local_changes_to_notes
-from ankihub.main.subdecks import (
-    SUBDECK_TAG,
-    build_subdecks_and_move_cards_to_them,
-    flatten_deck,
-)
+from ankihub.main.subdecks import SUBDECK_TAG, build_subdecks_and_move_cards_to_them, flatten_deck
 from ankihub.main.suggestions import (
     ANKIHUB_NO_CHANGE_ERROR,
     ANKIHUB_NOTE_DOES_NOT_EXIST_ERROR,
@@ -259,6 +211,7 @@ from ankihub.main.utils import (
     all_dids,
     get_note_types_in_deck,
     md5_file_hash,
+    note_ids_in_deck_hierarchy,
     note_type_contains_field,
 )
 from ankihub.settings import (
@@ -8666,6 +8619,64 @@ class TestBlockExamSubdecks:
             with pytest.raises(ValueError, match="Subdeck .* not found"):
                 add_notes_to_block_exam_subdeck(ah_did, "Non-existent Subdeck", [NoteId(1), NoteId(2), NoteId(3)])
 
+    def test_move_subdeck_to_main_deck_with_nested_subdecks(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        add_anki_note: AddAnkiNote,
+    ):
+        """Test moving a subdeck with nested children moves all notes to main deck."""
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            deck_config = config.deck_config(ah_did)
+            main_deck_id = deck_config.anki_id
+            main_deck_name = aqt.mw.col.decks.name_if_exists(main_deck_id)
+
+            # Create subdeck hierarchy: Main::Block Exam::Nested
+            due_date = (date.today() + timedelta(days=7)).strftime("%Y-%m-%d")
+            subdeck_name, _ = create_block_exam_subdeck(ah_did, "Block Exam", due_date)
+
+            subdeck_full_name = f"{main_deck_name}::{subdeck_name}"
+            subdeck_id = aqt.mw.col.decks.id_for_name(subdeck_full_name)
+
+            nested_subdeck_name = f"{subdeck_full_name}::Nested"
+            nested_subdeck_id = create_anki_deck(nested_subdeck_name)
+
+            # Create notes at each level
+            note_main = add_anki_note(anki_did=main_deck_id)
+            note_subdeck = add_anki_note(anki_did=subdeck_id)
+            note_nested = add_anki_note(anki_did=nested_subdeck_id)
+
+            # Verify initial card locations
+            assert note_main.cards()[0].did == main_deck_id
+            assert note_subdeck.cards()[0].did == subdeck_id
+            assert note_nested.cards()[0].did == nested_subdeck_id
+
+            # Move subdeck to main deck
+            subdeck_config = BlockExamSubdeckConfig(
+                ankihub_deck_id=str(ah_did),
+                subdeck_id=str(subdeck_id),
+                due_date=due_date,
+            )
+            move_subdeck_to_main_deck(subdeck_config)
+
+            # Verify all notes from subdeck hierarchy moved to main deck
+            note_main = aqt.mw.col.get_note(note_main.id)
+            note_subdeck = aqt.mw.col.get_note(note_subdeck.id)
+            note_nested = aqt.mw.col.get_note(note_nested.id)
+
+            assert note_main.cards()[0].did == main_deck_id
+            assert note_subdeck.cards()[0].did == main_deck_id
+            assert note_nested.cards()[0].did == main_deck_id
+
+            # Verify subdeck hierarchy was deleted
+            assert aqt.mw.col.decks.id_for_name(subdeck_full_name) is None
+            assert aqt.mw.col.decks.id_for_name(nested_subdeck_name) is None
+
+            # Verify config was removed
+            saved_due_date = config.get_block_exam_subdeck_due_date(str(ah_did), str(subdeck_id))
+            assert saved_due_date is None
+
 
 @pytest.mark.sequential
 class TestBlockExamSubdeckDialog:
@@ -8879,3 +8890,141 @@ class TestCheckBlockExamSubdeckDueDates:
             assert "deck1" in expired_deck_ids  # past date
             assert "deck2" in expired_deck_ids  # today's date
             assert "deck3" not in expired_deck_ids  # future date
+
+
+class TestNoteIdsInDeckHierarchy:
+    """Tests for note_ids_in_deck_hierarchy utility function."""
+
+    @staticmethod
+    def _create_filtered_deck_for_search(mw: AnkiQt, name: str, search: str) -> DeckId:
+        """Helper to create a filtered deck with a search term."""
+        filtered_deck = mw.col.sched.get_or_create_filtered_deck(DeckId(0))
+        filtered_deck.name = name
+        filtered_deck.config.search_terms.pop(0)
+        filtered_deck.config.search_terms.append(
+            FilteredDeckConfig.SearchTerm(
+                search=search,
+                limit=100,
+            )
+        )
+        mw.col.sched.add_or_update_filtered_deck(filtered_deck)
+        return mw.col.decks.id_for_name(name)
+
+    def test_basic_deck_with_subdecks(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        add_anki_note: AddAnkiNote,
+    ):
+        """Test basic case: deck with subdecks returns all note IDs."""
+        with anki_session_with_addon_data.profile_loaded():
+            # Create deck hierarchy
+            parent_deck_id = create_anki_deck("Parent")
+            child_deck_id = create_anki_deck("Parent::Child")
+
+            # Create notes in both decks
+            note1 = add_anki_note(anki_did=parent_deck_id)
+            note2 = add_anki_note(anki_did=child_deck_id)
+
+            # Get all note IDs in hierarchy
+            nids = note_ids_in_deck_hierarchy(parent_deck_id)
+
+            assert set(nids) == {note1.id, note2.id}
+
+    def test_include_self_false(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        add_anki_note: AddAnkiNote,
+    ):
+        """Test include_self=False returns only subdeck notes."""
+        with anki_session_with_addon_data.profile_loaded():
+            # Create deck hierarchy
+            parent_deck_id = create_anki_deck("Parent")
+            child_deck_id = create_anki_deck("Parent::Child")
+
+            # Create notes in both decks
+            _ = add_anki_note(anki_did=parent_deck_id)
+            note2 = add_anki_note(anki_did=child_deck_id)
+
+            # Get only subdeck note IDs
+            nids = note_ids_in_deck_hierarchy(parent_deck_id, include_self=False)
+
+            assert set(nids) == {note2.id}
+
+    def test_nested_subdecks(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        add_anki_note: AddAnkiNote,
+    ):
+        """Test deeply nested subdecks (3+ levels) are all included."""
+        with anki_session_with_addon_data.profile_loaded():
+            # Create 4-level hierarchy
+            deck1_id = create_anki_deck("Level1")
+            deck2_id = create_anki_deck("Level1::Level2")
+            deck3_id = create_anki_deck("Level1::Level2::Level3")
+            deck4_id = create_anki_deck("Level1::Level2::Level3::Level4")
+
+            # Create notes at each level
+            note1 = add_anki_note(anki_did=deck1_id)
+            note2 = add_anki_note(anki_did=deck2_id)
+            note3 = add_anki_note(anki_did=deck3_id)
+            note4 = add_anki_note(anki_did=deck4_id)
+
+            # Get all note IDs from top level
+            nids = note_ids_in_deck_hierarchy(deck1_id)
+
+            assert set(nids) == {note1.id, note2.id, note3.id, note4.id}
+
+    @pytest.mark.parametrize(
+        "include_filtered,expected_count",
+        [
+            (True, 1),  # include_filtered=True should include the note
+            (False, 0),  # include_filtered=False should exclude the note
+        ],
+    )
+    def test_include_filtered_parameter(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        add_anki_note: AddAnkiNote,
+        include_filtered: bool,
+        expected_count: int,
+    ):
+        """Test include_filtered parameter with notes in filtered decks."""
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            # Create regular deck
+            regular_deck_id = create_anki_deck("Regular")
+
+            # Create note in regular deck
+            note = add_anki_note(anki_did=regular_deck_id)
+
+            # Create filtered deck and move card there
+            self._create_filtered_deck_for_search(mw, "Filtered", "deck:Regular")
+
+            # Verify card is now in filtered deck with odid set
+            card = mw.col.get_card(note.cards()[0].id)
+            assert card.odid == regular_deck_id
+
+            # Get note IDs with the specified include_filtered parameter
+            nids = note_ids_in_deck_hierarchy(regular_deck_id, include_filtered=include_filtered)
+
+            # Verify expected result
+            if expected_count == 1:
+                assert set(nids) == {note.id}
+            else:
+                assert set(nids) == set()
+
+    def test_empty_deck_hierarchy(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+    ):
+        """Test empty deck hierarchy returns empty list."""
+        with anki_session_with_addon_data.profile_loaded():
+            # Create empty deck
+            deck_id = create_anki_deck("Empty")
+
+            # Get note IDs
+            nids = note_ids_in_deck_hierarchy(deck_id)
+
+            assert len(nids) == 0
+            assert nids == []

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9026,5 +9026,4 @@ class TestNoteIdsInDeckHierarchy:
             # Get note IDs
             nids = note_ids_in_deck_hierarchy(deck_id)
 
-            assert len(nids) == 0
-            assert nids == []
+            assert set(nids) == set()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3418,6 +3418,7 @@ class TestDeckImportSummaryDialog:
 class TestMoveSubdeckToMainDeck:
     """Tests for move_subdeck_to_main_deck function."""
 
+    @patch("ankihub.main.block_exam_subdecks.note_ids_in_deck_hierarchy")
     @patch("ankihub.main.block_exam_subdecks.move_notes_to_decks_while_respecting_odid")
     @patch("ankihub.main.block_exam_subdecks.remove_block_exam_subdeck_config")
     @patch("ankihub.main.block_exam_subdecks.aqt")
@@ -3428,6 +3429,7 @@ class TestMoveSubdeckToMainDeck:
         mock_aqt,
         mock_remove_config,
         mock_move_notes,
+        mock_note_ids_in_deck_hierarchy,
     ):
         """Test successfully moving subdeck to main deck."""
         # Setup mocks
@@ -3437,7 +3439,7 @@ class TestMoveSubdeckToMainDeck:
 
         mock_subdeck = {"name": "Test Deck::Subdeck", "id": 456}
         mock_aqt.mw.col.decks.get.return_value = mock_subdeck
-        mock_aqt.mw.col.db.list.return_value = [1, 2, 3]
+        mock_note_ids_in_deck_hierarchy.return_value = [1, 2, 3]
 
         subdeck_config = BlockExamSubdeckConfig(
             ankihub_deck_id=str(uuid.uuid4()), subdeck_id="456", due_date="2024-12-31"
@@ -3445,6 +3447,7 @@ class TestMoveSubdeckToMainDeck:
 
         move_subdeck_to_main_deck(subdeck_config)
 
+        mock_note_ids_in_deck_hierarchy.assert_called_once_with(456)
         mock_move_notes.assert_called_once_with({1: 123, 2: 123, 3: 123})
         mock_aqt.mw.col.decks.remove.assert_called_once_with([456])
         mock_remove_config.assert_called_once_with(subdeck_config)


### PR DESCRIPTION
This pull request addresses a critical bug where notes were inadvertently deleted when a subdeck containing further subdecks was removed. The issue stemmed from an incomplete method of identifying all notes associated with a deck hierarchy. The changes introduce a robust utility function to correctly gather all note IDs within a deck's hierarchy and integrate this function into the existing subdeck handling and deck flattening logic, thereby preventing data loss and improving the overall integrity of deck operations.


## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?selectedIssue=NRT-403


## Proposed changes
* **Introduction of `note_ids_in_deck_hierarchy`**: A new utility function `note_ids_in_deck_hierarchy` has been added to `ankihub/main/utils.py`. This function is designed to accurately retrieve all distinct note IDs within a given deck's hierarchy, including its subdecks and notes in filtered decks whose original deck belongs to the hierarchy.
* **Corrected Note Handling During Subdeck Deletion**: The logic in `ankihub/main/block_exam_subdecks.py` for moving notes from a subdeck to its parent deck has been updated to use the new `note_ids_in_deck_hierarchy` function. This ensures that all notes, including those in nested subdecks, are correctly identified and moved, preventing their accidental deletion when a subdeck is removed.
* **Enhanced Deck Flattening Mechanism**: The `flatten_deck` function in `ankihub/main/subdecks.py` now utilizes `note_ids_in_deck_hierarchy` to gather notes from subdecks. This change improves the reliability of flattening operations by ensuring all relevant notes are moved to the root deck, regardless of their nesting level.

## How to reproduce
This test verifies the correct behavior in the scenario where previously notes would get incorrectly deleted:
https://github.com/AnkiHubSoftware/ankihub_addon/blob/8df5114a9c737aaf7207e377599d9cce8e3a5df8/tests/addon/test_integration.py#L8622

Here are the steps to reproduce it manually:
- Check the amount of cards in the AnKing deck in your Anki collection
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/acb228fc-eef5-42fa-9da8-771cca731889" />

- Create a block exam subdeck using Smart Search opened from Anki
  - To open Smart Search, click on the AnKing deck to open the deck overview screen, then click the Smart Search button
  - Search for something using Smart Tag Search (e.g. "diabetes"), click the "Create block exam subdeck" button
  - Choose a name for the deck, e.g. "Diabetes"
- Create a nested block exam subdeck
  - Repeat the steps, searching for "diabetes type 1", then setting the subdeck name as "Diabetes::Diabetes Type 1"
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/51c0c460-f0f0-492a-899f-ef1a95904432" />
  
  This is how it looks for me after doing the steps above, and expanding the "Diabetes" deck
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/92d32814-6375-4581-8d53-431a06f02526" />
- Remove the "Diabetes" deck using the "AnkiHub: Remove subdeck" action
  <img width="500" alt="image" src="https://github.com/user-attachments/assets/068317dd-bdeb-4f6b-854c-825d0ceee154" />
- Check the amount of cards in the AnKing deck in your Anki collection, it should be the same as at the start, because the notes were moved back to the main deck.

Without this PR, the note amount would be lower at the end. The notes from the "Diabetes Type 1" deck would get completely removed from the Anki collection.

The problem would also happen if the user manually created a non-block-exam subdeck for a block-exam subdeck.