### PR TITLE
[ACTV-290][Bugfix] Onboarding tour locks on decks with all cards suspended

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -3,7 +3,7 @@ import json
 from asyncio.futures import Future
 from dataclasses import dataclass
 from functools import cached_property, partial
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypedDict, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict, Union, cast
 
 import aqt
 from anki.cards import CardId
@@ -41,9 +41,11 @@ from typing_extensions import Required, Unpack
 
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
+from ..db import ankihub_db
 from ..django import render_template, render_template_from_string
 from ..gui.overlay_dialog import OverlayDialog, OverlayTarget
 from ..main.deck_unsubscribtion import uninstall_deck
+from ..main.reset_local_changes import reset_local_changes_to_notes
 from ..settings import config
 from .flashcard_selector_dialog import (
     show_flashcard_selector,
@@ -885,11 +887,17 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         aqt.mw.moveToState("deckBrowser")
 
     def _unsuspend_cards_and_move_to_intro_deck_overview(self, on_done: Callable[[], None]) -> None:
-        intro_deck_config = config.deck_config(config.intro_deck_id)
-        cids: Sequence[CardId] = aqt.mw.col.find_cards(f'deck:"{intro_deck_config.name}"')
+        ah_did = config.intro_deck_id
+        intro_deck_config = config.deck_config(ah_did)
+        cids = list(aqt.mw.col.decks.cids(intro_deck_config.anki_id, True))
 
         if cids:
-            aqt.mw.col.sched.unsuspend_cards(ids=list(cids))
+            aqt.mw.col.sched.unsuspend_cards(ids=cids)
+            aqt.mw.col.sched.schedule_cards_as_new(card_ids=cids, restore_position=True)
+
+        if not self._has_cards_to_review():
+            nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+            reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
 
         self._move_to_intro_deck_overview(on_done)
 

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -10,6 +10,7 @@ from anki.cards import CardId
 from anki.config import Config
 from anki.hooks import wrap
 from anki.notes import NoteId
+from anki.scheduler.v3 import Scheduler
 from aqt import gui_hooks
 from aqt.browser import Browser
 from aqt.browser.sidebar.item import SidebarItem, SidebarItemType
@@ -893,6 +894,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         self._move_to_intro_deck_overview(on_done)
 
     def _has_cards_to_review(self) -> bool:
+        assert isinstance(aqt.mw.col.sched, Scheduler)
         return bool(aqt.mw.col.sched.get_queued_cards().cards)
 
     @cached_property

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -898,11 +898,11 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             aqt.mw.col.sched.schedule_cards_as_new(card_ids=cids, restore_position=True)
 
         if not self._has_cards_to_review():
-            nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-            reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
+            self._bump_intro_deck_daily_limits(intro_deck_config.anki_id, cids)
 
         if not self._has_cards_to_review():
-            self._bump_intro_deck_daily_limits(intro_deck_config.anki_id, cids)
+            nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+            reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
 
         self._move_to_intro_deck_overview(on_done)
 

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -913,7 +913,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         rev_sub = deck_config.setdefault("rev", {})
         cur_new = int(new_sub.get("perDay", 0))
         cur_rev = int(rev_sub.get("perDay", 0))
-        extra = max(len(cids), 20)
+        extra = max(len(cids), 30)
         new_sub["perDay"] = cur_new + extra
         rev_sub["perDay"] = max(cur_rev + extra, new_sub.get("perDay", DEFAULT_OVERRIDES["review_limit"]) * 10)
         aqt.mw.col.decks.update_config(deck_config)
@@ -950,7 +950,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             next_callback = self._move_to_intro_deck_overview
             if not self._has_cards_to_review():
                 body_text = (
-                    "This deck was already reviewed. Click on <b>Next</b> and we'll "
+                    "There are no cards available right now. Click on <b>Next</b> and we'll "
                     "bring the cards back so you can continue with the tour."
                 )
                 next_callback = self._reset_cards_and_move_to_intro_deck_overview

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict, U
 import aqt
 from anki.cards import CardId
 from anki.config import Config
+from anki.decks import DeckId
 from anki.hooks import wrap
 from anki.notes import NoteId
 from anki.scheduler.v3 import Scheduler
@@ -44,6 +45,7 @@ from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..django import render_template, render_template_from_string
 from ..gui.overlay_dialog import OverlayDialog, OverlayTarget
+from ..main.deck_options import DEFAULT_OVERRIDES
 from ..main.deck_unsubscribtion import uninstall_deck
 from ..main.reset_local_changes import reset_local_changes_to_notes
 from ..settings import config
@@ -899,7 +901,22 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
             reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
 
+        if not self._has_cards_to_review():
+            self._bump_intro_deck_daily_limits(intro_deck_config.anki_id, cids)
+
         self._move_to_intro_deck_overview(on_done)
+
+    def _bump_intro_deck_daily_limits(self, anki_did: DeckId, cids: List[CardId]) -> None:
+        """Raise new/review per-day caps so intro cards can enter the queue after daily limits were hit."""
+        deck_config = aqt.mw.col.decks.config_dict_for_deck_id(anki_did)
+        new_sub = deck_config.setdefault("new", {})
+        rev_sub = deck_config.setdefault("rev", {})
+        cur_new = int(new_sub.get("perDay", 0))
+        cur_rev = int(rev_sub.get("perDay", 0))
+        extra = max(len(cids), 20)
+        new_sub["perDay"] = cur_new + extra
+        rev_sub["perDay"] = max(cur_rev + extra, new_sub.get("perDay", DEFAULT_OVERRIDES["review_limit"]) * 10)
+        aqt.mw.col.decks.update_config(deck_config)
 
     def _has_cards_to_review(self) -> bool:
         assert isinstance(aqt.mw.col.sched, Scheduler)

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -883,6 +883,18 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         self._monitor_mw_state_change(on_done)
         aqt.mw.moveToState("deckBrowser")
 
+    def _unsuspend_cards_and_move_to_intro_deck_overview(self, on_done: Callable[[], None]) -> None:
+        intro_deck_config = config.deck_config(config.intro_deck_id)
+        cids: set[CardId] = aqt.mw.col.find_cards(f'deck:"{intro_deck_config.name}"')
+
+        if cids:
+            aqt.mw.col.sched.unsuspend_cards(ids=list(cids))
+
+        self._move_to_intro_deck_overview(on_done)
+
+    def _has_cards_to_review(self):
+        return bool(aqt.mw.col.sched.get_queued_cards().cards)
+
     @cached_property
     def steps(self) -> list[TutorialStep]:
         steps = [
@@ -907,13 +919,20 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
                 intro_deck_config = None
 
         if intro_deck_config:
+            body_text = "We've already subscribed you to this deck. Click on it to open."
+            if not self._has_cards_to_review():
+                body_text = (
+                    "This deck was already reviewed. Click on <b>Next</b> and we'll "
+                    "bring the cards back so you can continue with the tour."
+                )
+
             steps.append(
                 TutorialStep(
-                    body="We've already subscribed you to this deck. Click on it to open.",
+                    body=body_text,
                     target=f"[id='{intro_deck_config.anki_id}']",
                     click_target=lambda: f"[id='{intro_deck_config.anki_id}'] a.deck",
                     tooltip_context=aqt.mw.deckBrowser,
-                    next_callback=self._move_to_intro_deck_overview,
+                    next_callback=self._unsuspend_cards_and_move_to_intro_deck_overview,
                 )
             )
         else:

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -888,7 +888,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         self._monitor_mw_state_change(on_done)
         aqt.mw.moveToState("deckBrowser")
 
-    def _unsuspend_cards_and_move_to_intro_deck_overview(self, on_done: Callable[[], None]) -> None:
+    def _reset_cards_and_move_to_intro_deck_overview(self, on_done: Callable[[], None]) -> None:
         ah_did = config.intro_deck_id
         intro_deck_config = config.deck_config(ah_did)
         cids = list(aqt.mw.col.decks.cids(intro_deck_config.anki_id, True))
@@ -953,7 +953,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
                     "This deck was already reviewed. Click on <b>Next</b> and we'll "
                     "bring the cards back so you can continue with the tour."
                 )
-                next_callback = self._unsuspend_cards_and_move_to_intro_deck_overview
+                next_callback = self._reset_cards_and_move_to_intro_deck_overview
 
             steps.append(
                 TutorialStep(

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -3,7 +3,7 @@ import json
 from asyncio.futures import Future
 from dataclasses import dataclass
 from functools import cached_property, partial
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypedDict, Union, cast
 
 import aqt
 from anki.cards import CardId
@@ -885,14 +885,14 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
     def _unsuspend_cards_and_move_to_intro_deck_overview(self, on_done: Callable[[], None]) -> None:
         intro_deck_config = config.deck_config(config.intro_deck_id)
-        cids: set[CardId] = aqt.mw.col.find_cards(f'deck:"{intro_deck_config.name}"')
+        cids: Sequence[CardId] = aqt.mw.col.find_cards(f'deck:"{intro_deck_config.name}"')
 
         if cids:
             aqt.mw.col.sched.unsuspend_cards(ids=list(cids))
 
         self._move_to_intro_deck_overview(on_done)
 
-    def _has_cards_to_review(self):
+    def _has_cards_to_review(self) -> bool:
         return bool(aqt.mw.col.sched.get_queued_cards().cards)
 
     @cached_property
@@ -920,11 +920,13 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
         if intro_deck_config:
             body_text = "We've already subscribed you to this deck. Click on it to open."
+            next_callback = self._move_to_intro_deck_overview
             if not self._has_cards_to_review():
                 body_text = (
                     "This deck was already reviewed. Click on <b>Next</b> and we'll "
                     "bring the cards back so you can continue with the tour."
                 )
+                next_callback = self._unsuspend_cards_and_move_to_intro_deck_overview
 
             steps.append(
                 TutorialStep(
@@ -932,7 +934,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
                     target=f"[id='{intro_deck_config.anki_id}']",
                     click_target=lambda: f"[id='{intro_deck_config.anki_id}'] a.deck",
                     tooltip_context=aqt.mw.deckBrowser,
-                    next_callback=self._unsuspend_cards_and_move_to_intro_deck_overview,
+                    next_callback=next_callback,
                 )
             )
         else:


### PR DESCRIPTION
## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-290](https://ankihub.atlassian.net/browse/ACTV-290)


## Proposed changes
Unsuspend the cards when all cards of the getting started deck are suspended

## How to reproduce
#### Setup
1. Must have the Getting started deck
2. Must suspend all cards from the deck

#### Test Case
1. Trigger the onboarding tour in the help menu
2. The tutorial is triggered
3. The second step should display the new message and unsuspend the cards
4. The rest of the tour should work properly



[ACTV-290]: https://ankihub.atlassian.net/browse/ACTV-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ