### PR TITLE
Create action to point addon to a PR env

### DIFF
--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -54,10 +54,10 @@ jobs:
         run: |
           uv sync --locked --dev --group aqt
 
-      - name: Configure config.json for PR environment
+      - name: Configure addon for PR environment
         run: |
           sed -i 's/"use_staging": false/"use_staging": true/' ankihub/config.json
-          sed -i 's|"app_url": null|"app_url": "${{ inputs.pr_env_url }}"|' ankihub/config.json
+          sed -i 's|"app_url": null|"app_url": "${{ inputs.pr_env_url }}"|' ankihub/build_config.json
 
       - name: Create ankiaddon file
         run: |

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           uv sync --locked --dev --group aqt
 
+      - name: Enable staging mode
+        run: |
+          sed -i 's/"use_staging": false/"use_staging": true/' ankihub/config.json
+
       - name: Create ankiaddon file
         run: |
           bash ./scripts/release.sh

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -52,9 +52,11 @@ jobs:
           uv sync --locked --dev --group aqt
 
       - name: Configure addon for PR environment
+        env:
+          PR_ENV_URL: ${{ inputs.pr_env_url }}
         run: |
-          sed -i 's|"app_url": null|"app_url": "${{ inputs.pr_env_url }}"|' ankihub/build_config.json
-          sed -i 's/"use_staging": false/"use_staging": true/' ankihub/build_config.json
+          jq --arg url "$PR_ENV_URL" '.app_url = $url | .use_staging = true' ankihub/build_config.json > tmp.json
+          mv tmp.json ankihub/build_config.json
 
       - name: Create ankiaddon file
         run: |

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -65,9 +65,12 @@ jobs:
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
+      - name: Sanitize branch name for artifact
+        run: echo "SAFE_BRANCH=$(echo '${{ inputs.branch }}' | tr '/' '-')" >> $GITHUB_ENV
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ankihub-pr-env-${{ inputs.branch }}
+          name: ankihub-pr-env-${{ env.SAFE_BRANCH }}
           path: ankihub.ankiaddon
           retention-days: 30

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -51,42 +51,20 @@ jobs:
         run: |
           uv sync --locked --dev --group aqt
 
-      - name: Enable staging mode
+      - name: Configure config.json for PR environment
         run: |
           sed -i 's/"use_staging": false/"use_staging": true/' ankihub/config.json
+          sed -i 's|"app_url": null|"app_url": "${{ inputs.pr_env_url }}"|' ankihub/config.json
 
       - name: Create ankiaddon file
         run: |
           bash ./scripts/release.sh
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          ANKIHUB_APP_URL: ${{ inputs.pr_env_url }}
 
-      - name: Sanitize branch name for tag
-        id: tag
-        run: |
-          SANITIZED=$(echo "${{ inputs.branch }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-          echo "tag_name=pr-env-${SANITIZED}" >> $GITHUB_OUTPUT
-
-      - name: Delete existing pre-release if it exists
-        run: |
-          gh release delete "${{ steps.tag.outputs.tag_name }}" --yes 2>/dev/null || true
-          git push origin ":${{ steps.tag.outputs.tag_name }}" 2>/dev/null || true
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
-
-      - name: Create pre-release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.tag.outputs.tag_name }}
-          name: "PR Env Build: ${{ inputs.branch }}"
-          body: |
-            **Branch:** `${{ inputs.branch }}`
-            **AnkiHub URL:** ${{ inputs.pr_env_url }}
-            **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            > This is a development build targeting a PR environment. Not for production use.
-          prerelease: true
-          files: ankihub.ankiaddon
-        env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+          name: ankihub-pr-env-${{ inputs.branch }}
+          path: ankihub.ankiaddon
+          retention-days: 30

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -1,0 +1,80 @@
+name: Build PR Environment Addon
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        type: string
+      pr_env_url:
+        description: 'AnkiHub PR environment URL (e.g., https://pr-123.ankihub.net)'
+        required: true
+        type: string
+
+jobs:
+  build-pr-env:
+    name: Build PR Environment Addon
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install deps
+        run: |
+          uv sync --locked --dev --group aqt
+
+      - name: Create ankiaddon file
+        run: |
+          bash ./scripts/release.sh
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANKIHUB_APP_URL: ${{ inputs.pr_env_url }}
+
+      - name: Sanitize branch name for tag
+        id: tag
+        run: |
+          SANITIZED=$(echo "${{ inputs.branch }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          echo "tag_name=pr-env-${SANITIZED}" >> $GITHUB_OUTPUT
+
+      - name: Delete existing pre-release if it exists
+        run: |
+          gh release delete "${{ steps.tag.outputs.tag_name }}" --yes 2>/dev/null || true
+          git push origin ":${{ steps.tag.outputs.tag_name }}" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+
+      - name: Create pre-release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          name: "PR Env Build: ${{ inputs.branch }}"
+          body: |
+            **Branch:** `${{ inputs.branch }}`
+            **AnkiHub URL:** ${{ inputs.pr_env_url }}
+            **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            > This is a development build targeting a PR environment. Not for production use.
+          prerelease: true
+          files: ankihub.ankiaddon
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -1,9 +1,6 @@
 name: Build PR Environment Addon
 
 on:
-  push:
-    branches:
-      - feat/pr-env-build-action
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -26,6 +26,13 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Validate pr_env_url
+        run: |
+          if [[ ! "${{ inputs.pr_env_url }}" =~ ^https://pr-[^.]+\.ankihub\.net(/.*)?$ ]]; then
+            echo "Error: pr_env_url must match https://pr-<id>.ankihub.net (got: ${{ inputs.pr_env_url }}). URL must use https:// and target a pr-<id>.ankihub.net host."
+            exit 1
+          fi
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
           ref: ${{ inputs.branch }}
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Configure addon for PR environment
         run: |
-          sed -i 's/"use_staging": false/"use_staging": true/' ankihub/config.json
           sed -i 's|"app_url": null|"app_url": "${{ inputs.pr_env_url }}"|' ankihub/build_config.json
+          sed -i 's/"use_staging": false/"use_staging": true/' ankihub/build_config.json
 
       - name: Create ankiaddon file
         run: |

--- a/.github/workflows/build_pr_env_addon.yml
+++ b/.github/workflows/build_pr_env_addon.yml
@@ -1,14 +1,17 @@
 name: Build PR Environment Addon
 
 on:
+  push:
+    branches:
+      - feat/pr-env-build-action
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build from'
+        description: "Branch to build from"
         required: true
         type: string
       pr_env_url:
-        description: 'AnkiHub PR environment URL (e.g., https://pr-123.ankihub.net)'
+        description: "AnkiHub PR environment URL (e.g., https://pr-123.ankihub.net)"
         required: true
         type: string
 

--- a/ankihub/build_config.json
+++ b/ankihub/build_config.json
@@ -1,0 +1,1 @@
+{"app_url": null}

--- a/ankihub/build_config.json
+++ b/ankihub/build_config.json
@@ -1,1 +1,1 @@
-{"app_url": null}
+{"app_url": null, "use_staging": false}

--- a/ankihub/config.json
+++ b/ankihub/config.json
@@ -12,6 +12,5 @@
     "boards_and_beyond_step_2": true,
     "first_aid_forward_step_1": true,
     "first_aid_forward_step_2": true,
-    "remind_to_optimize_fsrs_parameters": true,
-    "app_url": null
+    "remind_to_optimize_fsrs_parameters": true
 }

--- a/ankihub/config.json
+++ b/ankihub/config.json
@@ -12,5 +12,6 @@
     "boards_and_beyond_step_2": true,
     "first_aid_forward_step_1": true,
     "first_aid_forward_step_2": true,
-    "remind_to_optimize_fsrs_parameters": true
+    "remind_to_optimize_fsrs_parameters": true,
+    "app_url": null
 }

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -256,9 +256,9 @@ class _Config:
             self.intro_deck_id = uuid.UUID("2fb041b2-1c29-4a81-a51a-31ee822984c8")
 
         # Priority chain for app_url (lowest to highest):
-        # staging/prod (above) < build_config.json < user config (non-null) < env var
+        # staging/prod (above) < user config (non-null) < build_config.json < env var
         if override_url := (
-            os.getenv("ANKIHUB_APP_URL") or self.public_config.get("app_url") or _get_build_config_app_url()
+            os.getenv("ANKIHUB_APP_URL") or _get_build_config_app_url() or self.public_config.get("app_url")
         ):
             self.app_url = override_url
             self.api_url = f"{override_url}/api"

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -262,6 +262,7 @@ class _Config:
         if override_url := (
             os.getenv("ANKIHUB_APP_URL") or build_config.get("app_url") or self.public_config.get("app_url")
         ):
+            override_url = override_url.rstrip("/")
             self.app_url = override_url
             self.api_url = f"{override_url}/api"
 

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -258,9 +258,9 @@ class _Config:
             self.intro_deck_id = uuid.UUID("2fb041b2-1c29-4a81-a51a-31ee822984c8")
 
         # Override urls with environment variables if they are set.
-        if app_url_from_env_var := os.getenv("ANKIHUB_APP_URL"):
-            self.app_url = app_url_from_env_var
-            self.api_url = f"{app_url_from_env_var}/api"
+        if app_url_override := os.getenv("ANKIHUB_APP_URL") or self.public_config.get("app_url"):
+            self.app_url = app_url_override
+            self.api_url = f"{app_url_override}/api"
 
         if s3_url_from_env_var := os.getenv("S3_BUCKET_URL"):
             self.s3_bucket_url = s3_url_from_env_var

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -240,7 +240,9 @@ class _Config:
         migrate_public_config()
         self.load_public_config()
 
-        if self.public_config.get("use_staging"):
+        build_config = _get_build_config()
+
+        if build_config.get("use_staging") or self.public_config.get("use_staging"):
             self.app_url = STAGING_APP_URL
             self.api_url = STAGING_API_URL
             self.s3_bucket_url = STAGING_S3_BUCKET_URL
@@ -258,7 +260,7 @@ class _Config:
         # Priority chain for app_url (lowest to highest):
         # staging/prod (above) < user config (non-null) < build_config.json < env var
         if override_url := (
-            os.getenv("ANKIHUB_APP_URL") or _get_build_config_app_url() or self.public_config.get("app_url")
+            os.getenv("ANKIHUB_APP_URL") or build_config.get("app_url") or self.public_config.get("app_url")
         ):
             self.app_url = override_url
             self.api_url = f"{override_url}/api"
@@ -733,13 +735,13 @@ class _Config:
             )
 
 
-def _get_build_config_app_url() -> Optional[str]:
+def _get_build_config() -> dict:
     build_config_path = ADDON_PATH / "build_config.json"
     try:
         with open(build_config_path) as f:
-            return json.load(f).get("app_url")
+            return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
-        return None
+        return {}
 
 
 config = _Config()

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -257,7 +257,8 @@ class _Config:
             self.anking_deck_id = uuid.UUID("e77aedfe-a636-40e2-8169-2fce2673187e")
             self.intro_deck_id = uuid.UUID("2fb041b2-1c29-4a81-a51a-31ee822984c8")
 
-        # Override urls with environment variables if they are set.
+        # Override URLs with environment variables if they are set. `app_url` can
+        # also be overridden via the public config key `app_url`.
         if app_url_override := os.getenv("ANKIHUB_APP_URL") or self.public_config.get("app_url"):
             self.app_url = app_url_override
             self.api_url = f"{app_url_override}/api"

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -244,12 +244,10 @@ class _Config:
             self.app_url = STAGING_APP_URL
             self.api_url = STAGING_API_URL
             self.s3_bucket_url = STAGING_S3_BUCKET_URL
-            if staging_anking_deck_id := self.public_config.get("staging_anking_deck_id"):
-                self.anking_deck_id = staging_anking_deck_id
-            else:
-                self.anking_deck_id = uuid.UUID("dfe7f548-f66e-4277-932b-c7a63db3223a")
+            self.anking_deck_id = uuid.UUID(
+                self.public_config.get("staging_anking_deck_id") or "dfe7f548-f66e-4277-932b-c7a63db3223a"
+            )
             self.intro_deck_id = uuid.UUID("9289bb71-7977-4141-a9c7-643f9e32f572")
-
         else:
             self.app_url = DEFAULT_APP_URL
             self.api_url = DEFAULT_API_URL
@@ -257,11 +255,13 @@ class _Config:
             self.anking_deck_id = uuid.UUID("e77aedfe-a636-40e2-8169-2fce2673187e")
             self.intro_deck_id = uuid.UUID("2fb041b2-1c29-4a81-a51a-31ee822984c8")
 
-        # Override URLs with environment variables if they are set. `app_url` can
-        # also be overridden via the public config key `app_url`.
-        if app_url_override := os.getenv("ANKIHUB_APP_URL") or self.public_config.get("app_url"):
-            self.app_url = app_url_override
-            self.api_url = f"{app_url_override}/api"
+        # Priority chain for app_url (lowest to highest):
+        # staging/prod (above) < build_config.json < user config (non-null) < env var
+        if override_url := (
+            os.getenv("ANKIHUB_APP_URL") or self.public_config.get("app_url") or _get_build_config_app_url()
+        ):
+            self.app_url = override_url
+            self.api_url = f"{override_url}/api"
 
         if s3_url_from_env_var := os.getenv("S3_BUCKET_URL"):
             self.s3_bucket_url = s3_url_from_env_var
@@ -731,6 +731,15 @@ class _Config:
                 FSRS_LAST_OPTIMIZATION_REMINDER_DATE_KEY,
                 date_.isoformat(),
             )
+
+
+def _get_build_config_app_url() -> Optional[str]:
+    build_config_path = ADDON_PATH / "build_config.json"
+    try:
+        with open(build_config_path) as f:
+            return json.load(f).get("app_url")
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
 
 
 config = _Config()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3905,7 +3905,7 @@ class TestSetupPublicConfigAndOtherSettings:
         monkeypatch.delenv("S3_BUCKET_URL", raising=False)
         monkeypatch.delenv("ANKING_DECK_ID", raising=False)
         monkeypatch.delenv("INTRO_DECK_ID", raising=False)
-        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: None)
+        monkeypatch.setattr("ankihub.settings._get_build_config", lambda: {})
 
     def test_production_defaults(self):
         config.public_config = {}
@@ -3932,18 +3932,18 @@ class TestSetupPublicConfigAndOtherSettings:
         assert config.anking_deck_id == uuid.UUID(custom_id)
 
     def test_build_config_app_url(self, monkeypatch: MonkeyPatch):
-        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: "https://build.example.com")
+        monkeypatch.setattr("ankihub.settings._get_build_config", lambda: {"app_url": "https://build.example.com"})
         config.public_config = {}
         config.setup_public_config_and_other_settings()
         assert config.app_url == "https://build.example.com"
         assert config.api_url == "https://build.example.com/api"
 
-    def test_user_config_app_url_overrides_build_config(self, monkeypatch: MonkeyPatch):
-        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: "https://build.example.com")
+    def test_build_config_app_url_overrides_user_config(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setattr("ankihub.settings._get_build_config", lambda: {"app_url": "https://build.example.com"})
         config.public_config = {"app_url": "https://user.example.com"}
         config.setup_public_config_and_other_settings()
-        assert config.app_url == "https://user.example.com"
-        assert config.api_url == "https://user.example.com/api"
+        assert config.app_url == "https://build.example.com"
+        assert config.api_url == "https://build.example.com/api"
 
     def test_env_var_app_url_overrides_user_config(self, monkeypatch: MonkeyPatch):
         monkeypatch.setenv("ANKIHUB_APP_URL", "https://env.example.com")

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -78,6 +78,10 @@ from ankihub.ankihub_client import (
 from ankihub.ankihub_client.ankihub_client import (
     DEFAULT_API_URL,
     DEFAULT_APP_URL,
+    DEFAULT_S3_BUCKET_URL,
+    STAGING_API_URL,
+    STAGING_APP_URL,
+    STAGING_S3_BUCKET_URL,
     AnkiHubRequestException,
 )
 from ankihub.ankihub_client.models import (  # type: ignore
@@ -3885,3 +3889,85 @@ class TestShowSubdeckDueDateReminders:
         assert _reminder_dialog_state.queue == expired_subdecks
         # Verify _show_next_due_date_reminder_dialog was called to start the flow
         mock_show_next.assert_called_once()
+
+
+class TestSetupPublicConfigAndOtherSettings:
+    @pytest.fixture(autouse=True)
+    def anki_session_with_addon_data(self):
+        """Override the global autouse fixture — these tests don't need a full Anki session."""
+        yield
+
+    @pytest.fixture(autouse=True)
+    def base_setup(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setattr("ankihub.settings.migrate_public_config", lambda: None)
+        monkeypatch.setattr(config, "load_public_config", lambda: None)
+        monkeypatch.delenv("ANKIHUB_APP_URL", raising=False)
+        monkeypatch.delenv("S3_BUCKET_URL", raising=False)
+        monkeypatch.delenv("ANKING_DECK_ID", raising=False)
+        monkeypatch.delenv("INTRO_DECK_ID", raising=False)
+        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: None)
+
+    def test_production_defaults(self):
+        config.public_config = {}
+        config.setup_public_config_and_other_settings()
+        assert config.app_url == DEFAULT_APP_URL
+        assert config.api_url == DEFAULT_API_URL
+        assert config.s3_bucket_url == DEFAULT_S3_BUCKET_URL
+        assert config.anking_deck_id == uuid.UUID("e77aedfe-a636-40e2-8169-2fce2673187e")
+        assert config.intro_deck_id == uuid.UUID("2fb041b2-1c29-4a81-a51a-31ee822984c8")
+
+    def test_staging_defaults(self):
+        config.public_config = {"use_staging": True}
+        config.setup_public_config_and_other_settings()
+        assert config.app_url == STAGING_APP_URL
+        assert config.api_url == STAGING_API_URL
+        assert config.s3_bucket_url == STAGING_S3_BUCKET_URL
+        assert config.anking_deck_id == uuid.UUID("dfe7f548-f66e-4277-932b-c7a63db3223a")
+        assert config.intro_deck_id == uuid.UUID("9289bb71-7977-4141-a9c7-643f9e32f572")
+
+    def test_staging_anking_deck_id_override(self):
+        custom_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        config.public_config = {"use_staging": True, "staging_anking_deck_id": custom_id}
+        config.setup_public_config_and_other_settings()
+        assert config.anking_deck_id == uuid.UUID(custom_id)
+
+    def test_build_config_app_url(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: "https://build.example.com")
+        config.public_config = {}
+        config.setup_public_config_and_other_settings()
+        assert config.app_url == "https://build.example.com"
+        assert config.api_url == "https://build.example.com/api"
+
+    def test_user_config_app_url_overrides_build_config(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setattr("ankihub.settings._get_build_config_app_url", lambda: "https://build.example.com")
+        config.public_config = {"app_url": "https://user.example.com"}
+        config.setup_public_config_and_other_settings()
+        assert config.app_url == "https://user.example.com"
+        assert config.api_url == "https://user.example.com/api"
+
+    def test_env_var_app_url_overrides_user_config(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setenv("ANKIHUB_APP_URL", "https://env.example.com")
+        config.public_config = {"app_url": "https://user.example.com"}
+        config.setup_public_config_and_other_settings()
+        assert config.app_url == "https://env.example.com"
+        assert config.api_url == "https://env.example.com/api"
+
+    def test_s3_bucket_url_env_var_override(self, monkeypatch: MonkeyPatch):
+        monkeypatch.setenv("S3_BUCKET_URL", "https://custom-s3.example.com")
+        config.public_config = {}
+        config.setup_public_config_and_other_settings()
+        assert config.s3_bucket_url == "https://custom-s3.example.com"
+
+    def test_anking_deck_id_env_var_override(self, monkeypatch: MonkeyPatch):
+        custom_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        monkeypatch.setenv("ANKING_DECK_ID", custom_id)
+        config.public_config = {}
+        config.setup_public_config_and_other_settings()
+        assert config.anking_deck_id == uuid.UUID(custom_id)
+
+    def test_intro_deck_id_env_var_override(self, monkeypatch: MonkeyPatch):
+        custom_id = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        monkeypatch.setenv("INTRO_DECK_ID", custom_id)
+        config.public_config = {}
+        config.setup_public_config_and_other_settings()
+        assert config.intro_deck_id == uuid.UUID(custom_id)


### PR DESCRIPTION
Add a GitHub Action to build and publish a PR-environment addon build.

Requires merging to `main` first because GitHub only registers `workflow_dispatch` workflows that exist on the default branch. The trigger won't appear in the Actions UI until the file is on `main`.