### PR TITLE
[NRT-748] Auto-protect fields when edited + Protect Fields dialog improvements

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -56,6 +56,7 @@ from ...main.note_conversion import (
     TAG_FOR_PROTECTING_ALL_FIELDS,
     TAG_FOR_PROTECTING_FIELDS,
     optional_tag_prefix_for_group,
+    protection_tag_for_field,
 )
 from ...main.reset_local_changes import reset_local_changes_to_notes
 from ...main.subdecks import SUBDECK_TAG, build_subdecks_and_move_cards_to_them
@@ -348,6 +349,16 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         )
         return
 
+    # The same note type can be shared across AnkiHub decks; require a single deck
+    # so the globally-protected-fields lock applies consistently to all selected notes.
+    ah_dids = {did for did in ankihub_db.ankihub_dids_for_anki_nids(nids) if did is not None}
+    if len(ah_dids) > 1:
+        showInfo(
+            "Please select notes from only one AnkiHub deck.",
+            parent=browser,
+        )
+        return
+
     note = aqt.mw.col.get_note(nids[0])
     field_names: List[str] = [field_name for field_name in note.keys() if field_name != ANKIHUB_NOTE_TYPE_FIELD_NAME]
     if len(nids) == 1:
@@ -356,10 +367,8 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         old_fields_protected_by_tags = []
 
     # Determine globally protected fields for this note's deck
-    ah_did = ankihub_db.ankihub_did_for_anki_nid(nids[0])
-    globally_protected: List[str] = []
-    if ah_did:
-        globally_protected = config.deck_config(ah_did).globally_protected_fields.get(note.mid, [])
+    ah_did = next(iter(ah_dids), None)
+    globally_protected = config.globally_protected_fields_for_note_type(ah_did, note.mid) if ah_did else []
 
     new_fields_protected_by_tags = choose_subset(
         "Choose which fields of this note should be protected from updates.<br><br>"
@@ -368,7 +377,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         "protect fields feature</a> on the AnkiHub website.",
         choices=field_names,
         current=old_fields_protected_by_tags,
-        description_html="This will edit the AnkiHub_Protect tags of the note.",
+        description_html=f"This will edit the {TAG_FOR_PROTECTING_FIELDS} tags of the note.",
         title="AnkiHub | Protect fields",
         disable_ok_when_unchanged=True,
         checked_and_disabled_choices=globally_protected,
@@ -384,11 +393,8 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         # if all fields are protected, we can just use the tag for protecting all fields
         new_tags_for_protecting_fields = [TAG_FOR_PROTECTING_ALL_FIELDS]
     else:
-        # otherwise we need to create a tag for each field.
-        # spaces are not allowed in tags, so we replace them with underscores
-        new_tags_for_protecting_fields = [
-            f"{TAG_FOR_PROTECTING_FIELDS}::{field.replace(' ', '_')}" for field in new_fields_protected_by_tags
-        ]
+        # otherwise we need to create a tag for each field
+        new_tags_for_protecting_fields = [protection_tag_for_field(field) for field in new_fields_protected_by_tags]
 
     def update_note_tags() -> None:
         notes = [aqt.mw.col.get_note(nid) for nid in nids]

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -77,6 +77,7 @@ from ..utils import (
     choose_list,
     choose_subset,
     sparkles_icon,
+    update_notes_with_named_undo,
 )
 from .custom_columns import (
     AnkiHubIdColumn,
@@ -405,10 +406,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
             # add new tags for protecting fields
             note.tags += new_tags_for_protecting_fields
 
-        # update the notes and add an undo entry
-        undo_entry_id = aqt.mw.col.add_custom_undo_entry("Protect fields of note(s) using tags")
-        aqt.mw.col.update_notes(notes)
-        aqt.mw.col.merge_undo_entries(undo_entry_id)
+        update_notes_with_named_undo("Protect fields of note(s) using tags", notes)
 
     def on_done(future: Future) -> None:
         future.result()

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -356,8 +356,8 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
     else:
         old_fields_protected_by_tags = []
 
-    # Note types are 1:1 with AH decks, so the single mid uniquely determines the deck.
-    ah_did = ankihub_db.ankihub_did_for_note_type(next(iter(mids)))
+    # Note types are 1:1 with AH decks, so the note's mid uniquely determines the deck.
+    ah_did = ankihub_db.ankihub_did_for_note_type(note.mid)
     globally_protected = config.globally_protected_fields_for_note_type(ah_did, note.mid) if ah_did else []
 
     new_fields_protected_by_tags = choose_subset(

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -349,16 +349,6 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         )
         return
 
-    # The same note type can be shared across AnkiHub decks; require a single deck
-    # so the globally-protected-fields lock applies consistently to all selected notes.
-    ah_dids = {did for did in ankihub_db.ankihub_dids_for_anki_nids(nids) if did is not None}
-    if len(ah_dids) > 1:
-        showInfo(
-            "Please select notes from only one AnkiHub deck.",
-            parent=browser,
-        )
-        return
-
     note = aqt.mw.col.get_note(nids[0])
     field_names: List[str] = [field_name for field_name in note.keys() if field_name != ANKIHUB_NOTE_TYPE_FIELD_NAME]
     if len(nids) == 1:
@@ -366,8 +356,8 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
     else:
         old_fields_protected_by_tags = []
 
-    # Determine globally protected fields for this note's deck
-    ah_did = next(iter(ah_dids), None)
+    # Note types are 1:1 with AH decks, so the single mid uniquely determines the deck.
+    ah_did = ankihub_db.ankihub_did_for_note_type(next(iter(mids)))
     globally_protected = config.globally_protected_fields_for_note_type(ah_did, note.mid) if ah_did else []
 
     new_fields_protected_by_tags = choose_subset(
@@ -382,7 +372,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         disable_ok_when_unchanged=True,
         checked_and_disabled_choices=globally_protected,
         checked_and_disabled_choices_tooltip=(
-            "This field is globally protected. Edit this setting on the AnkiHub website."
+            "This field is globally protected.\nEdit this setting on the AnkiHub website."
         ),
         parent=browser,
     )

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -60,7 +60,7 @@ from ...main.note_conversion import (
 )
 from ...main.reset_local_changes import reset_local_changes_to_notes
 from ...main.subdecks import SUBDECK_TAG, build_subdecks_and_move_cards_to_them
-from ...main.utils import mids_of_notes, retain_nids_with_ah_note_type
+from ...main.utils import mids_of_notes, retain_nids_with_ah_note_type, update_notes_with_named_undo
 from ...settings import ANKIHUB_NOTE_TYPE_FIELD_NAME, DeckExtensionConfig, config
 from ..deck_updater import NotLoggedInError
 from ..flashcard_selector_dialog import show_flashcard_selector
@@ -77,7 +77,6 @@ from ..utils import (
     choose_list,
     choose_subset,
     sparkles_icon,
-    update_notes_with_named_undo,
 )
 from .custom_columns import (
     AnkiHubIdColumn,

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -386,14 +386,23 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         # otherwise we need to create a tag for each field
         new_tags_for_protecting_fields = [protection_tag_for_field(field) for field in new_fields_protected_by_tags]
 
+    # `choose_subset` excludes locked (globally protected) fields from its return.
+    # Per-note `AnkiHub_Protect::<globally-protected-field>` tags that existed
+    # before this dialog represent user-authored intent (the user explicitly
+    # tagged the field, possibly before it was globally protected) and must
+    # survive the strip-and-rewrite below. Otherwise removing global protection
+    # later would silently leave the field unprotected.
+    globally_protected_tag_set_lower = {protection_tag_for_field(f).lower() for f in globally_protected}
+
     def update_note_tags() -> None:
         notes = [aqt.mw.col.get_note(nid) for nid in nids]
         for note in notes:
+            preserved_tags = [tag for tag in note.tags if tag.lower() in globally_protected_tag_set_lower]
             # remove old tags for protecting fields
             note.tags = [tag for tag in note.tags if not tag.lower().startswith(TAG_FOR_PROTECTING_FIELDS.lower())]
 
-            # add new tags for protecting fields
-            note.tags += new_tags_for_protecting_fields
+            # add new tags for protecting fields, plus tags preserved for globally-protected fields
+            note.tags += new_tags_for_protecting_fields + preserved_tags
 
         update_notes_with_named_undo("Protect fields of note(s) using tags", notes)
 

--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -355,15 +355,26 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
     else:
         old_fields_protected_by_tags = []
 
+    # Determine globally protected fields for this note's deck
+    ah_did = ankihub_db.ankihub_did_for_anki_nid(nids[0])
+    globally_protected: List[str] = []
+    if ah_did:
+        globally_protected = config.deck_config(ah_did).globally_protected_fields.get(note.mid, [])
+
     new_fields_protected_by_tags = choose_subset(
-        "Choose which fields of this note should be protected<br>"
-        "from updates.<br><br>"
-        "Tip: If you want to protect a field on every note, <br>"
-        "consider using the "
-        "<a href='https://community.ankihub.net/t/protecting-fields-and-tags/165604'>protected fields feature</a>.",
+        "Choose which fields of this note should be protected from updates.<br><br>"
+        "Tip: If you want to protect a field on every note, consider using the "
+        "<a href='https://community.ankihub.net/t/protecting-fields-and-tags/165604'>"
+        "protect fields feature</a> on the AnkiHub website.",
         choices=field_names,
         current=old_fields_protected_by_tags,
         description_html="This will edit the AnkiHub_Protect tags of the note.",
+        title="AnkiHub | Protect fields",
+        disable_ok_when_unchanged=True,
+        checked_and_disabled_choices=globally_protected,
+        checked_and_disabled_choices_tooltip=(
+            "This field is globally protected. Edit this setting on the AnkiHub website."
+        ),
         parent=browser,
     )
     if new_fields_protected_by_tags is None:

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -158,6 +158,8 @@ class _AnkiHubDeckUpdater:
         )
         self._import_results.append(import_result)
 
+        config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
+
         if deck_updates.latest_update:
             # latest_update is None if there were no notes in the updates
             config.save_latest_deck_update(ankihub_did, deck_updates.latest_update)

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -25,7 +25,7 @@ from ..main.utils import create_backup
 from ..settings import config
 from .media_sync import media_sync
 from .operations.scheduling import unsuspend_notes
-from .utils import deck_download_progress_cb, show_error_dialog
+from .utils import deck_download_progress_cb, show_error_dialog, update_notes_with_named_undo
 
 
 class NotLoggedInError(Exception):
@@ -314,16 +314,20 @@ def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[in
     personal protection tags added before the deck owner globally protected a field would silently
     keep blocking updates if the global protection were later removed.
     """
+    # Anki tags are case-preserving but case-insensitive, so compare in lowercase
+    # to match variants like `ankihub_protect::front` against `AnkiHub_Protect::Front`.
     redundant_tags_by_mid: Dict[int, set] = {
-        mid: {protection_tag_for_field(f) for f in fields} for mid, fields in globally_protected.items() if fields
+        mid: {protection_tag_for_field(f).lower() for f in fields}
+        for mid, fields in globally_protected.items()
+        if fields
     }
     if not redundant_tags_by_mid:
         return
 
-    # Narrow the candidate set with a single Anki tag search instead of scanning the whole deck.
-    candidate_nids = set(aqt.mw.col.find_notes(f'"tag:{TAG_FOR_PROTECTING_FIELDS}::*"'))
-    if not candidate_nids:
-        return
+    # Narrow at the Anki search layer so we don't scan notes outside this deck;
+    # intersect with ankihub_db as a safety net for shared note types across AH decks.
+    deck_name = aqt.mw.col.decks.name(config.deck_config(ah_did).anki_id)
+    candidate_nids = set(aqt.mw.col.find_notes(f'deck:"{deck_name}" "tag:{TAG_FOR_PROTECTING_FIELDS}::*"'))
     candidate_nids &= set(ankihub_db.anki_nids_for_ankihub_deck(ah_did))
     if not candidate_nids:
         return
@@ -334,7 +338,7 @@ def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[in
         redundant = redundant_tags_by_mid.get(note.mid)
         if not redundant:
             continue
-        new_tags = [t for t in note.tags if t not in redundant]
+        new_tags = [t for t in note.tags if t.lower() not in redundant]
         if new_tags == note.tags:
             continue
         note.tags = new_tags
@@ -343,9 +347,7 @@ def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[in
     if not notes_to_update:
         return
 
-    undo_entry_id = aqt.mw.col.add_custom_undo_entry("AnkiHub | Remove redundant protect tags")
-    aqt.mw.col.update_notes(notes_to_update)
-    aqt.mw.col.merge_undo_entries(undo_entry_id)
+    update_notes_with_named_undo("AnkiHub | Remove redundant protect tags", notes_to_update)
     LOGGER.info(
         "Removed redundant AnkiHub_Protect tags from notes overlapping globally protected fields.",
         ah_did=ah_did,

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -18,7 +18,6 @@ from ..db import ankihub_db
 from ..main.importing import AnkiHubImporter, AnkiHubImportResult
 from ..main.note_conversion import (
     is_tag_for_group,
-    protection_tag_for_field,
 )
 from ..main.utils import create_backup
 from ..settings import config
@@ -161,11 +160,7 @@ class _AnkiHubDeckUpdater:
         )
         self._import_results.append(import_result)
 
-        # Sweep first, then update the cache — if the sweep raises, leave the
-        # cached value stale so the next sync retries the cleanup.
-        if dict(deck_config.globally_protected_fields) != deck_updates.protected_fields:
-            _strip_redundant_protect_tags(ankihub_did, deck_updates.protected_fields)
-            config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
+        config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
 
         if deck_updates.latest_update:
             # latest_update is None if there were no notes in the updates
@@ -303,46 +298,6 @@ def show_tooltip_about_last_deck_updates_results() -> None:
             f"AnkiHub: Updated {total} note{'' if total == 1 else 's'}.",
             parent=aqt.mw,
         )
-
-
-def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected_fields: Dict[int, List[str]]) -> None:
-    """Remove personal AnkiHub_Protect::<field> tags that duplicate now-globally-protected fields.
-
-    Runs after the sync caches a new globally_protected_fields value for the deck. Without this,
-    personal protection tags added before the deck owner globally protected a field would silently
-    keep blocking updates if the global protection were later removed.
-    """
-    # Anki tags are case-preserving but case-insensitive, so compare in lowercase
-    # to match variants like `ankihub_protect::front` against `AnkiHub_Protect::Front`.
-    redundant_tags_by_mid: Dict[int, set] = {
-        mid: {protection_tag_for_field(f).lower() for f in fields}
-        for mid, fields in globally_protected_fields.items()
-        if fields
-    }
-    if not redundant_tags_by_mid:
-        return
-
-    notes_to_update = []
-    for mid, redundant_tags in redundant_tags_by_mid.items():
-        tag_filter = " OR ".join(f'"tag:{tag}"' for tag in redundant_tags)
-        nids = aqt.mw.col.find_notes(f"mid:{mid} ({tag_filter})")
-        for nid in nids:
-            note = aqt.mw.col.get_note(nid)
-            new_tags = [t for t in note.tags if t.lower() not in redundant_tags]
-            if new_tags == note.tags:
-                continue
-            note.tags = new_tags
-            notes_to_update.append(note)
-
-    if not notes_to_update:
-        return
-
-    aqt.mw.col.update_notes(notes_to_update)
-    LOGGER.info(
-        "Removed redundant AnkiHub_Protect tags from notes overlapping globally protected fields.",
-        ah_did=ah_did,
-        note_count=len(notes_to_update),
-    )
 
 
 def _update_deck_updates_download_progress_cb(notes_count: int, ankihub_did: uuid.UUID) -> None:

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -17,7 +17,6 @@ from ..ankihub_client.models import NotesActionChoices
 from ..db import ankihub_db
 from ..main.importing import AnkiHubImporter, AnkiHubImportResult
 from ..main.note_conversion import (
-    TAG_FOR_PROTECTING_FIELDS,
     is_tag_for_group,
     protection_tag_for_field,
 )
@@ -25,7 +24,7 @@ from ..main.utils import create_backup
 from ..settings import config
 from .media_sync import media_sync
 from .operations.scheduling import unsuspend_notes
-from .utils import deck_download_progress_cb, show_error_dialog, update_notes_with_named_undo
+from .utils import deck_download_progress_cb, show_error_dialog
 
 
 class NotLoggedInError(Exception):
@@ -307,7 +306,7 @@ def show_tooltip_about_last_deck_updates_results() -> None:
         )
 
 
-def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[int, List[str]]) -> None:
+def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected_fields: Dict[int, List[str]]) -> None:
     """Remove personal AnkiHub_Protect::<field> tags that duplicate now-globally-protected fields.
 
     Runs after the sync caches a new globally_protected_fields value for the deck. Without this,
@@ -318,36 +317,28 @@ def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[in
     # to match variants like `ankihub_protect::front` against `AnkiHub_Protect::Front`.
     redundant_tags_by_mid: Dict[int, set] = {
         mid: {protection_tag_for_field(f).lower() for f in fields}
-        for mid, fields in globally_protected.items()
+        for mid, fields in globally_protected_fields.items()
         if fields
     }
     if not redundant_tags_by_mid:
         return
 
-    # Narrow at the Anki search layer so we don't scan notes outside this deck;
-    # intersect with ankihub_db as a safety net for shared note types across AH decks.
-    deck_name = aqt.mw.col.decks.name(config.deck_config(ah_did).anki_id)
-    candidate_nids = set(aqt.mw.col.find_notes(f'deck:"{deck_name}" "tag:{TAG_FOR_PROTECTING_FIELDS}::*"'))
-    candidate_nids &= set(ankihub_db.anki_nids_for_ankihub_deck(ah_did))
-    if not candidate_nids:
-        return
-
     notes_to_update = []
-    for nid in candidate_nids:
-        note = aqt.mw.col.get_note(nid)
-        redundant = redundant_tags_by_mid.get(note.mid)
-        if not redundant:
-            continue
-        new_tags = [t for t in note.tags if t.lower() not in redundant]
-        if new_tags == note.tags:
-            continue
-        note.tags = new_tags
-        notes_to_update.append(note)
+    for mid, redundant_tags in redundant_tags_by_mid.items():
+        tag_filter = " OR ".join(f'"tag:{tag}"' for tag in redundant_tags)
+        nids = aqt.mw.col.find_notes(f"mid:{mid} ({tag_filter})")
+        for nid in nids:
+            note = aqt.mw.col.get_note(nid)
+            new_tags = [t for t in note.tags if t.lower() not in redundant_tags]
+            if new_tags == note.tags:
+                continue
+            note.tags = new_tags
+            notes_to_update.append(note)
 
     if not notes_to_update:
         return
 
-    update_notes_with_named_undo("AnkiHub | Remove redundant protect tags", notes_to_update)
+    aqt.mw.col.update_notes(notes_to_update)
     LOGGER.info(
         "Removed redundant AnkiHub_Protect tags from notes overlapping globally protected fields.",
         ah_did=ah_did,

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -161,12 +161,11 @@ class _AnkiHubDeckUpdater:
         )
         self._import_results.append(import_result)
 
-        # Compare against the cached value before updating so we can detect changes
-        # and run the redundant-tag sweep only when needed.
-        old_globally_protected = dict(deck_config.globally_protected_fields)
-        config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
-        if old_globally_protected != deck_updates.protected_fields:
+        # Sweep first, then update the cache — if the sweep raises, leave the
+        # cached value stale so the next sync retries the cleanup.
+        if dict(deck_config.globally_protected_fields) != deck_updates.protected_fields:
             _strip_redundant_protect_tags(ankihub_did, deck_updates.protected_fields)
+            config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
 
         if deck_updates.latest_update:
             # latest_update is None if there were no notes in the updates

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -16,7 +16,11 @@ from ..ankihub_client import AnkiHubHTTPError, DeckExtension
 from ..ankihub_client.models import NotesActionChoices
 from ..db import ankihub_db
 from ..main.importing import AnkiHubImporter, AnkiHubImportResult
-from ..main.note_conversion import is_tag_for_group
+from ..main.note_conversion import (
+    TAG_FOR_PROTECTING_FIELDS,
+    is_tag_for_group,
+    protection_tag_for_field,
+)
 from ..main.utils import create_backup
 from ..settings import config
 from .media_sync import media_sync
@@ -158,7 +162,12 @@ class _AnkiHubDeckUpdater:
         )
         self._import_results.append(import_result)
 
+        # Compare against the cached value before updating so we can detect changes
+        # and run the redundant-tag sweep only when needed.
+        old_globally_protected = dict(deck_config.globally_protected_fields)
         config.set_globally_protected_fields(ankihub_did, deck_updates.protected_fields)
+        if old_globally_protected != deck_updates.protected_fields:
+            _strip_redundant_protect_tags(ankihub_did, deck_updates.protected_fields)
 
         if deck_updates.latest_update:
             # latest_update is None if there were no notes in the updates
@@ -296,6 +305,52 @@ def show_tooltip_about_last_deck_updates_results() -> None:
             f"AnkiHub: Updated {total} note{'' if total == 1 else 's'}.",
             parent=aqt.mw,
         )
+
+
+def _strip_redundant_protect_tags(ah_did: uuid.UUID, globally_protected: Dict[int, List[str]]) -> None:
+    """Remove personal AnkiHub_Protect::<field> tags that duplicate now-globally-protected fields.
+
+    Runs after the sync caches a new globally_protected_fields value for the deck. Without this,
+    personal protection tags added before the deck owner globally protected a field would silently
+    keep blocking updates if the global protection were later removed.
+    """
+    redundant_tags_by_mid: Dict[int, set] = {
+        mid: {protection_tag_for_field(f) for f in fields} for mid, fields in globally_protected.items() if fields
+    }
+    if not redundant_tags_by_mid:
+        return
+
+    # Narrow the candidate set with a single Anki tag search instead of scanning the whole deck.
+    candidate_nids = set(aqt.mw.col.find_notes(f'"tag:{TAG_FOR_PROTECTING_FIELDS}::*"'))
+    if not candidate_nids:
+        return
+    candidate_nids &= set(ankihub_db.anki_nids_for_ankihub_deck(ah_did))
+    if not candidate_nids:
+        return
+
+    notes_to_update = []
+    for nid in candidate_nids:
+        note = aqt.mw.col.get_note(nid)
+        redundant = redundant_tags_by_mid.get(note.mid)
+        if not redundant:
+            continue
+        new_tags = [t for t in note.tags if t not in redundant]
+        if new_tags == note.tags:
+            continue
+        note.tags = new_tags
+        notes_to_update.append(note)
+
+    if not notes_to_update:
+        return
+
+    undo_entry_id = aqt.mw.col.add_custom_undo_entry("AnkiHub | Remove redundant protect tags")
+    aqt.mw.col.update_notes(notes_to_update)
+    aqt.mw.col.merge_undo_entries(undo_entry_id)
+    LOGGER.info(
+        "Removed redundant AnkiHub_Protect tags from notes overlapping globally protected fields.",
+        ah_did=ah_did,
+        note_count=len(notes_to_update),
+    )
 
 
 def _update_deck_updates_download_progress_cb(notes_count: int, ankihub_did: uuid.UUID) -> None:

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -150,7 +150,9 @@ class DeckManagementDialog(QDialog):
         return box
 
     def _setup_box_bottom_left(self) -> QVBoxLayout:
-        self.decks_list_label = QLabel("<b>Subscribed AnkiHub Decks</b>")
+        self.decks_list_label = QLabel(
+            '<span style="font-size: 16px; font-weight: 800; line-height: 100%;">Subscribed AnkiHub Decks</span>'
+        )
         self.decks_list_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
 
         self.decks_list = QListWidget()
@@ -183,12 +185,12 @@ class DeckManagementDialog(QDialog):
         # Deck Actions
         self.box_deck_actions = self._setup_box_deck_actions()
         self.box_bottom_right.addLayout(self.box_deck_actions)
-        self.box_bottom_right.addSpacing(20)
+        self.box_bottom_right.addSpacing(16)
 
         # Deck Options
         self.box_deck_options = self._setup_box_deck_options(selected_ah_did)
         self.box_bottom_right.addLayout(self.box_deck_options)
-        self.box_bottom_right.addSpacing(20)
+        self.box_bottom_right.addSpacing(16)
 
         if selected_ah_did not in config.deck_ids():
             self.box_bottom_right.addStretch()
@@ -255,14 +257,20 @@ class DeckManagementDialog(QDialog):
         # Setup "Remove AnkiHub deleted notes from deck"
         self.box_ankihub_deleted_notes_behavior = self._setup_box_ankihub_deleted_notes_behavior(selected_ah_did)
 
+        # Setup "Automatically protect fields when edited"
+        self.box_auto_protect_fields = self._setup_box_auto_protect_fields_when_edited(selected_ah_did)
+
         # Add individual elements to the deck options elements box
         self.box_deck_options_elements = QVBoxLayout()
         self.box_deck_options_elements.addLayout(self.box_suspend_new_cards_of_existing_notes)
+        self.box_deck_options_elements.addSpacing(8)
         self.box_deck_options_elements.addLayout(self.box_suspend_new_cards_of_new_notes)
-        self.box_deck_options_elements.addSpacing(10)
+        self.box_deck_options_elements.addSpacing(8)
         self.box_deck_options_elements.addLayout(self.box_subdecks_enabled)
-        self.box_deck_options_elements.addSpacing(10)
+        self.box_deck_options_elements.addSpacing(8)
         self.box_deck_options_elements.addLayout(self.box_ankihub_deleted_notes_behavior)
+        self.box_deck_options_elements.addSpacing(8)
+        self.box_deck_options_elements.addLayout(self.box_auto_protect_fields)
 
         # Add everything to the result layout
         box = QVBoxLayout()
@@ -420,11 +428,12 @@ class DeckManagementDialog(QDialog):
         self.subdecks_docs_link_label = QLabel(
             """
             <a href="https://community.ankihub.net/t/creating-a-deck/103683#subdecks-and-subdeck-tags-2">
-                More about subdecks
+                Learn about subdecks
             </a>
             """
         )
         self.subdecks_docs_link_label.setOpenExternalLinks(True)
+        self.subdecks_docs_link_label.setContentsMargins(20, 0, 0, 0)
 
         # Add everything to the result layout
         box = QVBoxLayout()
@@ -479,6 +488,53 @@ class DeckManagementDialog(QDialog):
 
         return box
 
+    def _setup_box_auto_protect_fields_when_edited(self, selected_ah_did: uuid.UUID) -> QVBoxLayout:
+        deck_config = config.deck_config(selected_ah_did)
+
+        auto_protect_tooltip_message = (
+            "When enabled, any field you edit will be automatically protected "
+            "so your changes aren't overwritten by future note updates."
+        )
+
+        # Setup checkbox
+        self.auto_protect_fields_cb = QCheckBox("Automatically protect fields when edited")
+        set_styled_tooltip(self.auto_protect_fields_cb, auto_protect_tooltip_message)
+        self.auto_protect_fields_cb.setChecked(deck_config.auto_protect_fields_when_edited)
+        qconnect(
+            self.auto_protect_fields_cb.toggled,
+            lambda: config.set_auto_protect_fields_when_edited(
+                selected_ah_did, self.auto_protect_fields_cb.isChecked()
+            ),
+        )
+
+        # Setup tooltip icon
+        self.auto_protect_fields_icon_label = QLabel()
+        self.auto_protect_fields_icon_label.setPixmap(tooltip_icon().pixmap(16, 16))
+        set_styled_tooltip(self.auto_protect_fields_icon_label, auto_protect_tooltip_message)
+
+        # Checkbox row
+        self.auto_protect_fields_row = QHBoxLayout()
+        self.auto_protect_fields_row.addWidget(self.auto_protect_fields_cb)
+        self.auto_protect_fields_row.addWidget(self.auto_protect_fields_icon_label)
+        self.auto_protect_fields_row.addStretch()
+
+        # Help link
+        self.auto_protect_fields_docs_link_label = QLabel(
+            """
+            <a href="https://community.ankihub.net/t/protecting-fields-and-tags/165604">
+                Learn about protecting fields
+            </a>
+            """
+        )
+        self.auto_protect_fields_docs_link_label.setOpenExternalLinks(True)
+        self.auto_protect_fields_docs_link_label.setContentsMargins(20, 0, 0, 0)
+
+        box = QVBoxLayout()
+        box.addLayout(self.auto_protect_fields_row)
+        box.addWidget(self.auto_protect_fields_docs_link_label)
+
+        return box
+
     def _setup_box_new_cards_destination(self, selected_ah_did: uuid.UUID) -> QVBoxLayout:
         # Set up the destination tooltip message
         new_cards_destination_tooltip_message = "Select the deck you want new cards to be saved to."
@@ -527,7 +583,7 @@ class DeckManagementDialog(QDialog):
         box.addLayout(self.new_cards_destination_label_row)
         box.addWidget(self.new_cards_destination_details_label)
         box.addWidget(self.set_new_cards_destination_btn)
-        box.addSpacing(5)
+        box.addSpacing(8)
         box.addWidget(self.new_cards_destination_docs_link_label)
 
         return box
@@ -538,7 +594,7 @@ class DeckManagementDialog(QDialog):
         if deck_config.user_relation != UserDeckRelation.OWNER:
             return box
 
-        self.note_types_label = QLabel("<b>📝 Note Types</b>")
+        self.note_types_label = QLabel("<b>Note Types</b>")
         self.add_note_type_btn = QPushButton("Publish note type")
         qconnect(self.add_note_type_btn.clicked, self._on_add_note_type_btn_clicked)
         self._update_add_note_type_btn_state()
@@ -549,8 +605,11 @@ class DeckManagementDialog(QDialog):
         qconnect(self.update_templates_btn.clicked, self._on_update_templates_btn_clicked)
         self._update_templates_btn_state()
         box.addWidget(self.note_types_label)
+        box.addSpacing(8)
         box.addWidget(self.add_note_type_btn)
+        box.addSpacing(4)
         box.addWidget(self.add_field_btn)
+        box.addSpacing(4)
         box.addWidget(self.update_templates_btn)
 
         return box

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -508,9 +508,7 @@ class DeckManagementDialog(QDialog):
         self.auto_protect_fields_cb.setChecked(deck_config.auto_protect_fields_when_edited)
         qconnect(
             self.auto_protect_fields_cb.toggled,
-            lambda: config.set_auto_protect_fields_when_edited(
-                selected_ah_did, self.auto_protect_fields_cb.isChecked()
-            ),
+            lambda checked: self._on_auto_protect_fields_toggled(selected_ah_did, checked),
         )
 
         # Setup tooltip icon
@@ -540,6 +538,10 @@ class DeckManagementDialog(QDialog):
         box.addWidget(self.auto_protect_fields_docs_link_label)
 
         return box
+
+    def _on_auto_protect_fields_toggled(self, ah_did: uuid.UUID, checked: bool) -> None:
+        config.set_auto_protect_fields_when_edited(ah_did, checked)
+        LOGGER.info("auto_protect_fields_toggled", value=checked, ah_did=str(ah_did))
 
     def _setup_box_new_cards_destination(self, selected_ah_did: uuid.UUID) -> QVBoxLayout:
         # Set up the destination tooltip message

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -496,8 +496,10 @@ class DeckManagementDialog(QDialog):
         deck_config = config.deck_config(selected_ah_did)
 
         auto_protect_tooltip_message = (
-            "When enabled, any field you edit will be automatically protected "
-            "so your changes aren't overwritten by future note updates."
+            "When enabled, any field you edit\n"
+            "will be automatically protected\n"
+            "so your changes aren't overwritten\n"
+            "by future note updates."
         )
 
         # Setup checkbox

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -257,8 +257,11 @@ class DeckManagementDialog(QDialog):
         # Setup "Remove AnkiHub deleted notes from deck"
         self.box_ankihub_deleted_notes_behavior = self._setup_box_ankihub_deleted_notes_behavior(selected_ah_did)
 
-        # Setup "Automatically protect fields when edited"
-        self.box_auto_protect_fields = self._setup_box_auto_protect_fields_when_edited(selected_ah_did)
+        # Setup "Automatically protect fields when edited" (gated on a server-controlled flag
+        # — the suggestion dialog needs to ship before this option is meaningful to users)
+        auto_protect_enabled = (config.get_feature_flags() or {}).get("auto_protect_fields_when_edited", False)
+        if auto_protect_enabled:
+            self.box_auto_protect_fields = self._setup_box_auto_protect_fields_when_edited(selected_ah_did)
 
         # Add individual elements to the deck options elements box
         self.box_deck_options_elements = QVBoxLayout()
@@ -269,8 +272,9 @@ class DeckManagementDialog(QDialog):
         self.box_deck_options_elements.addLayout(self.box_subdecks_enabled)
         self.box_deck_options_elements.addSpacing(8)
         self.box_deck_options_elements.addLayout(self.box_ankihub_deleted_notes_behavior)
-        self.box_deck_options_elements.addSpacing(8)
-        self.box_deck_options_elements.addLayout(self.box_auto_protect_fields)
+        if auto_protect_enabled:
+            self.box_deck_options_elements.addSpacing(8)
+            self.box_deck_options_elements.addLayout(self.box_auto_protect_fields)
 
         # Add everything to the result layout
         box = QVBoxLayout()

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -100,7 +100,7 @@ class DeckManagementDialog(QDialog):
     def _setup_ui(self):
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.setWindowTitle("AnkiHub | Deck Management")
-        self.setMinimumWidth(720)
+        self.setMinimumWidth(680)
         self.setMinimumHeight(820)
 
         self.box_main = QVBoxLayout()
@@ -150,6 +150,11 @@ class DeckManagementDialog(QDialog):
         screen = QApplication.primaryScreen()
         if screen is not None:
             self.setMaximumHeight(int(screen.availableGeometry().height() * 0.9))
+
+        # Force initial size to the minimum so platforms whose content sizeHint
+        # would otherwise open the dialog wider (observed on Linux) don't waste
+        # horizontal space. Users can still drag wider.
+        self.resize(680, 820)
 
     def _setup_box_top(self) -> QVBoxLayout:
         self.box_top_buttons = QHBoxLayout()

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -9,19 +9,23 @@ import aqt
 from anki.decks import DeckId
 from anki.models import NotetypeId, NotetypeNameId
 from aqt.qt import (
+    QApplication,
     QBoxLayout,
     QCheckBox,
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QFrame,
     QHBoxLayout,
     QLabel,
     QListWidget,
     QListWidgetItem,
     QPushButton,
+    QScrollArea,
     QSizePolicy,
     Qt,
     QVBoxLayout,
+    QWidget,
     qconnect,
 )
 from aqt.theme import theme_manager
@@ -96,8 +100,8 @@ class DeckManagementDialog(QDialog):
     def _setup_ui(self):
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self.setWindowTitle("AnkiHub | Deck Management")
-        self.setMinimumWidth(640)
-        self.setMinimumHeight(750)
+        self.setMinimumWidth(720)
+        self.setMinimumHeight(820)
 
         self.box_main = QVBoxLayout()
 
@@ -109,23 +113,43 @@ class DeckManagementDialog(QDialog):
 
         self.box_bottom = QHBoxLayout()
 
-        # Set up the bottom-left layout and add it to the bottom layout
+        # Set up the bottom-left layout and add it to the bottom layout. The left
+        # column only needs to display deck names, so give it a smaller share of the
+        # horizontal space via stretch factors below.
         self.box_bottom_left = self._setup_box_bottom_left()
         self.box_bottom_left.addSpacing(10)
         self.box_bottom.addSpacing(10)
-        self.box_bottom.addLayout(self.box_bottom_left)
+        self.box_bottom.addLayout(self.box_bottom_left, 2)
 
-        # Set up the bottom-right layout and add it to the bottom layout
+        # Set up the bottom-right layout inside a scroll area so that adding deck-option
+        # rows can never truncate labels on platforms where Qt font metrics are larger
+        # (e.g. macOS) or when the dialog is sized down to fit smaller screens.
         self.box_bottom_right = QVBoxLayout()
         self._refresh_box_bottom_right()
         self.box_bottom_right.addSpacing(10)
+
+        right_container = QWidget()
+        right_container.setLayout(self.box_bottom_right)
+
+        self.right_scroll_area = QScrollArea()
+        self.right_scroll_area.setWidget(right_container)
+        self.right_scroll_area.setWidgetResizable(True)
+        self.right_scroll_area.setFrameShape(QFrame.Shape.NoFrame)
+        self.right_scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.right_scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+
         self.box_bottom.addSpacing(10)
-        self.box_bottom.addLayout(self.box_bottom_right)
+        self.box_bottom.addWidget(self.right_scroll_area, 3)
         self.box_bottom.addSpacing(10)
 
         self.box_main.addLayout(self.box_bottom)
 
         self.setLayout(self.box_main)
+
+        # Cap the dialog's height to the screen so it stays usable on small displays.
+        screen = QApplication.primaryScreen()
+        if screen is not None:
+            self.setMaximumHeight(int(screen.availableGeometry().height() * 0.9))
 
     def _setup_box_top(self) -> QVBoxLayout:
         self.box_top_buttons = QHBoxLayout()

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -3,9 +3,8 @@
 import functools
 from typing import Any, List, Tuple, cast
 
-import anki
-import aqt
 from anki.models import NoteType
+from anki.notes import Note
 from aqt import gui_hooks
 from aqt.addcards import AddCards
 from aqt.editor import Editor
@@ -16,8 +15,10 @@ from .. import settings
 from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
+from ..main.note_conversion import TAG_FOR_PROTECTING_FIELDS
 from ..settings import (
     ANKI_INT_VERSION,
+    ANKIHUB_NOTE_TYPE_FIELD_NAME,
     ICONS_PATH,
     AnkiHubCommands,
     config,
@@ -35,6 +36,7 @@ VIEW_NOTE_HISTORY_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note-history"
 def setup() -> None:
     _setup_additional_editor_buttons()
     _setup_hide_ankihub_field()
+    _setup_auto_protect_fields_when_edited()
 
 
 def _setup_additional_editor_buttons():
@@ -52,6 +54,51 @@ def _setup_hide_ankihub_field():
     gui_hooks.editor_will_load_note.append(_hide_ankihub_field_in_editor)
 
 
+def _setup_auto_protect_fields_when_edited():
+    gui_hooks.editor_did_unfocus_field.append(_on_field_unfocus_auto_protect)
+
+
+def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx: int) -> bool:
+    """Hook handler for editor_did_unfocus_field.
+
+    Returns True if the note was modified (tag added or removed), otherwise returns
+    the original value of `changed`. Anki uses the return value to decide whether to
+    save the note.
+    """
+    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
+    if not ah_did:
+        return changed
+
+    deck_config = config.deck_config(ah_did)
+    if not deck_config.auto_protect_fields_when_edited:
+        return changed
+
+    field_name = note.keys()[current_field_idx]
+    if field_name == ANKIHUB_NOTE_TYPE_FIELD_NAME:
+        return changed
+
+    # Skip if globally protected for this deck (managed by deck owner, not locally)
+    if field_name in deck_config.globally_protected_fields.get(note.mid, []):
+        return changed
+
+    protection_tag = f"{TAG_FOR_PROTECTING_FIELDS}::{field_name.replace(' ', '_')}"
+    ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
+    ah_field_value = ah_note.fields.get(field_name, "") if ah_note and ah_note.fields else None
+
+    if ah_field_value is not None and note[field_name] != ah_field_value:
+        # Field differs from AnkiHub version — add protection if not already present
+        if protection_tag not in note.tags:
+            note.tags.append(protection_tag)
+            return True
+    elif ah_field_value is not None and note[field_name] == ah_field_value:
+        # Field matches AnkiHub version — remove protection tag if present
+        if protection_tag in note.tags:
+            note.tags.remove(protection_tag)
+            return True
+
+    return changed
+
+
 def _on_suggestion_button_press(editor: Editor) -> None:
     """
     Action to be performed when the AnkiHub icon button is clicked or when
@@ -64,7 +111,7 @@ def _on_suggestion_button_press(editor: Editor) -> None:
 
     # The command is expected to have been set at this point already, either by
     # fetching the default or by selecting a command from the dropdown menu.
-    def on_did_add_note(note: anki.notes.Note) -> None:
+    def on_did_add_note(note: Note) -> None:
         gui_hooks.add_cards_did_add_note.remove(on_did_add_note)
         if not sip.isdeleted(editor.widget):
             open_suggestion_dialog_for_single_suggestion(note, parent=editor.widget)
@@ -175,7 +222,7 @@ def _on_view_note_history_button_press(editor: Editor) -> None:
     openLink(url)
 
 
-def _hide_ankihub_field_in_editor(js: str, note: anki.notes.Note, _: aqt.editor.Editor) -> str:
+def _hide_ankihub_field_in_editor(js: str, note: Note, _: Editor) -> str:
     """Add JS to the JS code of the editor to hide the ankihub_id field if it is present."""
     hide_last_field = settings.ANKIHUB_NOTE_TYPE_FIELD_NAME in note
     if ANKI_INT_VERSION >= 50:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -85,12 +85,15 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
     ah_field_value = ah_note.fields.get(field_name, "") if ah_note and ah_note.fields else None
 
-    if ah_field_value is not None and note[field_name] != ah_field_value:
+    if ah_field_value is None:
+        return changed
+
+    if note[field_name] != ah_field_value:
         # Field differs from AnkiHub version — add protection if not already present
         if protection_tag not in note.tags:
             note.tags.append(protection_tag)
             return True
-    elif ah_field_value is not None and note[field_name] == ah_field_value:
+    else:
         # Field matches AnkiHub version — remove protection tag if present
         if protection_tag in note.tags:
             note.tags.remove(protection_tag)

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -16,6 +16,7 @@ from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
 from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
+from ..main.utils import update_notes_with_named_undo
 from ..settings import (
     ANKI_INT_VERSION,
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
@@ -26,7 +27,6 @@ from ..settings import (
     url_view_note_history,
 )
 from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
-from .utils import update_notes_with_named_undo
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -92,11 +92,13 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
         return changed
 
     ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
-    if not ah_note or not ah_note.fields or field_name not in ah_note.fields:
+    if not ah_note:
         return changed
 
+    # ah_note.fields omits empty fields, so treat a missing field name as empty
+    ah_field_value = (ah_note.fields or {}).get(field_name, "")
     protection_tag = protection_tag_for_field(field_name)
-    should_be_protected = note[field_name] != ah_note.fields[field_name]
+    should_be_protected = note[field_name] != ah_field_value
     if should_be_protected and protection_tag not in note.tags:
         # Field differs from AnkiHub version — add protection if not already present
         note.tags.append(protection_tag)

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -3,7 +3,7 @@
 import functools
 from typing import Any, List, Tuple, cast
 
-from anki.models import NoteType
+from anki.models import NoteType, NotetypeId
 from anki.notes import Note
 from aqt import gui_hooks
 from aqt.addcards import AddCards
@@ -93,6 +93,12 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
 
     ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
     if not ah_note:
+        return changed
+
+    # Skip fields the user added locally to the note type — they don't exist on
+    # AnkiHub, so protecting them has no effect and just leaves stale tags.
+    ah_field_names_lower = {f.lower() for f in ankihub_db.note_type_field_names(NotetypeId(note.mid))}
+    if field_name.lower() not in ah_field_names_lower:
         return changed
 
     # ah_note.fields omits empty fields, so treat a missing field name as empty

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -16,7 +16,7 @@ from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
 from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
-from ..main.utils import update_notes_with_named_undo
+from ..main.utils import is_tag_in_list, update_notes_with_named_undo
 from ..settings import (
     ANKI_INT_VERSION,
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
@@ -80,7 +80,7 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
         return changed
 
     # If all fields are already covered by the "All" tag, no per-field tag is needed.
-    if TAG_FOR_PROTECTING_ALL_FIELDS in note.tags:
+    if is_tag_in_list(TAG_FOR_PROTECTING_ALL_FIELDS, note.tags):
         return changed
 
     field_name = note.note_type()["flds"][current_field_idx]["name"]
@@ -99,14 +99,14 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     ah_field_value = (ah_note.fields or {}).get(field_name, "")
     protection_tag = protection_tag_for_field(field_name)
     should_be_protected = note[field_name] != ah_field_value
-    if should_be_protected and protection_tag not in note.tags:
+    if should_be_protected and not is_tag_in_list(protection_tag, note.tags):
         # Field differs from AnkiHub version — add protection if not already present
         note.tags.append(protection_tag)
         update_notes_with_named_undo(f"AnkiHub | Auto-protect {field_name}", note)
         return True
-    if not should_be_protected and protection_tag in note.tags:
+    if not should_be_protected and is_tag_in_list(protection_tag, note.tags):
         # Field matches AnkiHub version — remove protection tag if present
-        note.tags.remove(protection_tag)
+        note.tags = [t for t in note.tags if t.lower() != protection_tag.lower()]
         update_notes_with_named_undo(f"AnkiHub | Auto-unprotect {field_name}", note)
         return True
     return changed

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -66,6 +66,11 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     the original value of `changed`. Anki re-loads the note from the DB when this
     returns True, so the tag mutation is persisted via update_note() before returning.
     """
+    # Server-controlled rollout gate: the suggestion dialog needs to ship before
+    # auto-protect is safe to enable (otherwise edits get silently stripped on suggest).
+    if not (config.get_feature_flags() or {}).get("auto_protect_fields_when_edited", False):
+        return changed
+
     ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
     if not ah_did:
         return changed

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -3,7 +3,6 @@
 import functools
 from typing import Any, List, Tuple, cast
 
-import aqt
 from anki.models import NoteType
 from anki.notes import Note
 from aqt import gui_hooks
@@ -27,6 +26,7 @@ from ..settings import (
     url_view_note_history,
 )
 from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
+from .utils import update_notes_with_named_undo
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"
@@ -95,20 +95,14 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     if should_be_protected and protection_tag not in note.tags:
         # Field differs from AnkiHub version — add protection if not already present
         note.tags.append(protection_tag)
-        _save_with_named_undo(note, f"AnkiHub | Auto-protect {field_name}")
+        update_notes_with_named_undo(f"AnkiHub | Auto-protect {field_name}", note)
         return True
     if not should_be_protected and protection_tag in note.tags:
         # Field matches AnkiHub version — remove protection tag if present
         note.tags.remove(protection_tag)
-        _save_with_named_undo(note, f"AnkiHub | Auto-unprotect {field_name}")
+        update_notes_with_named_undo(f"AnkiHub | Auto-unprotect {field_name}", note)
         return True
     return changed
-
-
-def _save_with_named_undo(note: Note, undo_label: str) -> None:
-    undo_entry_id = aqt.mw.col.add_custom_undo_entry(undo_label)
-    aqt.mw.col.update_note(note)
-    aqt.mw.col.merge_undo_entries(undo_entry_id)
 
 
 def _on_suggestion_button_press(editor: Editor) -> None:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -3,6 +3,7 @@
 import functools
 from typing import Any, List, Tuple, cast
 
+import aqt
 from anki.models import NoteType
 from anki.notes import Note
 from aqt import gui_hooks
@@ -15,7 +16,7 @@ from .. import settings
 from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
-from ..main.note_conversion import TAG_FOR_PROTECTING_FIELDS
+from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
 from ..settings import (
     ANKI_INT_VERSION,
     ANKIHUB_NOTE_TYPE_FIELD_NAME,
@@ -62,8 +63,8 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     """Hook handler for editor_did_unfocus_field.
 
     Returns True if the note was modified (tag added or removed), otherwise returns
-    the original value of `changed`. Anki uses the return value to decide whether to
-    save the note.
+    the original value of `changed`. Anki re-loads the note from the DB when this
+    returns True, so the tag mutation is persisted via update_note() before returning.
     """
     ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
     if not ah_did:
@@ -73,33 +74,41 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     if not deck_config.auto_protect_fields_when_edited:
         return changed
 
-    field_name = note.keys()[current_field_idx]
+    # If all fields are already covered by the "All" tag, no per-field tag is needed.
+    if TAG_FOR_PROTECTING_ALL_FIELDS in note.tags:
+        return changed
+
+    field_name = note.note_type()["flds"][current_field_idx]["name"]
     if field_name == ANKIHUB_NOTE_TYPE_FIELD_NAME:
         return changed
 
     # Skip if globally protected for this deck (managed by deck owner, not locally)
-    if field_name in deck_config.globally_protected_fields.get(note.mid, []):
+    if field_name in config.globally_protected_fields_for_note_type(ah_did, note.mid):
         return changed
 
-    protection_tag = f"{TAG_FOR_PROTECTING_FIELDS}::{field_name.replace(' ', '_')}"
     ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
-    ah_field_value = ah_note.fields.get(field_name, "") if ah_note and ah_note.fields else None
-
-    if ah_field_value is None:
+    if not ah_note or not ah_note.fields or field_name not in ah_note.fields:
         return changed
 
-    if note[field_name] != ah_field_value:
+    protection_tag = protection_tag_for_field(field_name)
+    should_be_protected = note[field_name] != ah_note.fields[field_name]
+    if should_be_protected and protection_tag not in note.tags:
         # Field differs from AnkiHub version — add protection if not already present
-        if protection_tag not in note.tags:
-            note.tags.append(protection_tag)
-            return True
-    else:
+        note.tags.append(protection_tag)
+        _save_with_named_undo(note, f"AnkiHub | Auto-protect {field_name}")
+        return True
+    if not should_be_protected and protection_tag in note.tags:
         # Field matches AnkiHub version — remove protection tag if present
-        if protection_tag in note.tags:
-            note.tags.remove(protection_tag)
-            return True
-
+        note.tags.remove(protection_tag)
+        _save_with_named_undo(note, f"AnkiHub | Auto-unprotect {field_name}")
+        return True
     return changed
+
+
+def _save_with_named_undo(note: Note, undo_label: str) -> None:
+    undo_entry_id = aqt.mw.col.add_custom_undo_entry(undo_label)
+    aqt.mw.col.update_note(note)
+    aqt.mw.col.merge_undo_entries(undo_entry_id)
 
 
 def _on_suggestion_button_press(editor: Editor) -> None:

--- a/ankihub/gui/operations/deck_installation.py
+++ b/ankihub/gui/operations/deck_installation.py
@@ -291,6 +291,7 @@ def _install_deck(
         latest_udpate=latest_update,
         behavior_on_remote_note_deleted=behavior_on_remote_note_deleted,
     )
+    config.set_globally_protected_fields(ankihub_did, protected_fields)
 
     aqt.mw.taskman.run_on_main(media_sync.start_media_download)
 

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -122,7 +122,7 @@ def choose_subset(
     dialog.setWindowTitle(title)
     dialog.setMinimumWidth(350)
 
-    dialog.setWindowModality(Qt.WindowModality.WindowModal)
+    dialog.setWindowModality(Qt.WindowModality.ApplicationModal)
     layout = QVBoxLayout()
     dialog.setLayout(layout)
 

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -100,17 +100,32 @@ def choose_subset(
     parent: Any = None,
     require_at_least_one: bool = False,
     select_all_text: str = "Select All",
+    disable_ok_when_unchanged: bool = False,
+    checked_and_disabled_choices: Optional[List[str]] = None,
+    checked_and_disabled_choices_tooltip: Optional[str] = None,
 ) -> Optional[List[str]]:
+    """Show a dialog for selecting a subset of choices.
+
+    checked_and_disabled_choices are displayed as checked and non-interactive (grayed out).
+    They are excluded from the returned list — the return value contains only choices the
+    user actively selected from the interactive items.
+
+    Returns the selected choices, or None if the dialog was cancelled.
+    """
     if not parent:
         parent = active_window_or_mw()
+
+    checked_and_disabled_choices_set = set(checked_and_disabled_choices or [])
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
     dialog.setWindowTitle(title)
+    dialog.setMinimumWidth(350)
 
     dialog.setWindowModality(Qt.WindowModality.WindowModal)
     layout = QVBoxLayout()
     dialog.setLayout(layout)
+
     label = QLabel(prompt)
     label.setOpenExternalLinks(True)
     label.setWordWrap(True)
@@ -119,10 +134,17 @@ def choose_subset(
     layout.addWidget(list_widget)
     layout.addSpacing(5)
 
+    # Populate list items; disabled choices appear checked and non-interactive
     for choice in choices:
         item = QListWidgetItem(choice)
-        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
-        item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)
+        if choice in checked_and_disabled_choices_set:
+            item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable & ~Qt.ItemFlag.ItemIsEnabled)  # type: ignore
+            item.setCheckState(Qt.CheckState.Checked)
+            if checked_and_disabled_choices_tooltip:
+                item.setToolTip(checked_and_disabled_choices_tooltip)
+        else:
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
+            item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)
         list_widget.addItem(item)
 
     if description_html:
@@ -131,18 +153,22 @@ def choose_subset(
 
     layout.addSpacing(10)
 
+    # Build button row
     button_box = QDialogButtonBox()
 
-    # Add a "Select All" button
+    # "Select All" toggles all interactive items; deselects all if all are already selected
     def select_all() -> None:
-        all_selected = all(
-            list_widget.item(i).checkState() == Qt.CheckState.Checked for i in range(list_widget.count())
+        all_enabled_selected = all(
+            list_widget.item(i).checkState() == Qt.CheckState.Checked
+            for i in range(list_widget.count())
+            if list_widget.item(i).text() not in checked_and_disabled_choices_set
         )
-        if all_selected:
-            for i in range(list_widget.count()):
+        for i in range(list_widget.count()):
+            if list_widget.item(i).text() in checked_and_disabled_choices_set:
+                continue
+            if all_enabled_selected:
                 list_widget.item(i).setCheckState(Qt.CheckState.Unchecked)
-        else:
-            for i in range(list_widget.count()):
+            else:
                 list_widget.item(i).setCheckState(Qt.CheckState.Checked)
 
     select_all_button = QPushButton(select_all_text)
@@ -163,8 +189,9 @@ def choose_subset(
     if adjust_height_to_content:
         list_widget.setMinimumHeight(list_widget.sizeHintForRow(0) * list_widget.count() + 20)
 
-    def update_accept_button_state():
-        accept_button = next(
+    # Manage OK button enabled state based on require_at_least_one / disable_ok_when_unchanged
+    def _get_accept_button():
+        return next(
             (
                 button
                 for button in button_box.buttons()
@@ -172,17 +199,36 @@ def choose_subset(
             ),
             None,
         )
+
+    def update_accept_button_state():
+        accept_button = _get_accept_button()
         if not accept_button:
             return
-        for i in range(list_widget.count()):
-            item = list_widget.item(i)
-            if item.checkState() == Qt.CheckState.Checked:
-                accept_button.setEnabled(True)
+
+        if require_at_least_one:
+            has_checked = any(
+                list_widget.item(i).checkState() == Qt.CheckState.Checked
+                for i in range(list_widget.count())
+                if list_widget.item(i).text() not in checked_and_disabled_choices_set
+            )
+            if not has_checked:
+                accept_button.setEnabled(False)
                 return
 
-        accept_button.setEnabled(False)
+        if disable_ok_when_unchanged:
+            current_selection = sorted(
+                list_widget.item(i).text()
+                for i in range(list_widget.count())
+                if list_widget.item(i).checkState() == Qt.CheckState.Checked
+                and list_widget.item(i).text() not in checked_and_disabled_choices_set
+            )
+            if current_selection == sorted(c for c in current if c not in checked_and_disabled_choices_set):
+                accept_button.setEnabled(False)
+                return
 
-    if require_at_least_one:
+        accept_button.setEnabled(True)
+
+    if require_at_least_one or disable_ok_when_unchanged:
         qconnect(list_widget.itemChanged, lambda _: update_accept_button_state())
         update_accept_button_state()
 
@@ -193,6 +239,7 @@ def choose_subset(
         list_widget.item(i).text()
         for i in range(list_widget.count())
         if list_widget.item(i).checkState() == Qt.CheckState.Checked
+        and list_widget.item(i).text() not in checked_and_disabled_choices_set
     ]
     return result
 
@@ -223,7 +270,7 @@ class CustomListWidget(QListWidget):
     def mousePressEvent(self, event):
         super().mousePressEvent(event)
         item = self.itemAt(event.pos())
-        if item:
+        if item and item.flags() & Qt.ItemFlag.ItemIsEnabled:
             if item.checkState() == Qt.CheckState.Checked:
                 item.setCheckState(Qt.CheckState.Unchecked)
             else:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 import aqt
 from anki.decks import DeckId
+from anki.notes import Note
 from anki.utils import is_mac
 from aqt import QCheckBox, dialogs, sync
 from aqt.addons import check_and_prompt_for_updates
@@ -49,6 +50,16 @@ ButtonParam = Union[
     str,
     Tuple[str, QDialogButtonBox.ButtonRole],
 ]
+
+
+def update_notes_with_named_undo(label: str, notes: Union[Note, Sequence[Note]]) -> None:
+    """Persist note(s) wrapped in a labeled custom undo entry."""
+    undo_entry_id = aqt.mw.col.add_custom_undo_entry(label)
+    if isinstance(notes, Note):
+        aqt.mw.col.update_note(notes)
+    else:
+        aqt.mw.col.update_notes(list(notes))
+    aqt.mw.col.merge_undo_entries(undo_entry_id)
 
 
 def add_button_from_param(button_box: QDialogButtonBox, button_param: ButtonParam) -> QPushButton:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar
 
 import aqt
 from anki.decks import DeckId
-from anki.notes import Note
 from anki.utils import is_mac
 from aqt import QCheckBox, dialogs, sync
 from aqt.addons import check_and_prompt_for_updates
@@ -50,16 +49,6 @@ ButtonParam = Union[
     str,
     Tuple[str, QDialogButtonBox.ButtonRole],
 ]
-
-
-def update_notes_with_named_undo(label: str, notes: Union[Note, Sequence[Note]]) -> None:
-    """Persist note(s) wrapped in a labeled custom undo entry."""
-    undo_entry_id = aqt.mw.col.add_custom_undo_entry(label)
-    if isinstance(notes, Note):
-        aqt.mw.col.update_note(notes)
-    else:
-        aqt.mw.col.update_notes(list(notes))
-    aqt.mw.col.merge_undo_entries(undo_entry_id)
 
 
 def add_button_from_param(button_box: QDialogButtonBox, button_param: ButtonParam) -> QPushButton:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -107,8 +107,9 @@ def choose_subset(
     """Show a dialog for selecting a subset of choices.
 
     checked_and_disabled_choices are displayed as checked and non-interactive (grayed out).
-    They are excluded from the returned list — the return value contains only choices the
-    user actively selected from the interactive items.
+    They are included in the returned list along with whatever interactive choices the
+    user kept checked — the return value reflects the dialog's full final selection,
+    so callers don't have to remember to fold the locked choices back in.
 
     Returns the selected choices, or None if the dialog was cancelled.
     """
@@ -226,7 +227,9 @@ def choose_subset(
     if dialog.exec() != QDialog.DialogCode.Accepted:
         return None
 
-    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked]
+    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked] + list(
+        checked_and_disabled_choices or []
+    )
 
 
 class SearchableSelectionDialog(StudyDeck):

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -155,9 +155,6 @@ def choose_subset(
 
     layout.addSpacing(10)
 
-    # Build button row
-    button_box = QDialogButtonBox()
-
     # "Select All" toggles all interactive items; deselects all if all are already selected
     def select_all() -> None:
         all_selected = all(item.checkState() == Qt.CheckState.Checked for item in interactive_items)
@@ -167,18 +164,24 @@ def choose_subset(
 
     select_all_button = QPushButton(select_all_text)
     qconnect(select_all_button.clicked, select_all)
-    button_box.addButton(select_all_button, QDialogButtonBox.ButtonRole.ActionRole)
 
-    # Add other buttons
+    # Accept/reject buttons live in a standard button box on the right
+    button_box = QDialogButtonBox()
     if buttons:
         for button_param in buttons:
             add_button_from_param(button_box, button_param)
     else:
+        button_box.addButton(QDialogButtonBox.StandardButton.Cancel)
         button_box.addButton(QDialogButtonBox.StandardButton.Ok)
-
     qconnect(button_box.accepted, dialog.accept)
     qconnect(button_box.rejected, dialog.reject)
-    layout.addWidget(button_box)
+
+    # Select All on the left, accept/reject on the right
+    button_row = QHBoxLayout()
+    button_row.addWidget(select_all_button)
+    button_row.addStretch()
+    button_row.addWidget(button_box)
+    layout.addLayout(button_row)
 
     if adjust_height_to_content:
         list_widget.setMinimumHeight(list_widget.sizeHintForRow(0) * list_widget.count() + 20)

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -185,6 +185,11 @@ def choose_subset(
 
     if adjust_height_to_content:
         list_widget.setMinimumHeight(list_widget.sizeHintForRow(0) * list_widget.count() + 20)
+        # Pin the dialog's min height to its content-fitting size; otherwise the user can
+        # drag the dialog shorter than the list's minimum and Qt lets the description label
+        # / buttons overlap the bottom list rows.
+        dialog.adjustSize()
+        dialog.setMinimumHeight(dialog.height())
 
     # Manage OK button enabled state based on require_at_least_one / disable_ok_when_unchanged
     if require_at_least_one or disable_ok_when_unchanged:

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -115,7 +115,7 @@ def choose_subset(
     if not parent:
         parent = active_window_or_mw()
 
-    checked_and_disabled_choices_set = set(checked_and_disabled_choices or [])
+    locked_set = set(checked_and_disabled_choices or [])
 
     dialog = QDialog(parent)
     disable_help_button(dialog)
@@ -135,9 +135,10 @@ def choose_subset(
     layout.addSpacing(5)
 
     # Populate list items; disabled choices appear checked and non-interactive
+    interactive_items: List[QListWidgetItem] = []
     for choice in choices:
         item = QListWidgetItem(choice)
-        if choice in checked_and_disabled_choices_set:
+        if choice in locked_set:
             item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable & ~Qt.ItemFlag.ItemIsEnabled)  # type: ignore
             item.setCheckState(Qt.CheckState.Checked)
             if checked_and_disabled_choices_tooltip:
@@ -145,6 +146,7 @@ def choose_subset(
         else:
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
             item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)
+            interactive_items.append(item)
         list_widget.addItem(item)
 
     if description_html:
@@ -158,18 +160,10 @@ def choose_subset(
 
     # "Select All" toggles all interactive items; deselects all if all are already selected
     def select_all() -> None:
-        all_enabled_selected = all(
-            list_widget.item(i).checkState() == Qt.CheckState.Checked
-            for i in range(list_widget.count())
-            if list_widget.item(i).text() not in checked_and_disabled_choices_set
-        )
-        for i in range(list_widget.count()):
-            if list_widget.item(i).text() in checked_and_disabled_choices_set:
-                continue
-            if all_enabled_selected:
-                list_widget.item(i).setCheckState(Qt.CheckState.Unchecked)
-            else:
-                list_widget.item(i).setCheckState(Qt.CheckState.Checked)
+        all_selected = all(item.checkState() == Qt.CheckState.Checked for item in interactive_items)
+        new_state = Qt.CheckState.Unchecked if all_selected else Qt.CheckState.Checked
+        for item in interactive_items:
+            item.setCheckState(new_state)
 
     select_all_button = QPushButton(select_all_text)
     qconnect(select_all_button.clicked, select_all)
@@ -190,8 +184,8 @@ def choose_subset(
         list_widget.setMinimumHeight(list_widget.sizeHintForRow(0) * list_widget.count() + 20)
 
     # Manage OK button enabled state based on require_at_least_one / disable_ok_when_unchanged
-    def _get_accept_button():
-        return next(
+    if require_at_least_one or disable_ok_when_unchanged:
+        accept_button = next(
             (
                 button
                 for button in button_box.buttons()
@@ -199,49 +193,32 @@ def choose_subset(
             ),
             None,
         )
+        baseline_selection = sorted(c for c in current if c not in locked_set)
 
-    def update_accept_button_state():
-        accept_button = _get_accept_button()
-        if not accept_button:
-            return
-
-        if require_at_least_one:
-            has_checked = any(
-                list_widget.item(i).checkState() == Qt.CheckState.Checked
-                for i in range(list_widget.count())
-                if list_widget.item(i).text() not in checked_and_disabled_choices_set
-            )
-            if not has_checked:
+        def update_accept_button_state():
+            if not accept_button:
+                return
+            if require_at_least_one and not any(
+                item.checkState() == Qt.CheckState.Checked for item in interactive_items
+            ):
                 accept_button.setEnabled(False)
                 return
+            if disable_ok_when_unchanged:
+                current_selection = sorted(
+                    item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked
+                )
+                if current_selection == baseline_selection:
+                    accept_button.setEnabled(False)
+                    return
+            accept_button.setEnabled(True)
 
-        if disable_ok_when_unchanged:
-            current_selection = sorted(
-                list_widget.item(i).text()
-                for i in range(list_widget.count())
-                if list_widget.item(i).checkState() == Qt.CheckState.Checked
-                and list_widget.item(i).text() not in checked_and_disabled_choices_set
-            )
-            if current_selection == sorted(c for c in current if c not in checked_and_disabled_choices_set):
-                accept_button.setEnabled(False)
-                return
-
-        accept_button.setEnabled(True)
-
-    if require_at_least_one or disable_ok_when_unchanged:
         qconnect(list_widget.itemChanged, lambda _: update_accept_button_state())
         update_accept_button_state()
 
     if dialog.exec() != QDialog.DialogCode.Accepted:
         return None
 
-    result = [
-        list_widget.item(i).text()
-        for i in range(list_widget.count())
-        if list_widget.item(i).checkState() == Qt.CheckState.Checked
-        and list_widget.item(i).text() not in checked_and_disabled_choices_set
-    ]
-    return result
+    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked]
 
 
 class SearchableSelectionDialog(StudyDeck):

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -107,9 +107,8 @@ def choose_subset(
     """Show a dialog for selecting a subset of choices.
 
     checked_and_disabled_choices are displayed as checked and non-interactive (grayed out).
-    They are included in the returned list along with whatever interactive choices the
-    user kept checked — the return value reflects the dialog's full final selection,
-    so callers don't have to remember to fold the locked choices back in.
+    They are excluded from the returned list — the return value contains only choices the
+    user actively selected from the interactive items.
 
     Returns the selected choices, or None if the dialog was cancelled.
     """
@@ -227,9 +226,7 @@ def choose_subset(
     if dialog.exec() != QDialog.DialogCode.Accepted:
         return None
 
-    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked] + list(
-        checked_and_disabled_choices or []
-    )
+    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked]
 
 
 class SearchableSelectionDialog(StudyDeck):

--- a/ankihub/main/note_conversion.py
+++ b/ankihub/main/note_conversion.py
@@ -15,6 +15,11 @@ TAG_FOR_PROTECTING_ALL_FIELDS = f"{TAG_FOR_PROTECTING_FIELDS}::All"
 TAG_FOR_OPTIONAL_TAGS = "AnkiHub_Optional"
 
 
+def protection_tag_for_field(field_name: str) -> str:
+    # Spaces aren't allowed in tags, so they're replaced with underscores.
+    return f"{TAG_FOR_PROTECTING_FIELDS}::{field_name.replace(' ', '_')}"
+
+
 # top-level tags that are only used by the add-on, but not by the web app
 ADDON_INTERNAL_TAGS = [
     TAG_FOR_PROTECTING_FIELDS,

--- a/ankihub/main/utils.py
+++ b/ankihub/main/utils.py
@@ -7,7 +7,7 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 from uuid import UUID
 
 import aqt
@@ -850,3 +850,13 @@ def mh_tag_to_resource(tag: str) -> Optional[Resource]:
         return None
 
     return Resource(title=title, url=url_mh_integrations_preview(slug), usmle_step=step)
+
+
+def update_notes_with_named_undo(label: str, notes: Union[Note, Sequence[Note]]) -> None:
+    """Persist note(s) wrapped in a labeled custom undo entry."""
+    undo_entry_id = aqt.mw.col.add_custom_undo_entry(label)
+    if isinstance(notes, Note):
+        aqt.mw.col.update_note(notes)
+    else:
+        aqt.mw.col.update_notes(list(notes))
+    aqt.mw.col.merge_undo_entries(undo_entry_id)

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -141,6 +141,8 @@ class DeckConfig(DataClassJSONMixin):
         SuspendNewCardsOfExistingNotes.IF_SIBLINGS_SUSPENDED
     )
     has_note_embeddings: bool = False
+    auto_protect_fields_when_edited: bool = False
+    globally_protected_fields: Dict[int, List[str]] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def suspend_new_cards_of_new_notes_default(ah_did: uuid.UUID) -> bool:
@@ -391,6 +393,17 @@ class _Config:
 
     def set_suspend_new_cards_of_existing_notes(self, ankihub_did: uuid.UUID, suspend: SuspendNewCardsOfExistingNotes):
         self.deck_config(ankihub_did).suspend_new_cards_of_existing_notes = suspend
+        self._update_private_config()
+
+    def set_auto_protect_fields_when_edited(self, ankihub_did: uuid.UUID, value: bool) -> None:
+        self.deck_config(ankihub_did).auto_protect_fields_when_edited = value
+        self._update_private_config()
+
+    def set_globally_protected_fields(self, ankihub_did: uuid.UUID, protected_fields: Dict[int, List[str]]) -> None:
+        deck_cfg = self.deck_config(ankihub_did)
+        if deck_cfg.globally_protected_fields == protected_fields:
+            return
+        deck_cfg.globally_protected_fields = protected_fields
         self._update_private_config()
 
     def set_ankihub_deleted_notes_behavior(

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -141,7 +141,7 @@ class DeckConfig(DataClassJSONMixin):
         SuspendNewCardsOfExistingNotes.IF_SIBLINGS_SUSPENDED
     )
     has_note_embeddings: bool = False
-    auto_protect_fields_when_edited: bool = False
+    auto_protect_fields_when_edited: bool = True
     globally_protected_fields: Dict[int, List[str]] = dataclasses.field(default_factory=dict)
 
     @staticmethod

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -400,10 +400,7 @@ class _Config:
         self._update_private_config()
 
     def set_globally_protected_fields(self, ankihub_did: uuid.UUID, protected_fields: Dict[int, List[str]]) -> None:
-        deck_cfg = self.deck_config(ankihub_did)
-        if deck_cfg.globally_protected_fields == protected_fields:
-            return
-        deck_cfg.globally_protected_fields = protected_fields
+        self.deck_config(ankihub_did).globally_protected_fields = protected_fields
         self._update_private_config()
 
     def set_ankihub_deleted_notes_behavior(

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -400,8 +400,14 @@ class _Config:
         self._update_private_config()
 
     def set_globally_protected_fields(self, ankihub_did: uuid.UUID, protected_fields: Dict[int, List[str]]) -> None:
-        self.deck_config(ankihub_did).globally_protected_fields = protected_fields
+        deck_config = self.deck_config(ankihub_did)
+        if deck_config.globally_protected_fields == protected_fields:
+            return
+        deck_config.globally_protected_fields = protected_fields
         self._update_private_config()
+
+    def globally_protected_fields_for_note_type(self, ankihub_did: uuid.UUID, mid: int) -> List[str]:
+        return self.deck_config(ankihub_did).globally_protected_fields.get(mid, [])
 
     def set_ankihub_deleted_notes_behavior(
         self, ankihub_did: uuid.UUID, note_delete_behavior: BehaviorOnRemoteNoteDeleted

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -407,7 +407,8 @@ class _Config:
         self._update_private_config()
 
     def globally_protected_fields_for_note_type(self, ankihub_did: uuid.UUID, mid: int) -> List[str]:
-        return self.deck_config(ankihub_did).globally_protected_fields.get(mid, [])
+        # Return a copy so callers can't mutate the cached list.
+        return list(self.deck_config(ankihub_did).globally_protected_fields.get(mid, []))
 
     def set_ankihub_deleted_notes_behavior(
         self, ankihub_did: uuid.UUID, note_delete_behavior: BehaviorOnRemoteNoteDeleted

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -969,12 +969,14 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
-            # auto_protect_fields_when_edited defaults to False
+            config.set_auto_protect_fields_when_edited(ah_did, False)
+
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)
+            note["Front"] = "edited value"
 
-            result = _on_field_unfocus_auto_protect(changed=True, note=note, current_field_idx=0)
-            assert result is True  # changed was True, so it stays True
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is False  # changed stays False, no modification made
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
     def test_field_not_double_protected(
@@ -1059,13 +1061,10 @@ class TestAutoProtectFieldsWhenEdited:
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)
 
-            # Simulate a previous edit: modify field and add protection tag
-            note["Front"] = "edited value"
+            # Simulate a previously protected field (e.g. from a prior edit)
             note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
 
-            # Edit field back to the AnkiHub stored value — protection tag should be removed
-            note["Front"] = AnkiHubNote.get(anki_note_id=nid).fields["Front"]
-
+            # Field already matches the AnkiHub stored value — protection tag should be removed
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
             assert result is True
             assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
@@ -1077,6 +1076,7 @@ class TestAutoProtectFieldsWhenEdited:
     ):
         with anki_session_with_addon_data.profile_loaded():
             note = add_anki_note()
+            note["Front"] = "edited value"
 
             result = _on_field_unfocus_auto_protect(changed=True, note=note, current_field_idx=0)
             assert result is True  # changed stays True
@@ -1103,33 +1103,6 @@ class TestAutoProtectFieldsWhenEdited:
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
             assert result is False
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-    def test_globally_protected_field_not_tagged_after_demotion(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        """When global protection is removed (demotion), editing the field should add personal protection."""
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # First, field is globally protected — no personal tag added
-            config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
-            note["Front"] = "edited value"
-            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-            # Global protection removed (simulating demotion) — editing should now add personal protection
-            config.set_globally_protected_fields(ah_did, {})
-            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
 
 
 class TestDownloadAndInstallDecks:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1128,7 +1128,9 @@ class TestDownloadAndInstallDecks:
                     tags=[f"{SUBDECK_TAG}::Deck::Subdeck"] if has_subdeck_tags else [],
                 )
             ]
+            protected_fields = {ankihub_basic_note_type["id"]: ["Front"]}
             mocks = mock_download_and_install_deck_dependencies(deck, notes_data, ankihub_basic_note_type)
+            mocks["get_protected_fields"].return_value = protected_fields
 
             # Download and install the deck
             with qtbot.wait_callback() as callback:
@@ -1149,6 +1151,7 @@ class TestDownloadAndInstallDecks:
 
             # ... in the config
             assert config.deck_ids() == [deck.ah_did]
+            assert config.deck_config(deck.ah_did).globally_protected_fields == protected_fields
 
             # Assert that the mocked functions were called
             for name, mock in mocks.items():
@@ -5450,13 +5453,14 @@ class TestDeckUpdater:
             note_info = import_ah_note(ah_did=ah_did)
             note_info.fields[0].value = "changed"
 
+            protected_fields = {note_info.mid: ["Back"]}
             latest_update = datetime.now()
             mocker.patch.object(
                 AnkiHubClient,
                 "get_deck_updates",
                 return_value=DeckUpdates(
                     latest_update=latest_update,
-                    protected_fields={},
+                    protected_fields=protected_fields,
                     protected_tags=[],
                     notes=[note_info],
                 ),
@@ -5500,6 +5504,7 @@ class TestDeckUpdater:
 
             # Assert that the last update time was updated in the config
             assert config.deck_config(ah_did).latest_update == latest_update
+            assert config.deck_config(ah_did).globally_protected_fields == protected_fields
 
     @pytest.mark.parametrize(
         "initial_tags, incoming_optional_tags, expected_tags",

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -151,7 +151,7 @@ from ankihub.gui.config_dialog import get_config_dialog_manager, setup_config_di
 from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_fsrs_parameters
 from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
-from ankihub.gui.editor import SUGGESTION_BTN_ID
+from ankihub.gui.editor import SUGGESTION_BTN_ID, _on_field_unfocus_auto_protect
 from ankihub.gui.errors import upload_logs_and_data_in_background
 from ankihub.gui.exceptions import DeckDownloadAndInstallError, RemoteDeckNotFoundError
 from ankihub.gui.flashcard_selector_dialog import FlashCardSelectorDialog
@@ -390,6 +390,7 @@ def mock_client_methods_called_during_ankihub_sync(mocker: MockerFixture) -> Non
     deck_updates_mock = Mock()
     deck_updates_mock.notes = []
     deck_updates_mock.latest_update = None
+    deck_updates_mock.protected_fields = {}
     mocker.patch.object(AnkiHubClient, "get_deck_updates", return_value=deck_updates_mock)
 
 
@@ -933,6 +934,202 @@ def test_add_note_type_fields(
         db_note_type = add_note_type_fields(ah_did, note_type, ["New1"])
         assert ankihub_db.note_type_dict(note_type_id) == db_note_type
         assert "New1" in ankihub_db.note_type_field_names(note_type_id)
+
+
+class TestAutoProtectFieldsWhenEdited:
+    def test_field_is_protected_when_edited(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Modify the "Front" field so it differs from the AnkiHub stored value
+            note["Front"] = "edited value"
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is True
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
+
+    def test_field_not_protected_when_feature_disabled(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            # auto_protect_fields_when_edited defaults to False
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            result = _on_field_unfocus_auto_protect(changed=True, note=note, current_field_idx=0)
+            assert result is True  # changed was True, so it stays True
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_field_not_double_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Add protection tag manually and modify field
+            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+            note["Front"] = "edited value"
+
+            # Calling the hook again should not add a duplicate tag
+            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            protect_tags = [t for t in note.tags if t.startswith(f"{TAG_FOR_PROTECTING_FIELDS}::Front")]
+            assert len(protect_tags) == 1
+
+    def test_globally_protected_field_not_personally_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Modify the field and set it as globally protected
+            note["Front"] = "edited value"
+            config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is False  # changed stays False, no modification made
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_field_matching_ankihub_value_not_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Field value matches the AnkiHub stored value — no protection should be added
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is False
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_protection_tag_removed_when_field_edited_back_to_ankihub_value(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Simulate a previous edit: modify field and add protection tag
+            note["Front"] = "edited value"
+            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+
+            # Edit field back to the AnkiHub stored value — protection tag should be removed
+            note["Front"] = AnkiHubNote.get(anki_note_id=nid).fields["Front"]
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is True
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+
+    def test_non_ankihub_note_not_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        add_anki_note: AddAnkiNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            note = add_anki_note()
+
+            result = _on_field_unfocus_auto_protect(changed=True, note=note, current_field_idx=0)
+            assert result is True  # changed stays True
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_ankihub_id_field_not_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # Modify the ankihub_id field — it should never be protected
+            ankihub_id_idx = note.keys().index("ankihub_id")
+            note["ankihub_id"] = "edited value"
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
+            assert result is False
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_globally_protected_field_not_tagged_after_demotion(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        """When global protection is removed (demotion), editing the field should add personal protection."""
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            # First, field is globally protected — no personal tag added
+            config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
+            note["Front"] = "edited value"
+            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+            # Global protection removed (simulating demotion) — editing should now add personal protection
+            config.set_globally_protected_fields(ah_did, {})
+            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
 
 
 class TestDownloadAndInstallDecks:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1159,31 +1159,110 @@ class TestAutoProtectFieldsWhenEdited:
             assert result is False
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-    def test_sync_strips_personal_tags_for_globally_protected_fields(
+    def test_field_not_double_protected_when_lowercase_tag_present(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
     ):
+        # Anki tags are case-insensitive — a pre-existing lowercase variant should
+        # block the hook from appending the canonical-cased duplicate.
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-            # Import into the deck registered for this AH deck so the sync sweep's
-            # deck-scoped search finds the note.
-            anki_did = config.deck_config(ah_did).anki_id
-            note_info = import_ah_note(ah_did=ah_did, anki_did=anki_did)
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)
-            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
-            back_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Back"
-            note.tags.extend([front_tag, back_tag])
-            aqt.mw.col.update_note(note)
 
-            # Front becomes globally protected; Back stays user-controlled.
-            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
+            lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
+            note.tags.append(lowercase_tag)
+            note["Front"] = "edited value"
 
-            reloaded = aqt.mw.col.get_note(nid)
-            assert front_tag not in reloaded.tags
-            assert back_tag in reloaded.tags
+            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+
+            front_tags = [t for t in note.tags if t.lower() == lowercase_tag]
+            assert len(front_tags) == 1
+
+    def test_protection_tag_removed_when_lowercase_variant_present(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        # Removal must succeed even when the existing tag's casing differs from
+        # the canonical form (Anki tags are case-insensitive).
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+
+            lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
+            note.tags.append(lowercase_tag)
+            # Field already matches the AnkiHub stored value — tag should be removed.
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is True
+            assert not any(t.lower() == lowercase_tag for t in note.tags)
+
+    def test_field_not_protected_when_lowercase_all_tag_present(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        # The "All" short-circuit must match a lowercase variant of the tag too.
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS.lower())
+            note["Front"] = "edited value"
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is False
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+
+    def test_field_protected_when_field_missing_from_ah_fields(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        # The upsert logic omits empty fields from ah_note.fields. When the field
+        # name is missing there, a non-empty local value should be treated as
+        # differing from the AnkiHub stored value and trigger protection.
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(
+                ah_did=ah_did,
+                note_data=NoteInfoFactory.create(
+                    fields=[Field(name="Front", value=""), Field(name="Back", value="back-value")],
+                ),
+            )
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note["Front"] = "edited value"
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is True
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
 
 
 class TestDownloadAndInstallDecks:
@@ -5737,6 +5816,32 @@ class TestDeckUpdater:
             # Assert that the deck config was updated with the incoming relation
             assert config.deck_config(ah_did).user_relation == incoming_relation
             assert config.deck_config(ah_did).has_note_embeddings is True
+
+    def test_sync_strips_personal_tags_for_globally_protected_fields(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            # Import into the deck registered for this AH deck so the sync sweep's
+            # deck-scoped search finds the note.
+            anki_did = config.deck_config(ah_did).anki_id
+            note_info = import_ah_note(ah_did=ah_did, anki_did=anki_did)
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
+            back_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Back"
+            note.tags.extend([front_tag, back_tag])
+            aqt.mw.col.update_note(note)
+
+            # Front becomes globally protected; Back stays user-controlled.
+            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
+
+            reloaded = aqt.mw.col.get_note(nid)
+            assert front_tag not in reloaded.tags
+            assert back_tag in reloaded.tags
 
 
 class TestSyncWithAnkiHub:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -936,147 +936,82 @@ def test_add_note_type_fields(
         assert "New1" in ankihub_db.note_type_field_names(note_type_id)
 
 
+@pytest.fixture
+def auto_protect_note(
+    anki_session_with_addon_data: AnkiSession,
+    install_ah_deck: InstallAHDeck,
+    import_ah_note: ImportAHNote,
+):
+    """Yields (ah_did, note) with the auto-protect feature flag and the per-deck
+    setting both on. Use within the yielded `profile_loaded` context."""
+    with anki_session_with_addon_data.profile_loaded():
+        ah_did = install_ah_deck()
+        note_info = import_ah_note(ah_did=ah_did)
+        config.set_feature_flags({"auto_protect_fields_when_edited": True})
+        config.set_auto_protect_fields_when_edited(ah_did, True)
+        nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+        yield ah_did, aqt.mw.col.get_note(nid)
+
+
 class TestAutoProtectFieldsWhenEdited:
-    def test_field_is_protected_when_edited(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+    def test_field_is_protected_when_edited(self, auto_protect_note):
+        _, note = auto_protect_note
+        # Modify the "Front" field so it differs from the AnkiHub stored value
+        note["Front"] = "edited value"
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is True
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
+        # Persisted: reload from DB and confirm the tag survives.
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in aqt.mw.col.get_note(note.id).tags
 
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
+    def test_field_not_protected_when_feature_disabled(self, auto_protect_note):
+        ah_did, note = auto_protect_note
+        config.set_auto_protect_fields_when_edited(ah_did, False)
+        note["Front"] = "edited value"
 
-            # Modify the "Front" field so it differs from the AnkiHub stored value
-            note["Front"] = "edited value"
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False  # changed stays False, no modification made
+        assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is True
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
-            # Persisted: reload from DB and confirm the tag survives.
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in aqt.mw.col.get_note(nid).tags
+    def test_field_not_double_protected(self, auto_protect_note):
+        _, note = auto_protect_note
+        # Add protection tag manually and modify field
+        note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+        note["Front"] = "edited value"
 
-    def test_field_not_protected_when_feature_disabled(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+        # Calling the hook again should not add a duplicate tag
+        _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        protect_tags = [t for t in note.tags if t.startswith(f"{TAG_FOR_PROTECTING_FIELDS}::Front")]
+        assert len(protect_tags) == 1
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, False)
+    def test_globally_protected_field_not_personally_protected(self, auto_protect_note):
+        ah_did, note = auto_protect_note
+        # Modify the field and set it as globally protected
+        note["Front"] = "edited value"
+        config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
 
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            note["Front"] = "edited value"
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False  # changed stays False, no modification made
+        assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False  # changed stays False, no modification made
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+    def test_field_matching_ankihub_value_not_protected(self, auto_protect_note):
+        _, note = auto_protect_note
+        # Field value matches the AnkiHub stored value — no protection should be added
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False
+        assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-    def test_field_not_double_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+    def test_protection_tag_removed_when_field_edited_back_to_ankihub_value(self, auto_protect_note):
+        _, note = auto_protect_note
+        # Simulate a previously protected field (e.g. from a prior edit)
+        note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # Add protection tag manually and modify field
-            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
-            note["Front"] = "edited value"
-
-            # Calling the hook again should not add a duplicate tag
-            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            protect_tags = [t for t in note.tags if t.startswith(f"{TAG_FOR_PROTECTING_FIELDS}::Front")]
-            assert len(protect_tags) == 1
-
-    def test_globally_protected_field_not_personally_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # Modify the field and set it as globally protected
-            note["Front"] = "edited value"
-            config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
-
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False  # changed stays False, no modification made
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-    def test_field_matching_ankihub_value_not_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # Field value matches the AnkiHub stored value — no protection should be added
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-    def test_protection_tag_removed_when_field_edited_back_to_ankihub_value(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # Simulate a previously protected field (e.g. from a prior edit)
-            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
-
-            # Field already matches the AnkiHub stored value — protection tag should be removed
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is True
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in aqt.mw.col.get_note(nid).tags
+        # Field already matches the AnkiHub stored value — protection tag should be removed
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is True
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in aqt.mw.col.get_note(note.id).tags
 
     def test_non_ankihub_note_not_protected(
         self,
@@ -1092,148 +1027,68 @@ class TestAutoProtectFieldsWhenEdited:
             assert result is True  # changed stays True
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-    def test_field_not_protected_when_all_fields_already_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+    def test_field_not_protected_when_all_fields_already_protected(self, auto_protect_note):
+        _, note = auto_protect_note
+        note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS)
+        note["Front"] = "edited value"
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
 
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS)
-            note["Front"] = "edited value"
+    def test_ankihub_id_field_not_protected(self, auto_protect_note):
+        _, note = auto_protect_note
+        # Modify the ankihub_id field — it should never be protected
+        ankihub_id_idx = note.keys().index("ankihub_id")
+        note["ankihub_id"] = "edited value"
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
+        assert result is False
+        assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+    def test_hook_is_no_op_when_feature_flag_disabled(self, auto_protect_note):
+        # Per-deck setting is on (from fixture), but the server-side rollout flag is off.
+        _, note = auto_protect_note
+        config.set_feature_flags({"auto_protect_fields_when_edited": False})
+        note["Front"] = "edited value"
 
-    def test_ankihub_id_field_not_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False
+        assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            # Modify the ankihub_id field — it should never be protected
-            ankihub_id_idx = note.keys().index("ankihub_id")
-            note["ankihub_id"] = "edited value"
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
-            assert result is False
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-    def test_hook_is_no_op_when_feature_flag_disabled(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-
-            # Per-deck setting is on, but the server-side rollout flag is off.
-            config.set_feature_flags({"auto_protect_fields_when_edited": False})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            note["Front"] = "edited value"
-
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False
-            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
-
-    def test_field_not_double_protected_when_lowercase_tag_present(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
+    def test_field_not_double_protected_when_lowercase_tag_present(self, auto_protect_note):
         # Anki tags are case-insensitive — a pre-existing lowercase variant should
         # block the hook from appending the canonical-cased duplicate.
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+        _, note = auto_protect_note
+        lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
+        note.tags.append(lowercase_tag)
+        note["Front"] = "edited value"
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
+        _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
 
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
+        front_tags = [t for t in note.tags if t.lower() == lowercase_tag]
+        assert len(front_tags) == 1
 
-            lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
-            note.tags.append(lowercase_tag)
-            note["Front"] = "edited value"
-
-            _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-
-            front_tags = [t for t in note.tags if t.lower() == lowercase_tag]
-            assert len(front_tags) == 1
-
-    def test_protection_tag_removed_when_lowercase_variant_present(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
+    def test_protection_tag_removed_when_lowercase_variant_present(self, auto_protect_note):
         # Removal must succeed even when the existing tag's casing differs from
         # the canonical form (Anki tags are case-insensitive).
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+        _, note = auto_protect_note
+        lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
+        note.tags.append(lowercase_tag)
+        # Field already matches the AnkiHub stored value — tag should be removed.
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is True
+        assert not any(t.lower() == lowercase_tag for t in note.tags)
 
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-
-            lowercase_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front".lower()
-            note.tags.append(lowercase_tag)
-            # Field already matches the AnkiHub stored value — tag should be removed.
-
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is True
-            assert not any(t.lower() == lowercase_tag for t in note.tags)
-
-    def test_field_not_protected_when_lowercase_all_tag_present(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
+    def test_field_not_protected_when_lowercase_all_tag_present(self, auto_protect_note):
         # The "All" short-circuit must match a lowercase variant of the tag too.
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+        _, note = auto_protect_note
+        note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS.lower())
+        note["Front"] = "edited value"
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_auto_protect_fields_when_edited(ah_did, True)
-
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS.lower())
-            note["Front"] = "edited value"
-
-            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
-            assert result is False
-            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+        assert result is False
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
 
     def test_field_protected_when_field_missing_from_ah_fields(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5706,7 +5706,7 @@ class TestDeckUpdater:
         # user moved them to a personal study deck) are still cleaned up.
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-            other_anki_did = aqt.mw.col.decks.add_normal_deck_with_name("other").id
+            other_anki_did = DeckId(aqt.mw.col.decks.add_normal_deck_with_name("other").id)
             note_info = import_ah_note(ah_did=ah_did, anki_did=other_anki_did)
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -958,6 +958,8 @@ class TestAutoProtectFieldsWhenEdited:
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
             assert result is True
             assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
+            # Persisted: reload from DB and confirm the tag survives.
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in aqt.mw.col.get_note(nid).tags
 
     def test_field_not_protected_when_feature_disabled(
         self,
@@ -1068,6 +1070,7 @@ class TestAutoProtectFieldsWhenEdited:
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
             assert result is True
             assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in aqt.mw.col.get_note(nid).tags
 
     def test_non_ankihub_note_not_protected(
         self,
@@ -1081,6 +1084,29 @@ class TestAutoProtectFieldsWhenEdited:
             result = _on_field_unfocus_auto_protect(changed=True, note=note, current_field_idx=0)
             assert result is True  # changed stays True
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_field_not_protected_when_all_fields_already_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            from ankihub.main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS
+
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note.tags.append(TAG_FOR_PROTECTING_ALL_FIELDS)
+            note["Front"] = "edited value"
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
+            assert result is False
+            assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" not in note.tags
 
     def test_ankihub_id_field_not_protected(
         self,
@@ -1103,6 +1129,31 @@ class TestAutoProtectFieldsWhenEdited:
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
             assert result is False
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_sync_strips_personal_tags_for_globally_protected_fields(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        from ankihub.gui.deck_updater import _strip_redundant_protect_tags
+
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
+            back_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Back"
+            note.tags.extend([front_tag, back_tag])
+            aqt.mw.col.update_note(note)
+
+            # Front becomes globally protected; Back stays user-controlled.
+            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
+
+            reloaded = aqt.mw.col.get_note(nid)
+            assert front_tag not in reloaded.tags
+            assert back_tag in reloaded.tags
 
 
 class TestDownloadAndInstallDecks:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -149,7 +149,7 @@ from ankihub.gui.browser.custom_search_nodes import AnkiHubNoteSearchNode, Updat
 from ankihub.gui.changes_require_full_sync_dialog import ChangesRequireFullSyncDialog
 from ankihub.gui.config_dialog import get_config_dialog_manager, setup_config_dialog_manager
 from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_fsrs_parameters
-from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
+from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, _strip_redundant_protect_tags, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import SUGGESTION_BTN_ID, _on_field_unfocus_auto_protect
 from ankihub.gui.errors import upload_logs_and_data_in_background
@@ -1092,8 +1092,6 @@ class TestAutoProtectFieldsWhenEdited:
         import_ah_note: ImportAHNote,
     ):
         with anki_session_with_addon_data.profile_loaded():
-            from ankihub.main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS
-
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
@@ -1136,11 +1134,12 @@ class TestAutoProtectFieldsWhenEdited:
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
     ):
-        from ankihub.gui.deck_updater import _strip_redundant_protect_tags
-
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
+            # Import into the deck registered for this AH deck so the sync sweep's
+            # deck-scoped search finds the note.
+            anki_did = config.deck_config(ah_did).anki_id
+            note_info = import_ah_note(ah_did=ah_did, anki_did=anki_did)
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)
             front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1119,6 +1119,23 @@ class TestAutoProtectFieldsWhenEdited:
             assert result is True
             assert f"{TAG_FOR_PROTECTING_FIELDS}::Front" in note.tags
 
+    def test_locally_added_field_not_protected(self, auto_protect_note):
+        # Fields the user added to the note type locally aren't on AnkiHub,
+        # so auto-protecting them would just leave orphan tags.
+        _, note = auto_protect_note
+        # Add a new field to the local note type
+        note_type = note.note_type()
+        new_field = aqt.mw.col.models.new_field("LocalOnly")
+        aqt.mw.col.models.add_field(note_type, new_field)
+        aqt.mw.col.models.save(note_type)
+        note.load()
+        local_field_idx = note.keys().index("LocalOnly")
+        note["LocalOnly"] = "edited value"
+
+        result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=local_field_idx)
+        assert result is False
+        assert not any(tag.startswith(f"{TAG_FOR_PROTECTING_FIELDS}::LocalOnly") for tag in note.tags)
+
 
 class TestDownloadAndInstallDecks:
     @pytest.mark.qt_no_exception_capture

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4441,6 +4441,51 @@ def test_protect_fields_action(
         qtbot.wait_until(assert_note_has_expected_tag)
 
 
+@pytest.mark.qt_no_exception_capture
+def test_protect_fields_action_preserves_per_note_tag_on_globally_protected_field(
+    anki_session_with_addon_data: AnkiSession,
+    install_sample_ah_deck: InstallSampleAHDeck,
+    mocker: MockerFixture,
+    qtbot: QtBot,
+):
+    # When the user opens Protect Fields and edits a non-globally-protected field,
+    # any pre-existing per-note AnkiHub_Protect::<globally-protected-field> tag must
+    # survive the strip-and-rewrite. choose_subset excludes locked choices from its
+    # return value; _on_protect_fields_action preserves them explicitly before the
+    # rewrite so the user's authored intent survives a later removal of global
+    # protection.
+    with anki_session_with_addon_data.profile_loaded():
+        mw = anki_session_with_addon_data.mw
+
+        _anki_did, ah_did = install_sample_ah_deck()
+
+        # Pick a note, add a per-note Front tag, mark Front as globally protected.
+        nid = mw.col.find_notes("Front:*")[0]
+        note = mw.col.get_note(nid)
+        front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
+        back_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Back"
+        note.tags.append(front_tag)
+        mw.col.update_note(note)
+        config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
+
+        # Mock choose_subset to return only Back — mirrors the real dialog excluding
+        # the locked Front from its return value.
+        mocker.patch(
+            "ankihub.gui.browser.browser.choose_subset",
+            return_value={"Back"},
+        )
+
+        browser: Browser = dialogs.open("Browser", mw)
+        _on_protect_fields_action(browser, [nid])
+
+        def assert_both_tags_present():
+            tags = mw.col.get_note(nid).tags
+            assert front_tag in tags, "per-note Front tag was dropped (preservation regression)"
+            assert back_tag in tags, "Back tag from the dialog selection was not applied"
+
+        qtbot.wait_until(assert_both_tags_present)
+
+
 class TestDeckManagementDialog:
     @pytest.mark.parametrize(
         "nightmode",

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5825,10 +5825,7 @@ class TestDeckUpdater:
     ):
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-            # Import into the deck registered for this AH deck so the sync sweep's
-            # deck-scoped search finds the note.
-            anki_did = config.deck_config(ah_did).anki_id
-            note_info = import_ah_note(ah_did=ah_did, anki_did=anki_did)
+            note_info = import_ah_note(ah_did=ah_did)
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
             note = aqt.mw.col.get_note(nid)
             front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
@@ -5842,6 +5839,51 @@ class TestDeckUpdater:
             reloaded = aqt.mw.col.get_note(nid)
             assert front_tag not in reloaded.tags
             assert back_tag in reloaded.tags
+
+    def test_sync_strips_tag_on_note_in_other_anki_deck(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        # The sweep is scoped by note type, not by Anki deck, so notes that
+        # belong to the AH deck but live in a different Anki deck (e.g. the
+        # user moved them to a personal study deck) are still cleaned up.
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            other_anki_did = aqt.mw.col.decks.add_normal_deck_with_name("other").id
+            note_info = import_ah_note(ah_did=ah_did, anki_did=other_anki_did)
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
+            note.tags.append(front_tag)
+            aqt.mw.col.update_note(note)
+
+            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
+
+            assert front_tag not in aqt.mw.col.get_note(nid).tags
+
+    def test_sync_strips_tag_on_not_yet_submitted_note(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        add_anki_note: AddAnkiNote,
+    ):
+        # A note created locally with an AH note type but not yet suggested
+        # to AnkiHub has no row in the AH DB. The sweep should still catch
+        # its redundant protect tags via the note-type-based query.
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            mid = ankihub_db.note_types_for_ankihub_deck(ah_did)[0]
+            note_type = aqt.mw.col.models.get(mid)
+            unsubmitted_note = add_anki_note(note_type=note_type)
+            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
+            unsubmitted_note.tags.append(front_tag)
+            aqt.mw.col.update_note(unsubmitted_note)
+
+            _strip_redundant_protect_tags(ah_did, {mid: ["Front"]})
+
+            assert front_tag not in aqt.mw.col.get_note(unsubmitted_note.id).tags
 
 
 class TestSyncWithAnkiHub:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -947,6 +947,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -971,6 +972,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, False)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -991,6 +993,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1015,6 +1018,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1038,6 +1042,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1058,6 +1063,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1078,6 +1084,7 @@ class TestAutoProtectFieldsWhenEdited:
         add_anki_note: AddAnkiNote,
     ):
         with anki_session_with_addon_data.profile_loaded():
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             note = add_anki_note()
             note["Front"] = "edited value"
 
@@ -1095,6 +1102,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1116,6 +1124,7 @@ class TestAutoProtectFieldsWhenEdited:
             ah_did = install_ah_deck()
             note_info = import_ah_note(ah_did=ah_did)
 
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
             config.set_auto_protect_fields_when_edited(ah_did, True)
 
             nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
@@ -1125,6 +1134,28 @@ class TestAutoProtectFieldsWhenEdited:
             ankihub_id_idx = note.keys().index("ankihub_id")
             note["ankihub_id"] = "edited value"
             result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=ankihub_id_idx)
+            assert result is False
+            assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
+
+    def test_hook_is_no_op_when_feature_flag_disabled(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+
+            # Per-deck setting is on, but the server-side rollout flag is off.
+            config.set_feature_flags({"auto_protect_fields_when_edited": False})
+            config.set_auto_protect_fields_when_edited(ah_did, True)
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note["Front"] = "edited value"
+
+            result = _on_field_unfocus_auto_protect(changed=False, note=note, current_field_idx=0)
             assert result is False
             assert not any(tag.startswith(TAG_FOR_PROTECTING_FIELDS) for tag in note.tags)
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -149,7 +149,7 @@ from ankihub.gui.browser.custom_search_nodes import AnkiHubNoteSearchNode, Updat
 from ankihub.gui.changes_require_full_sync_dialog import ChangesRequireFullSyncDialog
 from ankihub.gui.config_dialog import get_config_dialog_manager, setup_config_dialog_manager
 from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_fsrs_parameters
-from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, _strip_redundant_protect_tags, ah_deck_updater
+from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import SUGGESTION_BTN_ID, _on_field_unfocus_auto_protect
 from ankihub.gui.errors import upload_logs_and_data_in_background
@@ -5688,74 +5688,6 @@ class TestDeckUpdater:
             # Assert that the deck config was updated with the incoming relation
             assert config.deck_config(ah_did).user_relation == incoming_relation
             assert config.deck_config(ah_did).has_note_embeddings is True
-
-    def test_sync_strips_personal_tags_for_globally_protected_fields(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            note_info = import_ah_note(ah_did=ah_did)
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
-            back_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Back"
-            note.tags.extend([front_tag, back_tag])
-            aqt.mw.col.update_note(note)
-
-            # Front becomes globally protected; Back stays user-controlled.
-            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
-
-            reloaded = aqt.mw.col.get_note(nid)
-            assert front_tag not in reloaded.tags
-            assert back_tag in reloaded.tags
-
-    def test_sync_strips_tag_on_note_in_other_anki_deck(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-    ):
-        # The sweep is scoped by note type, not by Anki deck, so notes that
-        # belong to the AH deck but live in a different Anki deck (e.g. the
-        # user moved them to a personal study deck) are still cleaned up.
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            other_anki_did = DeckId(aqt.mw.col.decks.add_normal_deck_with_name("other").id)
-            note_info = import_ah_note(ah_did=ah_did, anki_did=other_anki_did)
-            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
-            note = aqt.mw.col.get_note(nid)
-            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
-            note.tags.append(front_tag)
-            aqt.mw.col.update_note(note)
-
-            _strip_redundant_protect_tags(ah_did, {note.mid: ["Front"]})
-
-            assert front_tag not in aqt.mw.col.get_note(nid).tags
-
-    def test_sync_strips_tag_on_not_yet_submitted_note(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        install_ah_deck: InstallAHDeck,
-        add_anki_note: AddAnkiNote,
-    ):
-        # A note created locally with an AH note type but not yet suggested
-        # to AnkiHub has no row in the AH DB. The sweep should still catch
-        # its redundant protect tags via the note-type-based query.
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            mid = ankihub_db.note_types_for_ankihub_deck(ah_did)[0]
-            note_type = aqt.mw.col.models.get(mid)
-            unsubmitted_note = add_anki_note(note_type=note_type)
-            front_tag = f"{TAG_FOR_PROTECTING_FIELDS}::Front"
-            unsubmitted_note.tags.append(front_tag)
-            aqt.mw.col.update_note(unsubmitted_note)
-
-            _strip_redundant_protect_tags(ah_did, {mid: ["Front"]})
-
-            assert front_tag not in aqt.mw.col.get_note(unsubmitted_note.id).tags
 
 
 class TestSyncWithAnkiHub:


### PR DESCRIPTION
Add auto-protect feature that automatically tags fields as protected when users edit them, so future AnkiHub syncs don't overwrite local changes. Globally protected fields (set by the deck owner on the web app) are cached locally and skipped by the editor hook. Also includes UI tweaks to the Deck Management dialog and the Protect Fields dialog, plus sizing adjustments to the Deck Management dialog so the added option row fits without truncation on macOS.

## ⚠️ Rollout gated on a feature flag

The auto-protect editor hook and the Deck Management option row are both gated on the server-controlled feature flag `auto_protect_fields_when_edited`. The flag must be **off** at the server until the suggestion-dialog overhaul ([NRT-749](https://ankihub.atlassian.net/browse/NRT-749)) ships, otherwise auto-protect will silently strip user edits from outgoing change suggestions (the `_prepare_fields` filter that NRT-749 removes).

**Backend coordination needed**: add `auto_protect_fields_when_edited` to the AnkiHub backend's feature-flags response, default `False`. Flip to `True` once NRT-749 is in production.

## Related issues
- [NRT-748](https://ankihub.atlassian.net/browse/NRT-748) (subtask of parent story [NRT-508](https://ankihub.atlassian.net/browse/NRT-508))

Non-blocking, surfaced while testing on macOS:
- [NRT-763](https://ankihub.atlassian.net/browse/NRT-763) — Deck Management dialog doesn't refresh after subscribing via web.
- [NRT-764](https://ankihub.atlassian.net/browse/NRT-764) — macOS modal deadlock when clicking "Sync to install" from Deck Management.

## Stacked PRs
- #1291 — `choose_subset` class-based refactor (reviewability cleanup surfaced during this review).
- #1288 — [NRT-749] Redesign Suggest-a-change dialog with Fields to Suggest section.

## Proposed changes

- **Settings**: new `auto_protect_fields_when_edited` toggle and `globally_protected_fields` cache on `DeckConfig`; new `globally_protected_fields_for_note_type(ah_did, mid)` helper.
- **Editor hook**: on field unfocus, add/remove `AnkiHub_Protect::<FieldName>` based on whether the field differs from the AnkiHub source value. Gated on the feature flag.
- **Deck Management dialog**: new "Automatically protect fields when edited" row (gated) + spec-driven copy/layout touch-ups. The added row pushed past the dialog's previous height on macOS, so the right column now lives in a `QScrollArea` and the dialog has tighter min/max sizing rules to stay readable on small screens without opening over-sized on large ones.
- **Sync**: cache `globally_protected_fields` on each deck sync — the editor hook reads it to skip globally-protected fields. The cache write is the only thing the sync does with `globally_protected_fields`; per-note `AnkiHub_Protect::<field>` tags are never modified by sync, so a user's per-note protection survives even if a deck owner toggles global protection on and later off.
- **Install**: cache `globally_protected_fields` after first import.
- **Protect Fields dialog (`choose_subset`)**: globally-protected fields shown as checked + greyed-out (non-interactive); OK disabled when nothing changed; default Cancel button; Select All on the left; `ApplicationModal` so the dialog has a title bar on macOS. Min height pinned to content-fit so the description label can't overlap the bottom rows when the dialog is dragged shorter.
- **Browser action**: passes globally protected fields to the dialog as disabled choices. When rewriting per-note `AnkiHub_Protect::<field>` tags from the dialog's return, the caller now preserves any pre-existing per-note tags on globally-protected fields (the dialog excludes locked choices from its return; without this preservation, a user touching the dialog would silently lose per-note protection on globally-protected fields).
- **Helpers**: new `protection_tag_for_field()`; new `update_notes_with_named_undo()` consolidating the `add_custom_undo_entry`/`update_note(s)`/`merge_undo_entries` pattern.

## How to reproduce
1. Set `auto_protect_fields_when_edited: true` in the feature-flags response served to your account.
2. Subscribe to and install an AnkiHub deck (subscribing alone isn't enough — the deck-options rows only render once the deck is installed locally).
3. Open Deck Management → select the deck → confirm "Automatically protect fields when edited" appears and is checked by default.
4. Edit a field on a note from the deck — **make sure the field is _not_ already globally protected** (those are skipped) — then **unfocus the field** (press Tab or click outside it) → confirm `AnkiHub_Protect::<Field>` is added and the Edit menu shows an `AnkiHub | Auto-protect <Field>` undo entry. The hook fires on blur, not on every keystroke, so the tag won't appear until you leave the field.
5. Edit the same (non-globally-protected) field back to the AnkiHub value and unfocus again → confirm the tag is removed.
6. In the Anki browser, right-click a note from the deck → Protect fields → confirm the dialog has a Cancel button, globally protected fields appear greyed-out and can't be toggled, and OK is disabled until something changes.
7. With a per-note `AnkiHub_Protect::<field>` tag already on a note, mark that field as globally protected on the web and sync → confirm the per-note tag **remains** (sync preserves user-authored protection intent across global-protection toggles).
8. Add `AnkiHub_Protect::All` to a note → edit any field → confirm no per-field tag is added.
9. Open Protect fields on a note that has a per-note `AnkiHub_Protect::<field>` tag for a globally-protected field, toggle some other field, click OK → confirm the per-note tag on the globally-protected field is still present (the caller preserves it explicitly across the strip-and-rewrite).

## How to verify the flag gating
- With flag off: edit a field → no `AnkiHub_Protect::Field` tag added; Deck Management's auto-protect row is hidden.
- Flip the flag → no client restart needed beyond a sync; the row appears and the hook starts firing.

## Tests
Covered by integration tests in `TestAutoProtectFieldsWhenEdited` (editor hook scenarios, including flag-off no-op and case-insensitive tag handling) and `test_protect_fields_action_preserves_per_note_tag_on_globally_protected_field` (browser-side preservation when the user touches the Protect Fields dialog).

## Screenshots and videos

<p align="center"><img width="500" alt="Deck Management dialog on Linux with the new Automatically protect fields when edited row" src="https://github.com/user-attachments/assets/bce444a9-7381-4d3b-baec-0789e8e79bbd" /></p>
<p align="center"><em>Deck Management dialog with the new auto-protect row (Linux).</em></p>

[NRT-749]: https://ankihub.atlassian.net/browse/NRT-749
[NRT-748]: https://ankihub.atlassian.net/browse/NRT-748








