### PR TITLE
[ACTV-289] Trigger onboarding tour on first signup

### DIFF
--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -32,7 +32,7 @@ from .errors import upload_logs_and_data_in_background, upload_logs_in_backgroun
 from .media_sync import media_sync
 from .operations.ankihub_sync import sync_with_ankihub
 from .operations.deck_creation import create_collaborative_deck
-from .tutorial import OnboardingTutorial, StepDeckTutorial
+from .tutorial import OnboardingTutorial, StepDeckTutorial, prompt_for_onboarding_tutorial
 from .utils import (
     ask_user,
     check_and_prompt_for_updates_on_main_window,
@@ -203,6 +203,10 @@ class AnkiHubLogin(QWidget):
         LOGGER.info("User signed into AnkiHub.", user=username_or_email)
 
         tooltip("Signed into AnkiHub!", parent=aqt.mw)
+        # Ensure onboarding tutorial logic is wired up whenever user state is refreshed.
+        from ..user_state import add_user_state_refreshed_callback
+
+        add_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
         self.close()
 
     def _is_email(self, value):
@@ -227,6 +231,20 @@ class AnkiHubLogin(QWidget):
 
         LOGGER.info("Showed AnkiHub login dialog.")
         return cls._window
+
+
+def _maybe_show_onboarding_tutorial_after_login() -> None:
+    """Show the onboarding tutorial after the first successful login on this profile.
+
+    This triggers when:
+    - The user is logged in
+    - `last_deck_sync` is None (no previous sync/tutorial for this profile)
+    - Feature flags/user details have just been refreshed (so feature flag checks work)
+    """
+    if config.last_deck_sync() is not None:
+        return
+
+    prompt_for_onboarding_tutorial()
 
 
 def _create_collaborative_deck_setup(parent: QMenu):

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -206,7 +206,7 @@ class AnkiHubLogin(QWidget):
         # Ensure onboarding tutorial logic is wired up whenever user state is refreshed.
         from ..user_state import add_user_state_refreshed_callback
 
-        add_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
+        add_user_state_refreshed_callback(_show_onboarding_tutorial_if_first_sync)
         self.close()
 
     def _is_email(self, value):
@@ -233,7 +233,7 @@ class AnkiHubLogin(QWidget):
         return cls._window
 
 
-def _maybe_show_onboarding_tutorial_after_login() -> None:
+def _show_onboarding_tutorial_if_first_sync() -> None:
     """Show the onboarding tutorial after the first successful login on this profile.
 
     This triggers when:

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -244,6 +244,8 @@ def _maybe_show_onboarding_tutorial_after_login() -> None:
     if config.last_deck_sync() is not None:
         return
 
+    config.set_onboarding_tutorial_show_on_sync(False)
+
     prompt_for_onboarding_tutorial()
 
 

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -206,7 +206,7 @@ class AnkiHubLogin(QWidget):
         # Ensure onboarding tutorial logic is wired up whenever user state is refreshed.
         from ..user_state import add_user_state_refreshed_callback
 
-        add_user_state_refreshed_callback(_show_onboarding_tutorial_if_first_sync)
+        add_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
         self.close()
 
     def _is_email(self, value):
@@ -233,7 +233,7 @@ class AnkiHubLogin(QWidget):
         return cls._window
 
 
-def _show_onboarding_tutorial_if_first_sync() -> None:
+def _maybe_show_onboarding_tutorial_after_login() -> None:
     """Show the onboarding tutorial after the first successful login on this profile.
 
     This triggers when:

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -236,11 +236,19 @@ class AnkiHubLogin(QWidget):
 def _maybe_show_onboarding_tutorial_after_login() -> None:
     """Show the onboarding tutorial after the first successful login on this profile.
 
+    Fires once: removes itself from the user-state refresh callbacks before doing
+    anything else so subsequent refreshes (periodic timer, post-sync, etc.) cannot
+    re-show the prompt after the user dismissed it.
+
     This triggers when:
     - The user is logged in
     - `last_deck_sync` is None (no previous sync/tutorial for this profile)
     - Feature flags/user details have just been refreshed (so feature flag checks work)
     """
+    from ..user_state import remove_user_state_refreshed_callback
+
+    remove_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
+
     if config.last_deck_sync() is not None:
         return
 

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -248,6 +248,15 @@ def _schedule_post_sync_tasks() -> None:
     aqt.mw.taskman.run_in_background(send_review_data, on_done=_on_send_review_data_done)
     _maybe_send_daily_review_summaries()
     aqt.mw.taskman.run_on_main(maybe_show_subdeck_due_date_reminders)
+    aqt.mw.taskman.run_on_main(_show_onboarding_prompt_if_first_sync)
+
+
+def _show_onboarding_prompt_if_first_sync() -> None:
+    if config.last_deck_sync() is None:
+        from ..tutorial import prompt_for_onboarding_tutorial
+
+        prompt_for_onboarding_tutorial()
+        config.update_last_deck_sync()
 
 
 def _on_clear_unused_tags_done(future: Future) -> None:

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -248,15 +248,6 @@ def _schedule_post_sync_tasks() -> None:
     aqt.mw.taskman.run_in_background(send_review_data, on_done=_on_send_review_data_done)
     _maybe_send_daily_review_summaries()
     aqt.mw.taskman.run_on_main(maybe_show_subdeck_due_date_reminders)
-    aqt.mw.taskman.run_on_main(_show_onboarding_prompt_if_first_sync)
-
-
-def _show_onboarding_prompt_if_first_sync() -> None:
-    if config.last_deck_sync() is None:
-        from ..tutorial import prompt_for_onboarding_tutorial
-
-        prompt_for_onboarding_tutorial()
-        config.update_last_deck_sync()
 
 
 def _on_clear_unused_tags_done(future: Future) -> None:

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -252,7 +252,7 @@ def _schedule_post_sync_tasks() -> None:
 
 
 def _show_onboarding_prompt_if_first_sync() -> None:
-    if config.last_deck_sync() is None:
+    if config.onboarding_tutorial_show_on_sync() and config.last_deck_sync() is None:
         from ..tutorial import prompt_for_onboarding_tutorial
 
         prompt_for_onboarding_tutorial()

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -219,6 +219,7 @@ class PrivateConfig(DataClassJSONMixin):
     user_details: dict = field(default_factory=dict)
     block_exams_subdecks: List[BlockExamSubdeckConfig] = field(default_factory=list)
     onboarding_tutorial_pending: bool = False
+    onboarding_tutorial_show_on_sync: bool = True
     step_deck_tutorial_pending: bool = False
     # Show Step Deck tutorial next time the user opens the deck
     show_step_deck_tutorial: bool = False
@@ -355,6 +356,10 @@ class _Config:
 
     def set_onboarding_tutorial_pending(self, pending: bool):
         self._private_config.onboarding_tutorial_pending = pending
+        self._update_private_config()
+
+    def set_onboarding_tutorial_show_on_sync(self, show_on_sync: bool):
+        self._private_config.onboarding_tutorial_show_on_sync = show_on_sync
         self._update_private_config()
 
     def set_show_step_deck_tutorial(self, show: bool):
@@ -515,6 +520,9 @@ class _Config:
 
     def onboarding_tutorial_pending(self) -> bool:
         return self._private_config.onboarding_tutorial_pending
+
+    def onboarding_tutorial_show_on_sync(self) -> bool:
+        return self._private_config.onboarding_tutorial_show_on_sync
 
     def show_step_deck_tutorial(self) -> bool:
         return self._private_config.show_step_deck_tutorial

--- a/ankihub/user_state.py
+++ b/ankihub/user_state.py
@@ -103,6 +103,15 @@ def add_user_state_refreshed_callback(callback: Callable[[], None]) -> None:
     _state.user_state_refreshed_callbacks.append(callback)
 
 
+def remove_user_state_refreshed_callback(callback: Callable[[], None]) -> None:
+    """Remove a previously added user state refresh callback.
+
+    Safe to call if the callback is not currently registered.
+    """
+    if callback in _state.user_state_refreshed_callbacks:
+        _state.user_state_refreshed_callbacks.remove(callback)
+
+
 def setup_periodic_user_state_refresh(interval_minutes: int = 60) -> None:
     """Set up periodic refresh of user state during long Anki sessions.
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -166,7 +166,12 @@ from ankihub.gui.js_message_handling import (
     _post_message_to_ankihub_js,
 )
 from ankihub.gui.media_sync import media_sync
-from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
+from ankihub.gui.menu import (
+    AnkiHubLogin,
+    _maybe_show_onboarding_tutorial_after_login,
+    menu_state,
+    refresh_ankihub_menu,
+)
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
@@ -9968,6 +9973,7 @@ class TestPromptForOnboardingTutorial:
         from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
 
         with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
             mocker.patch.object(config, "last_deck_sync", return_value=None)
             mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
             mock_update = mocker.patch.object(config, "update_last_deck_sync")
@@ -9986,12 +9992,84 @@ class TestPromptForOnboardingTutorial:
         from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
 
         with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
             mocker.patch.object(config, "last_deck_sync", return_value=datetime.now())
             mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
 
             _show_onboarding_prompt_if_first_sync()
 
             mock_prompt.assert_not_called()
+
+    def test_show_onboarding_prompt_if_first_sync_skips_when_show_on_sync_false(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+    ):
+        """Test that _show_onboarding_prompt_if_first_sync does NOT call prompt when already shown after login."""
+        from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
+
+        with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(False)
+            mocker.patch.object(config, "last_deck_sync", return_value=None)
+            mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
+            mock_update = mocker.patch.object(config, "update_last_deck_sync")
+
+            _show_onboarding_prompt_if_first_sync()
+
+            mock_prompt.assert_not_called()
+            mock_update.assert_not_called()
+
+    def test_maybe_show_onboarding_tutorial_after_login_calls_prompt_and_disables_sync_prompt(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+    ):
+        """After login, prompt runs when there was no prior deck sync; sync-time prompt is then disabled."""
+        with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
+            mocker.patch.object(config, "last_deck_sync", return_value=None)
+            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
+
+            _maybe_show_onboarding_tutorial_after_login()
+
+            mock_prompt.assert_called_once()
+            assert config.onboarding_tutorial_show_on_sync() is False
+
+    def test_maybe_show_onboarding_tutorial_after_login_skips_when_last_deck_sync_exists(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+    ):
+        """If the profile already has a last deck sync time, do not prompt or change sync prompt flag."""
+        with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
+            mocker.patch.object(config, "last_deck_sync", return_value=datetime.now())
+            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
+
+            _maybe_show_onboarding_tutorial_after_login()
+
+            mock_prompt.assert_not_called()
+            assert config.onboarding_tutorial_show_on_sync() is True
+
+    def test_maybe_show_onboarding_tutorial_after_login_still_disables_sync_prompt_when_tour_disabled(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+    ):
+        """Even when onboarding_tour is off, clear show-on-sync so first sync does not duplicate the prompt."""
+        from ankihub.gui import tutorial
+
+        with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
+            mocker.patch.object(config, "last_deck_sync", return_value=None)
+            mocker.patch.object(config, "get_feature_flags", return_value={"onboarding_tour": False})
+            mocker.patch.object(tutorial, "active_tutorial", None)
+            mock_inject = mocker.patch.object(tutorial, "inject_tutorial_assets")
+
+            _maybe_show_onboarding_tutorial_after_login()
+
+            mock_inject.assert_not_called()
+            assert config.onboarding_tutorial_show_on_sync() is False
 
 
 class TestSubscribeToIntroDeck:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -166,7 +166,7 @@ from ankihub.gui.js_message_handling import (
     _post_message_to_ankihub_js,
 )
 from ankihub.gui.media_sync import media_sync
-from ankihub.gui.menu import AnkiHubLogin, _show_onboarding_tutorial_if_first_sync, menu_state, refresh_ankihub_menu
+from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
@@ -9959,31 +9959,37 @@ class TestPromptForOnboardingTutorial:
 
             mock_inject.assert_called()
 
-    def test_show_onboarding_tutorial_if_first_sync_calls_prompt_when_last_deck_sync_is_none(
+    def test_show_onboarding_prompt_if_first_sync_calls_prompt(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
     ):
-        """When last_deck_sync is unset, prompt_for_onboarding_tutorial is invoked."""
+        """Test that _show_onboarding_prompt_if_first_sync calls prompt when last_deck_sync is None."""
+        from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
+
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "last_deck_sync", return_value=None)
-            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
+            mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
+            mock_update = mocker.patch.object(config, "update_last_deck_sync")
 
-            _show_onboarding_tutorial_if_first_sync()
+            _show_onboarding_prompt_if_first_sync()
 
             mock_prompt.assert_called_once()
+            mock_update.assert_called_once()
 
-    def test_show_onboarding_tutorial_if_first_sync_skips_when_last_deck_sync_exists(
+    def test_show_onboarding_prompt_if_first_sync_skips_when_not_first_sync(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
     ):
-        """When last_deck_sync is set, the onboarding prompt is not shown."""
+        """Test that _show_onboarding_prompt_if_first_sync does NOT call prompt when last_deck_sync exists."""
+        from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
+
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "last_deck_sync", return_value=datetime.now())
-            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
+            mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
 
-            _show_onboarding_tutorial_if_first_sync()
+            _show_onboarding_prompt_if_first_sync()
 
             mock_prompt.assert_not_called()
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -166,7 +166,7 @@ from ankihub.gui.js_message_handling import (
     _post_message_to_ankihub_js,
 )
 from ankihub.gui.media_sync import media_sync
-from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
+from ankihub.gui.menu import AnkiHubLogin, _show_onboarding_tutorial_if_first_sync, menu_state, refresh_ankihub_menu
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
@@ -9959,37 +9959,31 @@ class TestPromptForOnboardingTutorial:
 
             mock_inject.assert_called()
 
-    def test_show_onboarding_prompt_if_first_sync_calls_prompt(
+    def test_show_onboarding_tutorial_if_first_sync_calls_prompt_when_last_deck_sync_is_none(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
     ):
-        """Test that _show_onboarding_prompt_if_first_sync calls prompt when last_deck_sync is None."""
-        from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
-
+        """When last_deck_sync is unset, prompt_for_onboarding_tutorial is invoked."""
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "last_deck_sync", return_value=None)
-            mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
-            mock_update = mocker.patch.object(config, "update_last_deck_sync")
+            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
 
-            _show_onboarding_prompt_if_first_sync()
+            _show_onboarding_tutorial_if_first_sync()
 
             mock_prompt.assert_called_once()
-            mock_update.assert_called_once()
 
-    def test_show_onboarding_prompt_if_first_sync_skips_when_not_first_sync(
+    def test_show_onboarding_tutorial_if_first_sync_skips_when_last_deck_sync_exists(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
     ):
-        """Test that _show_onboarding_prompt_if_first_sync does NOT call prompt when last_deck_sync exists."""
-        from ankihub.gui.operations.ankihub_sync import _show_onboarding_prompt_if_first_sync
-
+        """When last_deck_sync is set, the onboarding prompt is not shown."""
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "last_deck_sync", return_value=datetime.now())
-            mock_prompt = mocker.patch("ankihub.gui.tutorial.prompt_for_onboarding_tutorial")
+            mock_prompt = mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
 
-            _show_onboarding_prompt_if_first_sync()
+            _show_onboarding_tutorial_if_first_sync()
 
             mock_prompt.assert_not_called()
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -10071,6 +10071,37 @@ class TestPromptForOnboardingTutorial:
             mock_inject.assert_not_called()
             assert config.onboarding_tutorial_show_on_sync() is False
 
+    def test_maybe_show_onboarding_tutorial_after_login_removes_itself_from_refresh_callbacks(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+    ):
+        """The callback must fire only once per session so dismissing 'Maybe later' is final.
+
+        Subsequent user-state refreshes (periodic timer, post-sync, etc.) should not
+        re-show the prompt while ``last_deck_sync`` is still ``None``.
+        """
+        from ankihub.user_state import (
+            _state,
+            add_user_state_refreshed_callback,
+            remove_user_state_refreshed_callback,
+        )
+
+        with anki_session_with_addon_data.profile_loaded():
+            config.set_onboarding_tutorial_show_on_sync(True)
+            mocker.patch.object(config, "last_deck_sync", return_value=None)
+            mocker.patch("ankihub.gui.menu.prompt_for_onboarding_tutorial")
+
+            add_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
+            try:
+                assert _maybe_show_onboarding_tutorial_after_login in _state.user_state_refreshed_callbacks
+
+                _maybe_show_onboarding_tutorial_after_login()
+
+                assert _maybe_show_onboarding_tutorial_after_login not in _state.user_state_refreshed_callbacks
+            finally:
+                remove_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
+
 
 class TestSubscribeToIntroDeck:
     @pytest.mark.qt_no_exception_capture


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-289](https://ankihub.atlassian.net/browse/ACTV-289)


## Proposed changes
Triggers the Onboarding Tour when (new) users sign in or when they open up the addon without having syncing.

## How to reproduce

Test Case 1:
1. Create a new account
2. "Sign In" in the AnkiHub addon
3. The onboarding tour should appear
4. Click on "Maybe later"
5. Close the Anki and open it again
6. The onboarding tour should appear

Test Case 2:
1. Create a new account
2. "Sign In" in the AnkiHub addon
3. The onboarding tour should appear
4. Click on "X"
5. Close the Anki and open it again
6. The onboarding tour should not appear



[ACTV-289]: https://ankihub.atlassian.net/browse/ACTV-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ