### PR TITLE
[ACTV-294] product tours only to logged in users

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -449,7 +449,7 @@ def _ankihub_help_setup(parent: QMenu):
     help_menu = QMenu("🆘 Help", parent)
 
     tours_submenu = QMenu("Product tours", help_menu)
-    if config.get_feature_flags().get("onboarding_tour", False):
+    if config.is_logged_in() and config.get_feature_flags().get("onboarding_tour", False):
         q_onboarding_action = QAction("Onboarding", tours_submenu)
         qconnect(
             q_onboarding_action.triggered,
@@ -457,7 +457,11 @@ def _ankihub_help_setup(parent: QMenu):
         )
         tours_submenu.addAction(q_onboarding_action)
 
-    if config.get_feature_flags().get("step_deck_tour", False) and config.deck_config(config.anking_deck_id):
+    if (
+        config.is_logged_in()
+        and config.get_feature_flags().get("step_deck_tour", False)
+        and config.deck_config(config.anking_deck_id)
+    ):
         q_step_tour_action = QAction("AnKing Step Deck", tours_submenu)
         qconnect(
             q_step_tour_action.triggered,


### PR DESCRIPTION
## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-294](https://ankihub.atlassian.net/browse/actv-294)


## Proposed changes
Only display the product tours for logged in users

## How to reproduce

Pre-steps:

1. Subscribe to getting start deck
2. Subscribe to anking step deck
3. Sync decks


Test Case 1: Logged user
1. Log in to the add-on
2. Go to ankihub menu > Help > Product Tours
3. It should display the onboarding tour and step deck tour

Test Case 1: Logged user
1. Log out the add-on
2. Go to ankihub menu > Help
3. The product tours section should not be displayed



[ACTV-294]: https://ankihub.atlassian.net/browse/ACTV-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ