### PR TITLE
[NRT-739] Fix broken/clickable community.ankihub.net links

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -360,7 +360,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         "from updates.<br><br>"
         "Tip: If you want to protect a field on every note, <br>"
         "consider using the "
-        "<a href='https://community.ankihub.net/t/protecting-fields-and-tags'>protected fields feature</a>.",
+        "<a href='https://community.ankihub.net/t/protecting-fields-and-tags/165604'>protected fields feature</a>.",
         choices=field_names,
         current=old_fields_protected_by_tags,
         description_html="This will edit the AnkiHub_Protect tags of the note.",

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -475,7 +475,7 @@ def _ankihub_help_setup(parent: QMenu):
     q_notion_action = QAction("Documentation", help_menu)
     qconnect(
         q_notion_action.triggered,
-        lambda: openLink("https://community.ankihub.net/docs"),
+        lambda: openLink("https://community.ankihub.net/c/docs"),
     )
     help_menu.addAction(q_notion_action)
 

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -149,6 +149,7 @@ def _handle_suggestion_error(e: AnkiHubHTTPError, parent: QWidget) -> None:
                 "(Learn more about protected fields "
                 "<a href='https://community.ankihub.net/t/protecting-fields-and-tags/165604'>here</a>.)"
             )
+            label.setOpenExternalLinks(True)
             sublayout.addWidget(label)
             icon_label = QLabel("")
             pixmap = tooltip_icon().pixmap(QCheckBox().iconSize())

--- a/ankiweb_description.html
+++ b/ankiweb_description.html
@@ -6,7 +6,7 @@ Click <a href="https://www.reddit.com/r/medicalschoolanki/comments/rb62m6/ankihu
 ____________________________________________________________________
 
 ↗️ <b>Links</b>
-• 📋 <a href="https://community.ankihub.net/docs" rel="nofollow">User Guide</a>
+• 📋 <a href="https://community.ankihub.net/c/docs" rel="nofollow">User Guide</a>
 • 🚧 <a href="https://community.ankihub.net/c/announcements/" rel="nofollow">Changelog</a>
 • 🆘 <a href="https://community.ankihub.net/c/support" rel="nofollow">User support forum</a>
 ____________________________________________________________________


### PR DESCRIPTION
Audit of `community.ankihub.net` links in the addon turned up two broken URLs, one URL pointing to the wrong topic, and one clickable label that wasn't actually opening in a browser. This PR fixes all four.

## Related issues
- [NRT-739](https://ankihub.atlassian.net/browse/NRT-739)

## Proposed changes
- `ankihub/gui/menu.py`: "Documentation" menu action — `/docs` (currently 404) → `/c/docs` (the new "🎓 Docs" category page).
- `ankiweb_description.html`: "User Guide" link in the AnkiWeb listing — same `/docs` → `/c/docs` fix.
- `ankihub/gui/browser/browser.py`: "protect fields" hint — slug-only URL `/t/protecting-fields-and-tags` silently redirected to topic 585240, while the canonical topic used elsewhere in the addon is 165604. Updated to use the full canonical URL.
- `ankihub/gui/suggestion_dialog.py`: added `setOpenExternalLinks(True)` to the "Learn more about protected fields here." QLabel so clicking the link actually opens it in a browser. Without this, Qt swallows the click silently.

The webapp side (two more broken `/docs` links in `ankihub_web`) is fixed in a companion PR: AnkiHubSoftware/ankihub#3627.

## How to reproduce
1. Open Anki with the AnkiHub addon installed and signed in.
2. AnkiHub menu → Help → Documentation: previously opened a 404 page. Now opens the docs category.
3. Browser → right-click a note → AnkiHub → Protect Fields: the "protected fields feature" link now points to topic 165604.
4. Try to submit a suggestion that contains no real changes (e.g. only edits to a protected field). The "Invalid suggestion" dialog appears with a "Learn more about protected fields here." link. Previously clicking did nothing; now it opens in the browser.

## Screenshots and videos
N/A — link/text-only changes.

## Further comments
Found while doing a sweep of all `community.ankihub.net` URLs in the repo. Other slug-redirects (e.g. the FAQ topic title rename) were left alone since Discourse handles them transparently via 301s.

[NRT-739]: https://ankihub.atlassian.net/browse/NRT-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ