### PR TITLE
fix: Fix tour overlay not staying on top on resize in macOS

### DIFF
--- a/ankihub/gui/overlay_dialog.py
+++ b/ankihub/gui/overlay_dialog.py
@@ -73,6 +73,7 @@ class OverlayDialog(QDialog):
 
     def on_position(self) -> None:
         self.setGeometry(self.parentWidget().geometry())
+        self.raise_()
 
     def showEvent(self, event) -> None:
         super().showEvent(event)


### PR DESCRIPTION
## Related issues

None

## Proposed changes

The tour's overlay was getting obscured by the browser on resize events. Adding a .raise_() call appears to fix this. Only an issue on macOS

## How to reproduce

1. Enable the step deck tour feature flag.
2. Start the tour from AnkiHub > Help > Product tours.
3. Advance the tour until you reach the browser.
4. Resize the browser window and notice the tour dialog disappears (it's shown behind the browser).
5. Test again with this fix and confirm the tour stays on top.

