### PR TITLE
[ACTV-295][Bugfix] Tour locking screen when deck not present

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -42,6 +42,7 @@ from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..django import render_template, render_template_from_string
 from ..gui.overlay_dialog import OverlayDialog, OverlayTarget
+from ..main.deck_unsubscribtion import uninstall_deck
 from ..settings import config
 from .flashcard_selector_dialog import (
     show_flashcard_selector,
@@ -897,6 +898,14 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         ]
 
         intro_deck_config = config.deck_config(config.intro_deck_id)
+        if intro_deck_config:
+            did = intro_deck_config.anki_id
+            has_deck_and_cards = aqt.mw.col.decks.get(did, False) and aqt.mw.col.decks.card_count(did, True)
+
+            if not has_deck_and_cards:
+                uninstall_deck(config.intro_deck_id)
+                intro_deck_config = None
+
         if intro_deck_config:
             steps.append(
                 TutorialStep(


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-295](https://ankihub.atlassian.net/browse/ACTV-295)


## Proposed changes
When a user clicks on a Product Tour, but the deck does not have a clear state on Anki, the tour starts and considers that the deck exists. Thus, the sync dialog does not appear, and the tour gets stuck without a deck to show.


## How to reproduce
1. Install the Getting Started Deck
2. Delete the deck without unsubscribing
3. Go to Ankihub > Help > Tour > Onboarding
4. The tour should trigger and ask for syncing


[ACTV-295]: https://ankihub.atlassian.net/browse/ACTV-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ