### PR TITLE
ACTV-285 fix layout and open community url externally

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -254,6 +254,7 @@ class ReviewerSidebar:
         if not self.content_webview:
             return
 
+        self.content_webview.set_open_links_externally(False)
         self.last_accessed_url = url
         if self.needs_to_accept_terms:
             self.refresh_page_content()
@@ -267,7 +268,7 @@ class ReviewerSidebar:
                 resource_type=self.get_page_type().value,
             )
             self.content_webview.setHtml(html)
-            self.content_webview.set_open_links_externally(False)
+            self.content_webview.set_open_links_externally(True)
 
     def refresh_page_content(self):
         self.content_webview.reload()

--- a/ankihub/gui/web/mh_no_urls_empty_state.html
+++ b/ankihub/gui/web/mh_no_urls_empty_state.html
@@ -23,11 +23,6 @@
             background-color: #f9fafb;
         }
 
-        /* 🌙 DARK MODE (page background) */
-        .dark body {
-            background-color: #111827; /* darker outer */
-        }
-
         .empty-state {
             padding: 2rem;
             width: 100%;
@@ -36,7 +31,7 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
+            justify-content: flex-start;
             text-align: center;
 
             min-height: 100vh;
@@ -46,7 +41,7 @@
 
         /* 🌙 DARK MODE (inner panel) */
         .dark .empty-state {
-            background-color: #1f2937;
+            background-color: #030712;
         }
 
         .empty-state__icon {
@@ -64,7 +59,7 @@
         }
 
         .empty-state__divider {
-            width: 60%;
+            width: 100%;
             border: none;
             border-top: 1px solid #d4d4d4;
             margin: 1.5rem 0;
@@ -138,7 +133,7 @@
         <p class="empty-state__text">
             We couldn't find any <span class="empty-state__highlight">content</span> connected to this card.<br><br>
             If that seems wrong, let our
-            <a href="#" class="empty-state__link">support team</a> know.
+            <a href="https://community.ankihub.net/c/support/5" class="empty-state__link" rel="external">support team</a> know.
         </p>
     </div>
 </body>


### PR DESCRIPTION
## Related issues
- [ACTV-285](https://ankihub.atlassian.net/browse/ACTV-285)


## Proposed changes
Fix empty state layout issues, open community url externally instead of inside the webview;


## How to reproduce

1. Go to the addon
2. Open the anking step deck
3. Click on First Aid Forward or B&B icon for a card without resource
4. Check if the new empty state was rendered
5. Click on "support team" link
6. Check if it opened on the external browser

[ACTV-285]: https://ankihub.atlassian.net/browse/ACTV-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ