### PR TITLE
[NRT-645] Emit dialog result to web; suppress 0-added confusion

### DIFF
--- a/ankihub/gui/block_exam_dialog.py
+++ b/ankihub/gui/block_exam_dialog.py
@@ -468,13 +468,7 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        self.add_succeeded = True
-        if added_count == 0:
-            tooltip(f"All selected notes are already in '{actual_name}'", parent=aqt.mw)
-        else:
-            tooltip(f"{added_count} note(s) added to '{actual_name}'", parent=aqt.mw)
-        self.accept()
-
+        self._finish_with_added(added_count, actual_name)
         aqt.mw.moveToState("deckBrowser")
 
     def _on_add_notes(self):
@@ -504,12 +498,7 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        self.add_succeeded = True
-        if added_count == 0:
-            tooltip(f"All selected notes are already in '{self.selected_subdeck_name}'", parent=aqt.mw)
-        else:
-            tooltip(f"{added_count} note(s) added to '{self.selected_subdeck_name}'", parent=aqt.mw)
-        self.accept()
+        self._finish_with_added(added_count, self.selected_subdeck_name)
 
     def _rename_subdeck(self, old_subdeck_path: str, new_subdeck_path: str):
         """Rename an existing subdeck."""
@@ -551,13 +540,7 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        self.add_succeeded = True
-        if added_count == 0:
-            tooltip(f"All selected notes are already in '{actual_name}'", parent=aqt.mw)
-        else:
-            tooltip(f"{added_count} note(s) added to '{actual_name}'", parent=aqt.mw)
-        self.accept()
-
+        self._finish_with_added(added_count, actual_name)
         aqt.mw.moveToState("deckBrowser")
 
     def _handle_conflict_merge(self, conflicting_name: str):
@@ -583,11 +566,14 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
+        self._finish_with_added(added_count, conflicting_name)
+
+    def _finish_with_added(self, added_count: int, subdeck_name: str) -> None:
         self.add_succeeded = True
         if added_count == 0:
-            tooltip(f"All selected notes are already in '{conflicting_name}'")
+            tooltip(f"All selected notes are already in '{subdeck_name}'", parent=aqt.mw)
         else:
-            tooltip(f"{added_count} note(s) added to '{conflicting_name}'")
+            tooltip(f"{added_count} note(s) added to '{subdeck_name}'", parent=aqt.mw)
         self.accept()
 
     def _clear_layout(self):

--- a/ankihub/gui/block_exam_dialog.py
+++ b/ankihub/gui/block_exam_dialog.py
@@ -47,6 +47,7 @@ class BlockExamSubdeckDialog(QDialog):
         self.selected_subdeck_id: Optional[DeckId] = None
 
         self.action_source = ActionSource.SMART_SEARCH
+        self.add_succeeded: bool = False
 
         self.setModal(True)
         self.setMinimumWidth(440)
@@ -467,8 +468,11 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        # Show success message
-        tooltip(f"{added_count} note(s) added to '{actual_name}'")
+        self.add_succeeded = True
+        if added_count == 0:
+            tooltip(f"All selected notes are already in '{actual_name}'", parent=aqt.mw)
+        else:
+            tooltip(f"{added_count} note(s) added to '{actual_name}'", parent=aqt.mw)
         self.accept()
 
         aqt.mw.moveToState("deckBrowser")
@@ -500,7 +504,11 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        tooltip(f"{added_count} note(s) added to '{self.selected_subdeck_name}'")
+        self.add_succeeded = True
+        if added_count == 0:
+            tooltip(f"All selected notes are already in '{self.selected_subdeck_name}'", parent=aqt.mw)
+        else:
+            tooltip(f"{added_count} note(s) added to '{self.selected_subdeck_name}'", parent=aqt.mw)
         self.accept()
 
     def _rename_subdeck(self, old_subdeck_path: str, new_subdeck_path: str):
@@ -543,7 +551,11 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        tooltip(f"{added_count} note(s) added to '{actual_name}'")
+        self.add_succeeded = True
+        if added_count == 0:
+            tooltip(f"All selected notes are already in '{actual_name}'", parent=aqt.mw)
+        else:
+            tooltip(f"{added_count} note(s) added to '{actual_name}'", parent=aqt.mw)
         self.accept()
 
         aqt.mw.moveToState("deckBrowser")
@@ -571,8 +583,11 @@ class BlockExamSubdeckDialog(QDialog):
             action_source=self.action_source,
         )
 
-        # Show success message and close
-        tooltip(f"{added_count} note(s) added to '{conflicting_name}'")
+        self.add_succeeded = True
+        if added_count == 0:
+            tooltip(f"All selected notes are already in '{conflicting_name}'")
+        else:
+            tooltip(f"{added_count} note(s) added to '{conflicting_name}'")
         self.accept()
 
     def _clear_layout(self):

--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -12,10 +12,12 @@ from anki.decks import DeckId
 from anki.utils import ids2str
 from aqt.browser import Browser
 from aqt.gui_hooks import webview_did_receive_js_message
+from aqt.qt import qconnect, sip
 from aqt.utils import openLink, tooltip
 from aqt.webview import AnkiWebView
 from jinja2 import Template
 
+from .. import LOGGER
 from ..db import ankihub_db
 from ..gui.block_exam_dialog import BlockExamSubdeckDialog
 from ..gui.terms_dialog import TermsAndConditionsDialog
@@ -149,10 +151,31 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
             ah_nids_to_anki_nids = ankihub_db.ankihub_nids_to_anki_nids(ah_nids)
             note_ids = [anki_nid for anki_nid in ah_nids_to_anki_nids.values() if anki_nid]
         elif search_string.strip():
-            note_ids = list(aqt.mw.col.find_notes(search_string))
+            try:
+                note_ids = list(aqt.mw.col.find_notes(search_string))
+            except Exception:
+                LOGGER.warning(
+                    "ADD_TO_BLOCK_EXAM_SUBDECK: invalid search string, treating as empty",
+                    search_string=search_string,
+                )
+                note_ids = []
 
         deck_config = config.deck_config(uuid.UUID(ankihub_did))
-        BlockExamSubdeckDialog(root_deck_id=DeckId(deck_config.anki_id), note_ids=note_ids, parent=aqt.mw).show()
+        dialog = BlockExamSubdeckDialog(root_deck_id=DeckId(deck_config.anki_id), note_ids=note_ids, parent=aqt.mw)
+        web = context.web
+
+        def on_dialog_finished(_result: int) -> None:
+            if web is None or sip.isdeleted(web):
+                LOGGER.warning("ADD_TO_BLOCK_EXAM_SUBDECK: web is None or deleted, dropping result")
+                return
+            status = "added" if dialog.add_succeeded else "cancelled"
+            _post_message_to_ankihub_js(
+                {"blockExamSubdeckResult": {"status": status}},
+                web=web,
+            )
+
+        qconnect(dialog.finished, on_dialog_finished)
+        dialog.show()
 
         return (True, None)
 

--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -151,14 +151,7 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
             ah_nids_to_anki_nids = ankihub_db.ankihub_nids_to_anki_nids(ah_nids)
             note_ids = [anki_nid for anki_nid in ah_nids_to_anki_nids.values() if anki_nid]
         elif search_string.strip():
-            try:
-                note_ids = list(aqt.mw.col.find_notes(search_string))
-            except Exception:
-                LOGGER.warning(
-                    "ADD_TO_BLOCK_EXAM_SUBDECK: invalid search string, treating as empty",
-                    search_string=search_string,
-                )
-                note_ids = []
+            note_ids = list(aqt.mw.col.find_notes(search_string))
 
         deck_config = config.deck_config(uuid.UUID(ankihub_did))
         dialog = BlockExamSubdeckDialog(root_deck_id=DeckId(deck_config.anki_id), note_ids=note_ids, parent=aqt.mw)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9517,7 +9517,7 @@ class TestBlockExamSubdeckDialog:
 
             assert dialog.add_succeeded is True
 
-    def test_dialog_finished_emits_cancelled_status_on_reject(
+    def test_reject_does_not_set_add_succeeded(
         self,
         anki_session_with_addon_data: AnkiSession,
         qtbot: QtBot,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9564,7 +9564,7 @@ class TestBlockExamSubdeckDialog:
             dialog._on_create_subdeck()
 
             assert dialog.add_succeeded is True
-            tooltip_mock.assert_called_once_with("All selected notes are already in 'Test Subdeck'")
+            tooltip_mock.assert_called_once_with("All selected notes are already in 'Test Subdeck'", parent=aqt.mw)
 
 
 class TestGetExpiredBlockExamSubdecks:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -7888,15 +7888,12 @@ def test_add_to_block_exam_subdeck_pycmd(
         # Simulate dialog finished with add_succeeded=True to verify postMessage payload
         dialog_instance = dialog_mock.return_value
         dialog_instance.add_succeeded = True
-        # Find the qconnect callback attached to dialog.finished and invoke it
-        if dialog_instance.finished.connect.called:
-            connect_call_args = dialog_instance.finished.connect.call_args
-            if connect_call_args:
-                callback = connect_call_args[0][0]
-                callback(1)  # QDialog.Accepted
-                post_msg_mock.assert_called_once()
-                post_msg_kwargs = post_msg_mock.call_args.kwargs
-                assert post_msg_kwargs["message"]["blockExamSubdeckResult"]["status"] == "added"
+        assert dialog_instance.finished.connect.called
+        callback = dialog_instance.finished.connect.call_args[0][0]
+        callback(1)  # QDialog.Accepted
+        post_msg_mock.assert_called_once()
+        message_arg = post_msg_mock.call_args.args[0]
+        assert message_arg["blockExamSubdeckResult"]["status"] == "added"
 
 
 @pytest.mark.sequential

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -7842,6 +7842,7 @@ def test_add_to_block_exam_subdeck_pycmd(
             created_ah_nids.append(note_info.ah_nid)
 
         dialog_mock = mocker.patch("ankihub.gui.js_message_handling.BlockExamSubdeckDialog")
+        post_msg_mock = mocker.patch("ankihub.gui.js_message_handling._post_message_to_ankihub_js")
 
         # Build message based on test scenario
         message_data: dict[str, Any] = {"deckId": str(ah_did)}
@@ -7883,6 +7884,19 @@ def test_add_to_block_exam_subdeck_pycmd(
             assert len(actual_anki_note_ids) == 3
 
         dialog_mock.return_value.show.assert_called_once()
+
+        # Simulate dialog finished with add_succeeded=True to verify postMessage payload
+        dialog_instance = dialog_mock.return_value
+        dialog_instance.add_succeeded = True
+        # Find the qconnect callback attached to dialog.finished and invoke it
+        if dialog_instance.finished.connect.called:
+            connect_call_args = dialog_instance.finished.connect.call_args
+            if connect_call_args:
+                callback = connect_call_args[0][0]
+                callback(1)  # QDialog.Accepted
+                post_msg_mock.assert_called_once()
+                post_msg_kwargs = post_msg_mock.call_args.kwargs
+                assert post_msg_kwargs["message"]["blockExamSubdeckResult"]["status"] == "added"
 
 
 @pytest.mark.sequential
@@ -9479,6 +9493,81 @@ class TestBlockExamSubdeckDialog:
             dialog.name_input.setText("Invalid:Name")  # Contains invalid character
             qtbot.wait(100)
             assert dialog.create_button.isEnabled() is True  # Button state is only based on non-empty text
+
+    def test_dialog_finished_sets_add_succeeded(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+
+            mocker.patch("aqt.mw.col.decks.children", return_value=[])
+
+            deck_config = config.deck_config(ah_did)
+            root_deck_id = deck_config.anki_id
+            dialog = BlockExamSubdeckDialog(root_deck_id, self.note_ids, parent=None)
+            qtbot.addWidget(dialog)
+
+            mocker.patch("ankihub.gui.block_exam_dialog.create_block_exam_subdeck", return_value=("Test Subdeck", None))
+            mocker.patch("ankihub.gui.block_exam_dialog.add_notes_to_block_exam_subdeck", return_value=3)
+
+            assert dialog.add_succeeded is False
+            dialog.name_input.setText("Test Subdeck")
+            dialog._on_create_subdeck()
+
+            assert dialog.add_succeeded is True
+
+    def test_dialog_finished_emits_cancelled_status_on_reject(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+
+            mocker.patch("aqt.mw.col.decks.children", return_value=[])
+
+            deck_config = config.deck_config(ah_did)
+            root_deck_id = deck_config.anki_id
+            dialog = BlockExamSubdeckDialog(root_deck_id, self.note_ids, parent=None)
+            qtbot.addWidget(dialog)
+
+            assert dialog.add_succeeded is False
+            dialog.reject()
+            assert dialog.add_succeeded is False
+
+    def test_dialog_zero_added_still_emits_added_status(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+
+            mocker.patch("aqt.mw.col.decks.children", return_value=[])
+
+            tooltip_mock = mocker.patch("ankihub.gui.block_exam_dialog.tooltip")
+
+            deck_config = config.deck_config(ah_did)
+            root_deck_id = deck_config.anki_id
+            dialog = BlockExamSubdeckDialog(root_deck_id, self.note_ids, parent=None)
+            qtbot.addWidget(dialog)
+
+            mocker.patch("ankihub.gui.block_exam_dialog.create_block_exam_subdeck", return_value=("Test Subdeck", None))
+            mocker.patch("ankihub.gui.block_exam_dialog.add_notes_to_block_exam_subdeck", return_value=0)
+
+            dialog.name_input.setText("Test Subdeck")
+            dialog._on_create_subdeck()
+
+            assert dialog.add_succeeded is True
+            tooltip_mock.assert_called_once_with("All selected notes are already in 'Test Subdeck'")
 
 
 class TestGetExpiredBlockExamSubdecks:


### PR DESCRIPTION
## Related issues
- [x] Closes [NRT-645](https://ankihub.atlassian.net/browse/NRT-645)


## Proposed changes
Companion PR to [AnkiHubSoftware/ankihub#3646](https://github.com/AnkiHubSoftware/ankihub/pull/3646).

The web side needs to know when the **Add to block exam subdeck** dialog finishes (and whether it actually added notes) so it can disable the button for the current selection. Today the dialog closes without telling the web view anything, so the web has no way to react.

This PR adds:

- **\`BlockExamSubdeckDialog.add_succeeded\`** — flag set across the four success paths (\`_on_create_subdeck\`, \`_on_add_notes\`, \`_handle_conflict_create_new\`, \`_handle_conflict_merge\`) before \`self.accept()\`. Lets the caller distinguish a real add from a cancel/reject.
- **\`js_message_handling._on_js_message\`** now connects \`dialog.finished\` to a closure that posts \`{\"blockExamSubdeckResult\": {\"status\": \"added\" | \"cancelled\"}}\` via the existing \`_post_message_to_ankihub_js\` helper. Guarded with \`sip.isdeleted(web)\` in case the user navigates away while the dialog is open.
- **Zero-added UX cleanup** — when \`add_notes_to_block_exam_subdeck\` returns 0 (all selected notes already in the chosen subdeck), the tooltip now reads \`\"All selected notes are already in '<name>'\"\` instead of the misleading \`\"0 note(s) added to '<name>'\"\`.
- **Tooltip parent fix** — \`tooltip(...)\` now passes \`parent=aqt.mw\`. Previously \`aqt.utils.tooltip\` parented to \`activeWindow()\` (the dialog), and \`self.accept()\` immediately destroyed the tooltip child.
- **Tests** in \`TestBlockExamSubdeckDialog\` cover \`add_succeeded\` toggling on success, the unchanged-on-reject path, and the zero-added tooltip text. \`test_add_to_block_exam_subdeck_pycmd\` is extended to assert the \`blockExamSubdeckResult\` payload coming back through \`_post_message_to_ankihub_js\`.

requestId routing (for addon→web result correlation) was considered and dropped — the dialog is modal so only one add can be in flight at a time, and the web-side \`pendingAdd\` gate is sufficient.


## How to reproduce
1. Run the local stack with the AnkiHub addon and the companion ankihub PR deployed.
2. Open Anki, log in, run a Smart Search on a flashcard deck.
3. Select notes, click **Add to block exam subdeck**, complete the dialog.
4. Verify the success tooltip appears in the Anki main window (not lost to the closing dialog).
5. Verify the web button transitions to **disabled**.
6. Cancel the dialog on a fresh click — verify button stays **enabled**.
7. With notes already in subdeck \"X\", reopen the dialog and merge the same notes into \"X\" — verify the tooltip reads \`\"All selected notes are already in 'X'\"\`.

Run the addon tests:
\`\`\`
cd /home/daniel/lab/ankihub_addon
just test \"-k 'block_exam or BlockExamSubdeck'\"
\`\`\`


## Screenshots and videos
_To be added._


## Further comments
- The \`tooltip(parent=aqt.mw)\` fix predates NRT-645 (the original code had the same orphan-on-close issue) but became visible because the web-side \`pendingAdd\` flow makes the tooltip behavior more important to verify.
- \`BlockExamSubdeckDialog\` stays decoupled from the web — the \`finished\` connection is wired by the caller in \`js_message_handling\`, not inside the dialog itself.

[NRT-645]: https://ankihub.atlassian.net/browse/NRT-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ