### PR TITLE
[NRT-418] Remove local error handling from block exam dialog

### DIFF
--- a/ankihub/gui/block_exam_dialog.py
+++ b/ankihub/gui/block_exam_dialog.py
@@ -18,6 +18,7 @@ from aqt.qt import (
     QPushButton,
     Qt,
     QVBoxLayout,
+    qconnect,
 )
 from aqt.utils import showInfo, tooltip
 
@@ -75,7 +76,7 @@ class BlockExamSubdeckDialog(QDialog):
         filter_layout = QHBoxLayout()
         filter_layout.addWidget(QLabel("Filter:"))
         self.filter_input = QLineEdit()
-        self.filter_input.textChanged.connect(self._filter_subdecks)  # type: ignore[attr-defined]
+        qconnect(self.filter_input.textChanged, self._filter_subdecks)
         self.filter_input.setPlaceholderText("Search subdecks...")
         filter_layout.addWidget(self.filter_input)
         layout.addLayout(filter_layout)
@@ -83,7 +84,7 @@ class BlockExamSubdeckDialog(QDialog):
         # Subdeck list
         self.subdeck_list = QListWidget()
         self._populate_subdeck_list()
-        self.subdeck_list.itemDoubleClicked.connect(self._on_subdeck_selected)  # type: ignore[attr-defined]
+        qconnect(self.subdeck_list.itemDoubleClicked, self._on_subdeck_selected)
         layout.addWidget(self.subdeck_list)
 
         # Buttons
@@ -91,15 +92,15 @@ class BlockExamSubdeckDialog(QDialog):
         button_layout.addStretch()
 
         cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self.reject)  # type: ignore[attr-defined]
+        qconnect(cancel_button.clicked, self.reject)
         button_layout.addWidget(cancel_button)
 
         create_button = QPushButton("Create new subdeck")
-        create_button.clicked.connect(self._show_create_subdeck_screen)  # type: ignore[attr-defined]
+        qconnect(create_button.clicked, self._show_create_subdeck_screen)
         button_layout.addWidget(create_button)
 
         select_button = QPushButton("Choose")
-        select_button.clicked.connect(self._on_subdeck_selected)  # type: ignore[attr-defined]
+        qconnect(select_button.clicked, self._on_subdeck_selected)
         select_button.setDefault(True)
         button_layout.addWidget(select_button)
 
@@ -143,7 +144,7 @@ class BlockExamSubdeckDialog(QDialog):
         name_layout.addWidget(name_label)
         self.name_input = QLineEdit()
         self.name_input.setPlaceholderText("e.g. Cardio Block Exam")
-        self.name_input.textChanged.connect(self._update_create_button_state)  # type: ignore[attr-defined]
+        qconnect(self.name_input.textChanged, self._update_create_button_state)
         name_layout.addWidget(self.name_input)
         layout.addLayout(name_layout)
         layout.addSpacing(8)
@@ -170,11 +171,11 @@ class BlockExamSubdeckDialog(QDialog):
         button_layout.addStretch()
 
         cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self.reject)  # type: ignore[attr-defined]
+        qconnect(cancel_button.clicked, self.reject)
         button_layout.addWidget(cancel_button)
 
         create_button = QPushButton("Create subdeck")
-        create_button.clicked.connect(self._on_create_subdeck)  # type: ignore[attr-defined]
+        qconnect(create_button.clicked, self._on_create_subdeck)
         create_button.setDefault(True)
         create_button.setEnabled(False)  # Initially disabled
         self.create_button = create_button  # Store reference for enabling/disabling
@@ -224,7 +225,7 @@ class BlockExamSubdeckDialog(QDialog):
         self.name_input = QLineEdit()
         self.name_input.setText(self.selected_subdeck_name)
         self.name_input.setPlaceholderText("Enter subdeck name")
-        self.name_input.textChanged.connect(self._update_add_notes_button_state)  # type: ignore[attr-defined]
+        qconnect(self.name_input.textChanged, self._update_add_notes_button_state)
         name_layout.addWidget(self.name_input)
         layout.addLayout(name_layout)
         layout.addSpacing(8)
@@ -258,11 +259,11 @@ class BlockExamSubdeckDialog(QDialog):
         button_layout.addStretch()
 
         cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self.reject)  # type: ignore[attr-defined]
+        qconnect(cancel_button.clicked, self.reject)
         button_layout.addWidget(cancel_button)
 
         add_button = QPushButton("Add notes")
-        add_button.clicked.connect(self._on_add_notes)  # type: ignore[attr-defined]
+        qconnect(add_button.clicked, self._on_add_notes)
         add_button.setDefault(True)
         # Enable initially if there's already a name, disable if empty
         add_button.setEnabled(bool(self.selected_subdeck_name and self.selected_subdeck_name.strip()))
@@ -323,15 +324,15 @@ class BlockExamSubdeckDialog(QDialog):
         button_layout.setSpacing(12)
 
         cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self.reject)  # type: ignore[attr-defined]
+        qconnect(cancel_button.clicked, self.reject)
         button_layout.addWidget(cancel_button)
 
         create_new_button = QPushButton("Create new")
-        create_new_button.clicked.connect(lambda: self._handle_conflict_create_new(conflicting_name))  # type: ignore[attr-defined]
+        qconnect(create_new_button.clicked, lambda: self._handle_conflict_create_new(conflicting_name))
         button_layout.addWidget(create_new_button)
 
         merge_button = QPushButton("Merge")
-        merge_button.clicked.connect(lambda: self._handle_conflict_merge(conflicting_name))  # type: ignore[attr-defined]
+        qconnect(merge_button.clicked, lambda: self._handle_conflict_merge(conflicting_name))
         merge_button.setDefault(True)
         button_layout.addWidget(merge_button)
 


### PR DESCRIPTION
Remove local error handling from block exam dialog.
Let exceptions propagate to the global `excepthook` which shows `ErrorDialog`, instead of catching and showing error messages locally.

Benefits:
  - Cleaner code
  - Consistent error UI across the addon

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/NRT/boards/41?useStoredSettings=true


## Proposed changes
- Remove try-except blocks from `BlockExamSubdeckDialog` methods
- Use `qconnect()` instead of `.connect()` in `BlockExamSubdeckDialog` methods
  - This just makes the code a bit nicer, it removes the need for the `type: ignore[attr-defined]` comments

## How to reproduce
You can reproduce the error handling like this:
- Add `raise Exception("test")` to `BlockExamSubdeckDialog._on_create_subdeck`
  - https://github.com/AnkiHubSoftware/ankihub_addon/blob/7f8a6fa3a7b5d320da68ac6e89dd76c7d342f0fd/ankihub/gui/block_exam_dialog.py#L417
- Create a block exam subdeck via the flashcard selector
- The global exception handler will catch the exception and show the error dialog:
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/57f2f020-7b2d-46b6-9f5c-26c0222676c4" />
