### PR TITLE
[NRT-749] Redesign Suggest-a-change dialog with "Include in suggestion" section

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -358,7 +358,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
 
     # Note types are 1:1 with AH decks, so the note's mid uniquely determines the deck.
     ah_did = ankihub_db.ankihub_did_for_note_type(note.mid)
-    globally_protected = config.globally_protected_fields_for_note_type(ah_did, note.mid) if ah_did else []
+    globally_protected = config.globally_protected_fields(ah_did).get(note.mid, []) if ah_did else []
 
     new_fields_protected_by_tags = choose_subset(
         "Choose which fields of this note should be protected from updates.<br><br>"

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -47,6 +47,7 @@ from ..main.note_type_management import (
     update_note_type_templates_and_styles,
 )
 from ..main.subdecks import SUBDECK_TAG, deck_contains_subdeck_tags
+from ..main.suggestions import AUTO_PROTECT_FEATURE_FLAG
 from ..main.utils import (
     all_notes_in_deck,
     get_deck_for_ah_did,
@@ -288,7 +289,7 @@ class DeckManagementDialog(QDialog):
 
         # Setup "Automatically protect fields when edited" (gated on a server-controlled flag
         # — the suggestion dialog needs to ship before this option is meaningful to users)
-        auto_protect_enabled = (config.get_feature_flags() or {}).get("auto_protect_fields_when_edited", False)
+        auto_protect_enabled = config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False)
         if auto_protect_enabled:
             self.box_auto_protect_fields = self._setup_box_auto_protect_fields_when_edited(selected_ah_did)
 

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -16,6 +16,7 @@ from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
 from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
+from ..main.suggestions import AUTO_PROTECT_FEATURE_FLAG
 from ..main.utils import is_tag_in_list, update_notes_with_named_undo
 from ..settings import (
     ANKI_INT_VERSION,
@@ -68,18 +69,13 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     """
     # Server-controlled rollout gate: the suggestion dialog needs to ship before
     # auto-protect is safe to enable (otherwise edits get silently stripped on suggest).
-    if not (config.get_feature_flags() or {}).get("auto_protect_fields_when_edited", False):
+    if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
         return changed
 
     ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
-    if not ah_did:
+    if not ah_did or not config.deck_config(ah_did).auto_protect_fields_when_edited:
         return changed
 
-    deck_config = config.deck_config(ah_did)
-    if not deck_config.auto_protect_fields_when_edited:
-        return changed
-
-    # If all fields are already covered by the "All" tag, no per-field tag is needed.
     if is_tag_in_list(TAG_FOR_PROTECTING_ALL_FIELDS, note.tags):
         return changed
 
@@ -87,8 +83,7 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     if field_name == ANKIHUB_NOTE_TYPE_FIELD_NAME:
         return changed
 
-    # Skip if globally protected for this deck (managed by deck owner, not locally)
-    if field_name in config.globally_protected_fields_for_note_type(ah_did, note.mid):
+    if field_name in config.globally_protected_fields(ah_did).get(note.mid, []):
         return changed
 
     ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
@@ -101,21 +96,23 @@ def _on_field_unfocus_auto_protect(changed: bool, note: Note, current_field_idx:
     if field_name.lower() not in ah_field_names_lower:
         return changed
 
-    # ah_note.fields omits empty fields, so treat a missing field name as empty
-    ah_field_value = (ah_note.fields or {}).get(field_name, "")
     protection_tag = protection_tag_for_field(field_name)
+    is_protected = is_tag_in_list(protection_tag, note.tags)
+    # ah_note.fields omits empty fields, so treat a missing field name as empty.
+    ah_field_value = (ah_note.fields or {}).get(field_name, "")
     should_be_protected = note[field_name] != ah_field_value
-    if should_be_protected and not is_tag_in_list(protection_tag, note.tags):
-        # Field differs from AnkiHub version — add protection if not already present
+    if is_protected == should_be_protected:
+        return changed
+
+    if should_be_protected:
         note.tags.append(protection_tag)
-        update_notes_with_named_undo(f"AnkiHub | Auto-protect {field_name}", note)
-        return True
-    if not should_be_protected and is_tag_in_list(protection_tag, note.tags):
-        # Field matches AnkiHub version — remove protection tag if present
-        note.tags = [t for t in note.tags if t.lower() != protection_tag.lower()]
-        update_notes_with_named_undo(f"AnkiHub | Auto-unprotect {field_name}", note)
-        return True
-    return changed
+        verb = "protect"
+    else:
+        protection_tag_lower = protection_tag.lower()
+        note.tags = [t for t in note.tags if t.lower() != protection_tag_lower]
+        verb = "unprotect"
+    update_notes_with_named_undo(f"AnkiHub | Auto-{verb} {field_name}", note)
+    return True
 
 
 def _on_suggestion_button_press(editor: Editor) -> None:

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -661,6 +661,9 @@ class SuggestionDialog(QDialog):
     def _refresh_source_widget(self):
         if self._source_needed():
             self.source_widget.setup_for_change_type(change_type=self._change_type())
+            # DELETE's source (Duplicate Note) is optional, so don't claim "(Required)" there.
+            title = "Source (Required)" if self.source_widget.input_is_required() else "Source"
+            self.source_widget_group_box.setTitle(title)
             self.source_widget_group_box.show()
         else:
             self.source_widget_group_box.hide()
@@ -833,6 +836,12 @@ class SourceWidget(QWidget):
             source = f"{step} {source}"
 
         return SuggestionSource(source_type=source_type, source_text=source)
+
+    def input_is_required(self) -> bool:
+        """Whether the current source type requires the user to fill the input. DELETE's only
+        source type (Duplicate Note) is optional, so callers can drop the "(Required)" label.
+        """
+        return self._source_type() not in source_types_where_input_is_optional
 
     def is_valid(self) -> bool:
         if self._source_type() in source_types_where_input_is_optional:

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -870,11 +870,9 @@ class SourceWidget(QWidget):
 
     def _refresh_source_input_label(self) -> None:
         source_type = self._source_type()
-        text = source_type_to_source_label[source_type]
-        if source_type not in source_types_where_input_is_optional:
-            text = f"{text} (Required)"
-
-        self.source_input_label.setText(text)
+        # The "(Required)" indicator lives on the Source group box title (set by the dialog),
+        # so the inner field label stays bare to avoid showing "(Required)" twice.
+        self.source_input_label.setText(source_type_to_source_label[source_type])
 
         place_holder_text = source_type_to_source_place_holder_text.get(source_type, "")
         self.source_edit.setPlaceholderText(place_holder_text)

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -2,25 +2,32 @@
 
 import uuid
 from concurrent.futures import Future
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+from html import escape
 from pprint import pformat
-from typing import Callable, Collection, List, Optional, Set
+from typing import Callable, Collection, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 import aqt
+from anki.models import NotetypeId
 from anki.notes import Note, NoteId
 from aqt.qt import (
     QCheckBox,
     QComboBox,
-    QCursor,
     QDialog,
     QDialogButtonBox,
+    QFrame,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
     QPlainTextEdit,
+    QScrollArea,
+    QSize,
+    QSizePolicy,
     QSpacerItem,
+    QStyle,
+    QStyleOptionButton,
     Qt,
     QVBoxLayout,
     QWidget,
@@ -33,31 +40,33 @@ from .. import LOGGER
 from ..ankihub_client import (
     AnkiHubHTTPError,
     SuggestionType,
-    get_media_names_from_note_info,
 )
 from ..ankihub_client.models import UserDeckRelation
 from ..db import ankihub_db
-from ..main.exporting import to_note_data
 from ..main.suggestions import (
     ANKIHUB_EMPTY_FIRST_FIELD_ERROR,
     ANKIHUB_NO_CHANGE_ERROR,
     ANKIHUB_NOTE_DOES_NOT_EXIST_ERROR,
+    AUTO_PROTECT_FEATURE_FLAG,
     BulkNoteSuggestionsResult,
+    BulkSuggestionFilters,
     ChangeSuggestionResult,
+    NoteDiff,
+    any_suggestible_from_diffs,
+    compute_note_diffs,
     get_anki_nid_to_ah_dids_dict,
     suggest_new_note,
     suggest_note_update,
     suggest_notes_in_bulk,
 )
+from ..main.utils import note_type_name_without_ankihub_modifications
 from ..settings import RATIONALE_FOR_CHANGE_MAX_LENGTH, config
 from .errors import report_exception_and_upload_logs
 from .media_sync import media_sync
 from .utils import (
     active_window_or_mw,
-    show_dialog,
     show_error_dialog,
     show_tooltip,
-    tooltip_icon,
 )
 
 
@@ -81,6 +90,7 @@ class SuggestionMetadata:
     auto_accept: bool = False
     change_type: Optional[SuggestionType] = None
     source: Optional[SuggestionSource] = None
+    filters: BulkSuggestionFilters = field(default_factory=BulkSuggestionFilters)
 
 
 def open_suggestion_dialog_for_single_suggestion(
@@ -103,18 +113,23 @@ def open_suggestion_dialog_for_single_suggestion(
         return
 
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(note.id)
+    diffs = compute_note_diffs([note])
     SuggestionDialog(
         is_new_note_suggestion=ah_nid is None,
         is_for_anking_deck=ah_did == config.anking_deck_id,
         can_submit_without_review=_can_submit_without_review(ah_did=ah_did),
-        added_new_media=_added_new_media(note),
+        added_new_media=diffs[NoteId(note.id)].added_new_media,
         callback=lambda suggestion_meta: _on_suggestion_dialog_for_single_suggestion_closed(
             suggestion_meta=suggestion_meta,
             note=note,
             ah_did=ah_did,
             parent=parent,
         ),
+        notes=[note],
+        note_diffs=diffs,
+        ah_did=ah_did,
         preselected_change_type=preselected_change_type,
+        globally_protected_fields_by_mid=_globally_protected_fields_by_mid(ah_did),
         parent=parent,
     )
 
@@ -132,37 +147,10 @@ def _handle_suggestion_error(e: AnkiHubHTTPError, parent: QWidget) -> None:
             report_exception_and_upload_logs(e)
         all_no_changes_errors = all(ANKIHUB_NO_CHANGE_ERROR in error for error in non_field_errors)
         if all_no_changes_errors:
-            dialog = show_dialog(
-                title="Invalid suggestion",
-                text=(
-                    "No field or tag changes were detected. "
-                    "Please verify that the changes you made were not to a protected field and try again.<br><br>"
-                ),
-                parent=parent,
-                open_dialog=False,
-            )
-            layout = dialog.content_layout
-            sublayout = QHBoxLayout()
-            subwidget = QWidget()
-            subwidget.setLayout(sublayout)
-            label = QLabel(
-                "(Learn more about protected fields "
-                "<a href='https://community.ankihub.net/t/protecting-fields-and-tags/165604'>here</a>.)"
-            )
-            label.setOpenExternalLinks(True)
-            sublayout.addWidget(label)
-            icon_label = QLabel("")
-            pixmap = tooltip_icon().pixmap(QCheckBox().iconSize())
-            icon_label.setPixmap(pixmap)
-            icon_label.setToolTip(
-                "Protecting a field allows you to add anything you want to a field\n"
-                "without it being overwritten via AnkiHub suggestions."
-            )
-            icon_label.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-            sublayout.addWidget(icon_label)
-            layout.insertWidget(layout.count() - 1, subwidget)
-            dialog.adjustSize()
-            dialog.open()
+            # The dialog OK button is gated on at least one field/tag change being
+            # selected, so this branch should be unreachable in normal use. If it
+            # still fires (e.g. sync racing with submit), fall through to a tooltip.
+            show_tooltip("No changes to suggest.", parent=parent)
         else:
             showInfo(
                 text=(f"There are some problems with this suggestion:<br><br><b>{error_message}</b>"),
@@ -193,6 +181,8 @@ def _on_suggestion_dialog_for_single_suggestion_closed(
     if suggestion_meta is None:
         return
 
+    per_note_filters = suggestion_meta.filters.for_mid(NotetypeId(note.mid))
+
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(note.id)
     if ah_nid:
         try:
@@ -202,6 +192,7 @@ def _on_suggestion_dialog_for_single_suggestion_closed(
                 comment=_comment_with_source(suggestion_meta),
                 media_upload_cb=media_sync.start_media_upload,
                 auto_accept=suggestion_meta.auto_accept,
+                filters=per_note_filters,
             )
         except AnkiHubHTTPError as e:
             _handle_suggestion_error(e, parent)
@@ -229,16 +220,21 @@ def _on_suggestion_dialog_for_single_suggestion_closed(
             return
 
         try:
-            suggest_new_note(
+            submitted = suggest_new_note(
                 note=note,
                 ankihub_did=ah_did,
                 comment=suggestion_meta.comment,
                 media_upload_cb=media_sync.start_media_upload,
                 auto_accept=suggestion_meta.auto_accept,
+                filters=per_note_filters,
             )
-            show_tooltip("Submitted suggestion to AnkiHub.", parent=parent)
         except AnkiHubHTTPError as e:
             _handle_suggestion_error(e, parent)
+            return
+        if submitted:
+            show_tooltip("Submitted suggestion to AnkiHub.", parent=parent)
+        else:
+            show_tooltip("No changes to suggest.", parent=parent)
 
 
 def open_suggestion_dialog_for_bulk_suggestion(
@@ -260,21 +256,32 @@ def open_suggestion_dialog_for_bulk_suggestion(
         return
 
     notes = [aqt.mw.col.get_note(nid) for nid in anki_nids]
+    globally_protected = _globally_protected_fields_by_mid(ah_did)
+
+    diffs = compute_note_diffs(notes)
+
+    if config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False) and not any_suggestible_from_diffs(
+        notes, diffs, preselected_change_type, globally_protected
+    ):
+        show_tooltip("No changes to suggest. Try syncing with AnkiHub first.", parent=parent)
+        return
 
     SuggestionDialog(
         is_new_note_suggestion=False,
         is_for_anking_deck=ah_did == config.anking_deck_id,
         can_submit_without_review=_can_submit_without_review(ah_did=ah_did),
-        # We currently have a limit of 500 notes per bulk suggestion, so we don't have to worry
-        # about performance here.
-        added_new_media=any(_added_new_media(note) for note in notes),
+        added_new_media=any(d.added_new_media for d in diffs.values()),
         callback=lambda suggestion_meta: _on_suggestion_dialog_for_bulk_suggestion_closed(
             suggestion_meta=suggestion_meta,
             notes=notes,
             ah_did=ah_did,
             parent=parent,
         ),
+        notes=notes,
+        note_diffs=diffs,
+        ah_did=ah_did,
         preselected_change_type=preselected_change_type,
+        globally_protected_fields_by_mid=globally_protected,
         parent=parent,
     )
 
@@ -302,6 +309,7 @@ def _on_suggestion_dialog_for_bulk_suggestion_closed(
             change_type=suggestion_meta.change_type,
             comment=_comment_with_source(suggestion_meta),
             media_upload_cb=media_upload_cb,
+            filters=suggestion_meta.filters,
         ),
         on_done=lambda future: _on_suggest_notes_in_bulk_done(future, parent),
         parent=parent,
@@ -337,21 +345,9 @@ def _determine_ah_did_for_nids_to_be_suggested(anki_nids: Collection[NoteId], pa
     return ah_did
 
 
-def _added_new_media(note: Note) -> bool:
-    """Returns True if media files were added to the notes when comparing with
-    the notes in the ankihub database, else False."""
-    note_info_anki = to_note_data(note)
-    media_names_anki = get_media_names_from_note_info(note_info_anki, note.note_type())
-
-    note_info_ah = ankihub_db.note_data(note.id)
-    if note_info_ah is None:
-        return bool(media_names_anki)
-
-    media_names_ah = get_media_names_from_note_info(note_info_ah, note.note_type())
-
-    added_media_names = set(media_names_anki) - set(media_names_ah)
-    result = len(added_media_names) > 0
-    return result
+def _globally_protected_fields_by_mid(ah_did: uuid.UUID) -> Dict[NotetypeId, Set[str]]:
+    """Coerce the cached globally-protected fields into the shape the widget expects."""
+    return {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
 
 
 def _comment_with_source(suggestion_meta: SuggestionMetadata) -> str:
@@ -447,19 +443,47 @@ class SuggestionDialog(QDialog):
         can_submit_without_review: bool,
         added_new_media: bool,
         callback: Callable[[Optional[SuggestionMetadata]], None],
+        notes: Sequence[Note] = (),
+        note_diffs: Optional[Mapping[NoteId, NoteDiff]] = None,
+        ah_did: Optional[uuid.UUID] = None,
         preselected_change_type: Optional[SuggestionType] = None,
+        globally_protected_fields_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None,
         parent: Optional[QWidget] = None,
     ) -> None:
         if parent is None:
             parent = active_window_or_mw()
 
         super().__init__(parent)
+        # Block input to other Anki windows while the dialog is open — prevents
+        # the user from editing the selected notes (or syncing) between dialog
+        # open and submit, which would invalidate the "Include in suggestion"
+        # selection.
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self._is_new_note_suggestion = is_new_note_suggestion
         self._is_for_anking_deck = is_for_anking_deck
         self._can_submit_without_review = can_submit_without_review
         self._added_new_media = added_new_media
         self._callback = callback
-        self._preselected_change_type = preselected_change_type
+        self._notes = list(notes)
+        self._note_diffs = note_diffs
+        # Notes and diffs are paired inputs — callers always compute diffs at the same time as
+        # the note list and pass both. Pinning the invariant here means downstream code (e.g.
+        # the widget gate) can treat `_note_diffs` as non-None whenever `_notes` is non-empty.
+        assert not self._notes or self._note_diffs is not None
+        self._ah_did = ah_did
+        self._fields_widget: Optional[IncludeInSuggestionWidget] = None
+        self._globally_protected_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = (
+            globally_protected_fields_by_mid
+        )
+        # Snapshot prior per-mid deselections at construction. Reused by `_save_deselections`
+        # so a field deselected in an earlier session survives even when it isn't shown in
+        # this session's widget.
+        self._initial_deselected_by_mid: Dict[NotetypeId, Set[str]] = {}
+        if self._ah_did is not None and self._notes:
+            mids = {NotetypeId(n.mid) for n in self._notes}
+            self._initial_deselected_by_mid = {
+                mid: set(config.last_deselected_fields(self._ah_did, mid)) for mid in mids
+            }
 
         self._setup_ui()
 
@@ -470,47 +494,80 @@ class SuggestionDialog(QDialog):
 
     def _setup_ui(self) -> None:
         self.setWindowTitle("Note Suggestion(s)")
+        # Without a floor, non-AnKing / new-note configurations (no Change Type
+        # dropdown, no Source widget, no photo-credit hint) collapse the dialog
+        # to an awkwardly short height.
+        self.setMinimumHeight(480)
 
-        self.layout_ = QVBoxLayout()
-        self.setLayout(self.layout_)
+        # Outer vbox = [ two-column content row , button row ]. Buttons live
+        # below both columns so the left frame stops at the bottom of the
+        # right column's content (e.g. "Submit without review"), not at the
+        # bottom of the dialog.
+        outer_layout = QVBoxLayout()
+        self.setLayout(outer_layout)
 
-        # Set up change type dropdown
+        content_row = QHBoxLayout()
+        content_row.setSpacing(16)
+        outer_layout.addLayout(content_row, 1)
+
+        if (
+            config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False)
+            and self._notes
+            and self._ah_did is not None
+        ):
+            assert self._note_diffs is not None  # paired with `_notes`; see __init__
+            self._fields_widget = IncludeInSuggestionWidget(
+                notes=self._notes,
+                note_diffs=self._note_diffs,
+                initial_deselected_by_mid=self._initial_deselected_by_mid,
+                globally_protected_fields_by_mid=self._globally_protected_by_mid,
+            )
+            self._fields_widget.setMinimumWidth(220)
+            # Cap the left column so pathologically long section titles can't
+            # push the dialog wide; the section-title checkbox elides instead.
+            self._fields_widget.setMaximumWidth(360)
+            content_row.addWidget(self._fields_widget, 2)
+            qconnect(self._fields_widget.selection_changed, self._validate)
+
+        right_layout = QVBoxLayout()
+        content_row.addLayout(right_layout, 3)
+
+        # Small top inset so "Change Type" doesn't sit flush against the top edge.
+        right_layout.addSpacing(8)
+
         self.change_type_select = QComboBox()
         if not self._is_new_note_suggestion:
             self.change_type_select.addItems([x.value[1] for x in SuggestionType])
-            label = QLabel("Change Type")
-            self.layout_.addWidget(label)
-            self.layout_.addWidget(self.change_type_select)
+            right_layout.addWidget(QLabel("Change Type"))
+            right_layout.addWidget(self.change_type_select)
             qconnect(
                 self.change_type_select.currentTextChanged,
                 self._on_change_type_changed,
             )
-            self.layout_.addSpacing(10)
+            right_layout.addSpacing(10)
 
-        # Set up source widget in a group box (group box is for styling purposes)
         self.source_widget = SourceWidget()
-        self.source_widget_group_box = QGroupBox("Source")
-        self.layout_.addWidget(self.source_widget_group_box)
+        self.source_widget_group_box = QGroupBox("Source (Required)")
+        right_layout.addWidget(self.source_widget_group_box)
         self.source_widget_group_box_layout = QVBoxLayout()
         self.source_widget_group_box.setLayout(self.source_widget_group_box_layout)
 
         self.source_widget_group_box_layout.addWidget(self.source_widget)
         qconnect(self.source_widget.validation_signal, self._validate)
-        self.layout_.addSpacing(10)
+        right_layout.addSpacing(10)
 
         self._refresh_source_widget()
 
         self.hint_for_note_deletions = QLabel("💡 When deleting a note, any changes<br>to fields will not be applied.")
         self.hint_for_note_deletions.hide()
-        self.layout_.addWidget(self.hint_for_note_deletions)
-        self.layout_.addSpacing(10)
+        right_layout.addWidget(self.hint_for_note_deletions)
+        right_layout.addSpacing(10)
 
-        # Set up rationale field
-        label = QLabel("Rationale for Change (Required)")
-        self.layout_.addWidget(label)
+        right_layout.addWidget(QLabel("Rationale for Change (Required)"))
 
         self.rationale_edit = QPlainTextEdit()
-        self.layout_.addWidget(self.rationale_edit)
+        self.rationale_edit.setPlaceholderText(RATIONALE_FOR_CHANGE_PLACEHOLDER)
+        right_layout.addWidget(self.rationale_edit)
 
         def limit_length():
             while len(self.rationale_edit.toPlainText()) >= RATIONALE_FOR_CHANGE_MAX_LENGTH:
@@ -519,51 +576,87 @@ class SuggestionDialog(QDialog):
         qconnect(self.rationale_edit.textChanged, limit_length)
         qconnect(self.rationale_edit.textChanged, self._validate)
 
-        self.layout_.addSpacing(10)
+        right_layout.addSpacing(10)
 
-        # Add note about media source if a media file was added
         if self._added_new_media and self._is_for_anking_deck:
-            label = QLabel(
-                "Please provide the source of images or audio files<br>"
-                "in the rationale field. For example:<br>"
-                "Photo credit: The AnKing [www.ankingmed.com]"
+            right_layout.addWidget(
+                QLabel(
+                    "Please provide the source of images or audio files<br>"
+                    "in the rationale field. For example:<br>"
+                    "Photo credit: The AnKing [www.ankingmed.com]"
+                )
             )
-            self.layout_.addWidget(label)
-            self.layout_.addSpacing(10)
+            right_layout.addSpacing(10)
 
-        # Set up "auto-accept" checkbox
         self.auto_accept_cb = QCheckBox("Submit without review.")
         self.auto_accept_cb.setVisible(self._can_submit_without_review)
-        self.layout_.addWidget(self.auto_accept_cb)
+        right_layout.addWidget(self.auto_accept_cb)
 
-        # Set up button box
-        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        # Button box at the dialog's bottom edge (outside the two-column row)
+        # so the left frame stops at the bottom of the right column's content.
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         qconnect(self.button_box.accepted, self.accept)
-        self.layout_.addWidget(self.button_box)
+        qconnect(self.button_box.rejected, self.reject)
+        outer_layout.addWidget(self.button_box)
+
+        # Visibility depends on _change_type(), so this has to run after the dropdown exists.
+        if self._fields_widget is not None:
+            self._refresh_fields_widget_visibility()
 
         self._set_submit_button_enabled_state(False)
         qconnect(self.validation_signal, self._set_submit_button_enabled_state)
 
     def accept(self) -> None:
+        if self._fields_widget_active():
+            self._save_deselections()
         self._callback(self.suggestion_meta())
         super().accept()
+
+    def _save_deselections(self) -> None:
+        """Persist the user's per-mid deselected fields. Merges with priors so a deselection
+        survives sessions where the field isn't shown (not edited this round); an explicit
+        re-check in this session clears that field's prior deselection.
+        """
+        assert self._fields_widget is not None and self._ah_did is not None
+        for mid, this_session in self._fields_widget.field_selection_state_by_mid().items():
+            selected = {name for name, checked in this_session.items() if checked}
+            deselected = {name for name, checked in this_session.items() if not checked}
+            prior = self._initial_deselected_by_mid.get(mid, set())
+            merged = (prior - selected) | deselected
+            config.set_last_deselected_fields(self._ah_did, mid, sorted(merged))
 
     def reject(self) -> None:
         self._callback(None)
         super().reject()
 
+    def _fields_widget_active(self) -> bool:
+        """The Include-in-suggestion selector exists for this dialog instance and is currently
+        visible. It's constructed for both change-note and new-note flows; hidden only when the
+        change type is DELETE.
+        """
+        return self._fields_widget is not None and self._fields_widget.isVisible()
+
     def suggestion_meta(self) -> Optional[SuggestionMetadata]:
+        filters = self._fields_widget.suggestion_filters() if self._fields_widget_active() else BulkSuggestionFilters()
         return SuggestionMetadata(
             change_type=self._change_type(),
             comment=self._comment(),
             auto_accept=self._auto_accept(),
             source=(self.source_widget.suggestion_source() if self._source_needed() else None),
+            filters=filters,
         )
 
     def _on_change_type_changed(self) -> None:
         self._refresh_source_widget()
         self._refresh_hint_for_note_deletions()
+        self._refresh_fields_widget_visibility()
         self._validate()
+
+    def _refresh_fields_widget_visibility(self) -> None:
+        if self._fields_widget is None:
+            return
+        # Hide for DELETE — the field-selection logic doesn't apply.
+        self._fields_widget.setVisible(self._change_type() != SuggestionType.DELETE)
 
     def _refresh_source_widget(self):
         if self._source_needed():
@@ -589,10 +682,7 @@ class SuggestionDialog(QDialog):
         self.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(enabled)
 
     def _validate(self) -> None:
-        if self._is_valid():
-            self.validation_signal.emit(True)
-        else:
-            self.validation_signal.emit(False)
+        self.validation_signal.emit(self._is_valid())
 
     def _is_valid(self) -> bool:
         if len(self.rationale_edit.toPlainText().strip()) == 0:
@@ -601,13 +691,22 @@ class SuggestionDialog(QDialog):
         if self._source_needed() and not self.source_widget.is_valid():
             return False
 
+        if self._fields_widget_active() and not self._fields_widget.has_any_selection():
+            # Covers both "user unchecked everything" and "no edits to suggest in the first place"
+            # — submitting either would just produce a NO_CHANGES tooltip on the server round-trip.
+            return False
+
         return True
 
     def _change_type(self) -> Optional[SuggestionType]:
+        """Returns the user-selected change type for change-note flows, or `None` for
+        new-note flows (which don't carry a change type — the server infers it).
+        Callers that compare against a specific `SuggestionType` (e.g. `== DELETE`)
+        silently evaluate False on the new-note branch, which is the intended behavior.
+        """
         if self._is_new_note_suggestion:
             return None
-        else:
-            return next(x for x in SuggestionType if x.value[1] == self.change_type_select.currentText())
+        return next(x for x in SuggestionType if x.value[1] == self.change_type_select.currentText())
 
     def _comment(self) -> str:
         return self.rationale_edit.toPlainText()
@@ -641,14 +740,21 @@ source_type_to_source_label = {
     SourceType.UWORLD: "UWorld Question ID",
     SourceType.SOCIETY_GUIDELINES: "Link",
     SourceType.DUPLICATE_NOTE: "Anki note ID of duplicate note",
-    SourceType.OTHER: "",
+    SourceType.OTHER: "Details",
 }
 
 # Maps source types to the placeholder text that is shown in the source input field.
 # If a source type is not in this dict, no placeholder text is shown.
 source_type_to_source_place_holder_text = {
+    SourceType.AMBOSS: "Paste AMBOSS link",
+    SourceType.UWORLD: "e.g. 12345",
+    SourceType.SOCIETY_GUIDELINES: "Paste link to guidelines",
     SourceType.DUPLICATE_NOTE: "[Include ID, if applicable]",
+    SourceType.OTHER: "Describe the source and include relevant details...",
 }
+
+# Placeholder shown in the Rationale-for-change textarea.
+RATIONALE_FOR_CHANGE_PLACEHOLDER = "Explain why this change should be made..."
 
 source_types_where_input_is_optional = [
     SourceType.DUPLICATE_NOTE,
@@ -736,10 +842,7 @@ class SourceWidget(QWidget):
         return len(text) > 0
 
     def _validate(self) -> None:
-        if not self.is_valid():
-            self.validation_signal.emit(False)
-        else:
-            self.validation_signal.emit(True)
+        self.validation_signal.emit(self.is_valid())
 
     def _on_source_type_change(self) -> None:
         source_type = self._source_type()
@@ -757,11 +860,14 @@ class SourceWidget(QWidget):
             self.layout_.invalidate()
 
     def _refresh_source_input_label(self) -> None:
-        text = source_type_to_source_label[self._source_type()]
+        source_type = self._source_type()
+        text = source_type_to_source_label[source_type]
+        if source_type not in source_types_where_input_is_optional:
+            text = f"{text} (Required)"
 
         self.source_input_label.setText(text)
 
-        place_holder_text = source_type_to_source_place_holder_text.get(self._source_type(), "")
+        place_holder_text = source_type_to_source_place_holder_text.get(source_type, "")
         self.source_edit.setPlaceholderText(place_holder_text)
 
     def _source_type(self) -> Optional[SourceType]:
@@ -769,3 +875,487 @@ class SourceWidget(QWidget):
             return SourceType(self.source_type_select.currentText())
         else:
             return None
+
+
+class _TagLabel(QLabel):
+    """A QLabel for tag-name display.
+
+    Centralizes tag rendering: elides long tags to `…::leaf` (or `<head>…` for
+    flat names), injects zero-width spaces after `::` and `_` so `wordWrap`
+    has break points inside identifier-style names, and sets a (rich-text)
+    tooltip with the full tag — only when actually elided. Emits `clicked`
+    on mouse press so a paired checkbox can toggle.
+    """
+
+    clicked = pyqtSignal()
+
+    _MAX_LEN = 85
+
+    def __init__(self, tag: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        display = self._elide(tag)
+        self.setText(self._inject_breakpoints(display))
+        self.setWordWrap(True)
+        self.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+        # Wrapping a label inside a layout takes both: a horizontal policy that
+        # lets the layout pick the width (else sizeHint is the unwrapped single
+        # line) and `setHeightForWidth(True)` on the policy so the layout asks
+        # the label "how tall do you want to be at this width?" Without the
+        # latter, wordWrap=True wraps the *paint* but vertical sizing stays at
+        # a single line.
+        sp = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        sp.setHeightForWidth(True)
+        self.setSizePolicy(sp)
+        self.setMinimumWidth(1)
+        if display != tag:
+            self.setToolTip(f"<p>{self._inject_breakpoints(escape(tag))}</p>")
+
+    @classmethod
+    def _elide(cls, tag: str) -> str:
+        """Tags shorter than the budget render as-is. Longer hierarchical tags
+        collapse to `…::leaf` (the trailing `::`-segment with an ellipsis
+        prefix). The leaf itself is truncated if it would still exceed the
+        budget. Long flat tags get a plain `…` truncation.
+        """
+        if len(tag) <= cls._MAX_LEN:
+            return tag
+        if "::" in tag:
+            leaf = tag.rsplit("::", 1)[-1]
+            leaf_budget = cls._MAX_LEN - 3  # account for "…::" prefix
+            if len(leaf) > leaf_budget:
+                leaf = f"{leaf[: leaf_budget - 1]}…"
+            return f"…::{leaf}"
+        return f"{tag[: cls._MAX_LEN - 1]}…"
+
+    @staticmethod
+    def _inject_breakpoints(text: str) -> str:
+        """Insert zero-width spaces after `::` and `_` so QLabel.wordWrap has
+        valid break points inside identifier-style names (`a::b::c_d`).
+        """
+        return text.replace("::", "::​").replace("_", "_​")
+
+    def mousePressEvent(self, event) -> None:  # noqa: N802 - Qt override
+        super().mousePressEvent(event)
+        self.clicked.emit()
+
+
+class _TagCheckBox(QWidget):
+    """A QCheckBox-like row pairing a checkbox indicator with a `_TagLabel`
+    whose tag name wraps to multiple lines.
+
+    QCheckBox draws its label inline as a single line; long tag names overflow
+    the section width and force a horizontal scrollbar. This widget keeps the
+    same `.isChecked() / .setChecked() / .toggled` API the rest of the code
+    expects but pairs the indicator with a wrappable `_TagLabel`.
+    """
+
+    toggled = pyqtSignal(bool)
+
+    def __init__(self, tag: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        row = QHBoxLayout()
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(6)
+        self.setLayout(row)
+
+        self._checkbox = QCheckBox()
+        row.addWidget(self._checkbox, 0, Qt.AlignmentFlag.AlignTop)
+
+        self._label = _TagLabel(tag)
+        qconnect(self._label.clicked, self._checkbox.toggle)
+        row.addWidget(self._label, 1)
+
+        qconnect(self._checkbox.toggled, self.toggled.emit)
+
+    # Propagate heightForWidth from the inner label up to this widget so the
+    # parent QVBoxLayout grows the row vertically when the label wraps.
+    def hasHeightForWidth(self) -> bool:  # noqa: N802
+        return True
+
+    def heightForWidth(self, width: int) -> int:  # noqa: N802
+        indicator_w = self._checkbox.sizeHint().width()
+        spacing = self.layout().spacing() if self.layout() else 0
+        label_width = max(1, width - indicator_w - spacing)
+        label_height = self._label.heightForWidth(label_width)
+        # Don't drop below the bare checkbox height (single-line fallback).
+        return max(label_height, self._checkbox.sizeHint().height())
+
+    def sizeHint(self) -> QSize:  # noqa: N802
+        hint_w = self._checkbox.sizeHint().width()  # ignore label's natural width
+        hint_h = self._checkbox.sizeHint().height()
+        return QSize(hint_w, hint_h)
+
+    # QCheckBox-compatible surface used by `_GroupController` and the
+    # `IncludeInSuggestionWidget` accessors.
+    def isChecked(self) -> bool:  # noqa: N802 - Qt-style name
+        return self._checkbox.isChecked()
+
+    def setChecked(self, value: bool) -> None:  # noqa: N802
+        self._checkbox.setChecked(value)
+
+
+class _SelectAllCheckBox(QCheckBox):
+    """Displays PartiallyChecked programmatically, but user clicks only toggle
+    Checked ↔ Unchecked — Qt's default Unchecked → PartiallyChecked cycle would
+    block "select all" from an empty group.
+
+    Elides its label dynamically: the displayed text shrinks to fit the
+    checkbox's actual width via QFontMetrics. When elided, the full text
+    shows up as a tooltip.
+    """
+
+    def __init__(self, full_text: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__("", parent)
+        self._full_text = full_text
+        # Without Ignored, the checkbox's sizeHint claims the full text width
+        # and the parent layout grows to fit — elision never kicks in.
+        self.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
+        self.setMinimumWidth(1)
+        self._elide_to_fit()
+
+    def nextCheckState(self) -> None:  # noqa: N802 - Qt override
+        if self.checkState() == Qt.CheckState.Checked:
+            self.setCheckState(Qt.CheckState.Unchecked)
+        else:
+            self.setCheckState(Qt.CheckState.Checked)
+
+    def resizeEvent(self, event) -> None:  # noqa: N802 - Qt override
+        super().resizeEvent(event)
+        self._elide_to_fit()
+
+    def _elide_to_fit(self) -> None:
+        opt = QStyleOptionButton()
+        self.initStyleOption(opt)
+        style = self.style()
+        indicator = style.subElementRect(QStyle.SubElement.SE_CheckBoxIndicator, opt, self).width()
+        spacing = style.pixelMetric(QStyle.PixelMetric.PM_CheckBoxLabelSpacing, opt, self)
+        avail = self.width() - indicator - spacing - 4  # small safety margin
+
+        if avail <= 0:
+            text = self._full_text
+        else:
+            text = self.fontMetrics().elidedText(self._full_text, Qt.TextElideMode.ElideRight, avail)
+
+        # Skip setText if unchanged to avoid resize-event loops.
+        if text != self.text():
+            super().setText(text)
+        self.setToolTip(self._full_text if text != self._full_text else "")
+
+
+_Toggleable = Union[QCheckBox, _TagCheckBox]
+
+
+class _GroupController:
+    """Wires a Select-all parent checkbox to its child checkboxes with tri-state
+    feedback: parent reflects PartiallyChecked when children are mixed; toggling
+    the parent sets every child to the new state.
+    """
+
+    def __init__(
+        self,
+        parent_cb: QCheckBox,
+        on_child_toggle: Callable[[], None],
+    ) -> None:
+        self._parent = parent_cb
+        self._children: List[_Toggleable] = []
+        self._on_child_toggle = on_child_toggle
+        self._suppress = False
+        self._parent.setTristate(True)
+        qconnect(self._parent.clicked, self._on_parent_clicked)
+
+    def add_child(self, cb: _Toggleable) -> None:
+        self._children.append(cb)
+        qconnect(cb.toggled, self._on_child_toggled)
+
+    def refresh_parent(self) -> None:
+        # Disabled children are locked (always-checked) — they shouldn't drive
+        # parent tri-state or be touched by Select-all.
+        togglable = [c for c in self._children if c.isEnabled()]
+        if not togglable:
+            return
+        selected = sum(1 for c in togglable if c.isChecked())
+        self._suppress = True
+        if selected == 0:
+            self._parent.setCheckState(Qt.CheckState.Unchecked)
+        elif selected == len(togglable):
+            self._parent.setCheckState(Qt.CheckState.Checked)
+        else:
+            self._parent.setCheckState(Qt.CheckState.PartiallyChecked)
+        self._suppress = False
+
+    def _on_parent_clicked(self, _checked: bool) -> None:
+        # `clicked` (vs `toggled`) only fires on user interaction, so we don't
+        # need to guard against the programmatic setCheckState calls in
+        # refresh_parent. After a user click, Qt advances the tri-state cycle
+        # — interpret anything other than "now Checked" as "set all off".
+        target = self._parent.checkState() == Qt.CheckState.Checked
+        self._suppress = True
+        for c in self._children:
+            if c.isEnabled():
+                c.setChecked(target)
+        self._suppress = False
+        self.refresh_parent()
+        self._on_child_toggle()
+
+    def _on_child_toggled(self, _checked: bool) -> None:
+        if self._suppress:
+            return
+        self.refresh_parent()
+        self._on_child_toggle()
+
+
+_FIRST_FIELD_LOCK_TOOLTIP = "The first field is required for new-note suggestions."
+
+
+class IncludeInSuggestionWidget(QWidget):
+    """Selector for which edited fields and tag changes to include in the
+    outgoing suggestion. Shown for change-note and new-note flows; hidden
+    for DELETE.
+
+    Layout: one group per note type for fields (single and bulk), plus
+    "Added Tags" / "Removed Tags" sections. Each group has a tri-state
+    Select-all checkbox. Globally-protected fields are excluded entirely —
+    not listed in the widget and not sent in the suggestion.
+    """
+
+    selection_changed = pyqtSignal()
+
+    def __init__(
+        self,
+        notes: Sequence[Note],
+        note_diffs: Mapping[NoteId, NoteDiff],
+        initial_deselected_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None,
+        globally_protected_fields_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._notes = list(notes)
+        self._note_diffs = note_diffs
+        self._globally_protected: Dict[NotetypeId, Set[str]] = {
+            mid: set(names) for mid, names in (globally_protected_fields_by_mid or {}).items()
+        }
+        self._field_checkboxes: Dict[NotetypeId, Dict[str, QCheckBox]] = {}
+        self._added_tag_boxes: Dict[str, QCheckBox] = {}
+        self._removed_tag_boxes: Dict[str, QCheckBox] = {}
+        self._setup_ui(initial_deselected_by_mid or {})
+
+    def _setup_ui(self, initial_deselected_by_mid: Mapping[NotetypeId, Collection[str]]) -> None:
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        outer = QVBoxLayout()
+        outer.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(outer)
+
+        frame = QFrame()
+        frame.setFrameShape(QFrame.Shape.StyledPanel)
+        frame.setObjectName("includeInSuggestionFrame")
+        frame.setStyleSheet(
+            "#includeInSuggestionFrame { background-color: palette(alternate-base); "
+            "border: 1px solid palette(mid); border-radius: 6px; }"
+        )
+        frame.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        outer.addWidget(frame)
+
+        frame_layout = QVBoxLayout()
+        frame_layout.setContentsMargins(14, 14, 14, 14)
+        frame_layout.setSpacing(10)
+        frame.setLayout(frame_layout)
+
+        title_row = QHBoxLayout()
+        self._title_label = QLabel("<b>Include in suggestion</b>")
+        self._counter_label = QLabel("")
+        counter_font = self._counter_label.font()
+        counter_font.setPointSize(max(counter_font.pointSize() - 2, 8))
+        self._counter_label.setFont(counter_font)
+        self._counter_label.setStyleSheet("color: palette(placeholder-text);")
+        title_row.addWidget(self._title_label)
+        title_row.addStretch()
+        title_row.addWidget(self._counter_label)
+        frame_layout.addLayout(title_row)
+
+        subtitle = QLabel("Select which fields you want to submit changes for")
+        subtitle.setStyleSheet("color: palette(placeholder-text);")
+        subtitle.setWordWrap(True)
+        frame_layout.addWidget(subtitle)
+        frame_layout.addSpacing(6)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setMinimumHeight(120)
+        self._scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._scroll.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        self._scroll.setStyleSheet(
+            "QScrollArea { background: transparent; } QScrollArea > QWidget > QWidget { background: transparent; }"
+        )
+        body = QWidget()
+        self._body_layout = QVBoxLayout()
+        self._body_layout.setContentsMargins(0, 0, 0, 0)
+        self._body_layout.setSpacing(8)
+        body.setLayout(self._body_layout)
+        self._scroll.setWidget(body)
+        frame_layout.addWidget(self._scroll)
+
+        self._populate(initial_deselected_by_mid)
+        self._refresh_counter()
+
+    def _add_section(
+        self,
+        title: str,
+        items: List[str],
+        initial_checked: Dict[str, bool],
+        lock_first_field: Optional[str] = None,
+        item_widget: Callable[[str], "_Toggleable"] = QCheckBox,
+    ) -> Dict[str, QCheckBox]:
+        """Render one section: select-all checkbox (with the section title as
+        its label) + one child checkbox per item, then a thin separator below.
+
+        `lock_first_field`, if set, names the item to render as checked +
+        disabled (skipped by Select-all) — used to lock the first field for
+        new-note suggestions.
+        `item_widget` is a factory that builds the per-item checkbox from the
+        item name. Defaults to plain `QCheckBox`; `_add_tag_section` passes
+        `_TagCheckBox` so tag names wrap and self-tooltip when elided.
+        Returns `item -> checkbox` so the caller can wire up persistence.
+        """
+        if self._body_layout.count() > 0:
+            separator = QFrame()
+            separator.setFrameShape(QFrame.Shape.HLine)
+            separator.setFrameShadow(QFrame.Shadow.Plain)
+            separator.setStyleSheet("color: palette(mid);")
+            self._body_layout.addWidget(separator)
+
+        # Title sits on the select-all checkbox itself, so clicking the title
+        # toggles the section and keeps the label aligned at the same x as the
+        # child item checkboxes. Pass `full_text` so the label elides
+        # dynamically to fit the checkbox's actual width (tooltip shows the
+        # full string when elided).
+        select_all = _SelectAllCheckBox(title)
+        select_all.setStyleSheet("QCheckBox { color: palette(placeholder-text); font-weight: bold; }")
+        self._body_layout.addWidget(select_all)
+
+        controller = _GroupController(select_all, self._on_toggle)
+        # Anchor the controller to a Qt-owned widget — without this Qt drops
+        # the bound-method signal connections when the Python ref is GC'd.
+        select_all._group_controller_ref = controller  # type: ignore[attr-defined]
+
+        # No indent — all checkboxes (section select-alls + items) align at the same x.
+        items_layout = QVBoxLayout()
+        items_layout.setContentsMargins(0, 0, 0, 0)
+        items_layout.setSpacing(2)
+        self._body_layout.addLayout(items_layout)
+
+        result: Dict[str, QCheckBox] = {}
+        for item in items:
+            cb = item_widget(item)
+            if lock_first_field is not None and item == lock_first_field:
+                cb.setChecked(True)
+                cb.setEnabled(False)
+                cb.setToolTip(_FIRST_FIELD_LOCK_TOOLTIP)
+            else:
+                cb.setChecked(initial_checked.get(item, True))
+            controller.add_child(cb)
+            items_layout.addWidget(cb)
+            result[item] = cb  # type: ignore[assignment]
+        controller.refresh_parent()
+        return result
+
+    def _populate(self, initial_deselected_by_mid: Mapping[NotetypeId, Collection[str]]) -> None:
+        fields_by_mid: Dict[NotetypeId, List[str]] = {}
+        note_type_name_by_mid: Dict[NotetypeId, str] = {}
+        # The first field is required for new-note suggestions (server-side
+        # validation rejects otherwise). Lock the checkbox for any mid that
+        # has at least one new-note candidate in the batch.
+        locked_first_field_by_mid: Dict[NotetypeId, str] = {}
+        added_tags: List[str] = []
+        removed_tags: List[str] = []
+        for note in self._notes:
+            mid = NotetypeId(note.mid)
+            note_type_name_by_mid.setdefault(mid, note.note_type()["name"])
+            diff = self._note_diffs[NoteId(note.id)]
+            globally_protected = self._globally_protected.get(mid, set())
+            fields = [f for f in diff.edited_fields if f not in globally_protected]
+            # `dict.fromkeys(...)` dedupes across notes sharing this mid while preserving
+            # first-seen field order so the widget renders fields in note-type definition order.
+            fields_by_mid[mid] = list(dict.fromkeys((*fields_by_mid.get(mid, ()), *fields)))
+            added_tags.extend(diff.added_tags)
+            removed_tags.extend(diff.removed_tags)
+            if not diff.exists_in_ah_db and mid not in locked_first_field_by_mid:
+                locked_first_field_by_mid[mid] = note.note_type()["flds"][0]["name"]
+
+        for mid, fields in fields_by_mid.items():
+            if not fields:
+                continue
+            deselected = set(initial_deselected_by_mid.get(mid, ()))
+            clean_name = note_type_name_without_ankihub_modifications(note_type_name_by_mid[mid])
+            first_field = locked_first_field_by_mid.get(mid)
+            lock_first_field = first_field if (first_field is not None and first_field in fields) else None
+            self._field_checkboxes[mid] = self._add_section(
+                title=clean_name,
+                items=fields,
+                initial_checked={f: f not in deselected for f in fields},
+                lock_first_field=lock_first_field,
+            )
+
+        if added_tags:
+            self._added_tag_boxes = self._add_tag_section("Added Tags", sorted(set(added_tags)))
+        if removed_tags:
+            self._removed_tag_boxes = self._add_tag_section("Removed Tags", sorted(set(removed_tags)))
+
+        self._body_layout.addStretch()
+
+    def _add_tag_section(self, title: str, tags: List[str]) -> Dict[str, QCheckBox]:
+        return self._add_section(
+            title=title,
+            items=tags,
+            initial_checked={t: True for t in tags},
+            item_widget=_TagCheckBox,
+        )
+
+    def _on_toggle(self) -> None:
+        self._refresh_counter()
+        self.selection_changed.emit()
+
+    def _all_checkboxes(self) -> List[QCheckBox]:
+        boxes: List[QCheckBox] = []
+        for mid_map in self._field_checkboxes.values():
+            boxes.extend(mid_map.values())
+        boxes.extend(self._added_tag_boxes.values())
+        boxes.extend(self._removed_tag_boxes.values())
+        return boxes
+
+    def _refresh_counter(self) -> None:
+        boxes = self._all_checkboxes()
+        total = len(boxes)
+        selected = sum(1 for cb in boxes if cb.isChecked())
+        self._counter_label.setText(f"{selected}/{total}" if total else "")
+
+    def has_any_selection(self) -> bool:
+        return any(cb.isChecked() for cb in self._all_checkboxes())
+
+    def suggestion_filters(self) -> BulkSuggestionFilters:
+        return BulkSuggestionFilters(
+            fields_to_include_by_mid=self.selected_field_names_by_mid(),
+            tags_to_add=self.selected_tag_additions(),
+            tags_to_remove=self.selected_tag_removals(),
+        )
+
+    def selected_field_names_by_mid(self) -> Dict[NotetypeId, List[str]]:
+        return {
+            mid: [name for name, cb in mid_map.items() if cb.isChecked()]
+            for mid, mid_map in self._field_checkboxes.items()
+        }
+
+    def field_selection_state_by_mid(self) -> Dict[NotetypeId, Dict[str, bool]]:
+        """Per-mid `{field_name: is_checked}` for every field the widget rendered. Used by the
+        dialog to merge "this session's deselections" with priors from earlier sessions.
+        """
+        return {
+            mid: {name: cb.isChecked() for name, cb in mid_map.items()}
+            for mid, mid_map in self._field_checkboxes.items()
+        }
+
+    def selected_tag_additions(self) -> List[str]:
+        return [tag for tag, cb in self._added_tag_boxes.items() if cb.isChecked()]
+
+    def selected_tag_removals(self) -> List[str]:
+        return [tag for tag, cb in self._removed_tag_boxes.items() if cb.isChecked()]

--- a/ankihub/main/exporting.py
+++ b/ankihub/main/exporting.py
@@ -4,9 +4,9 @@ This is used for exporting notes from Anki to AnkiHub, e.g. when creating sugges
 
 import re
 import uuid
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from anki.models import NotetypeId
+from anki.models import NotetypeDict, NotetypeId
 from anki.notes import Note
 
 from ..ankihub_client import Field, NoteInfo
@@ -18,23 +18,49 @@ from .note_conversion import (
     is_optional_tag,
 )
 
+# Sentinel marking "look the ah_nid up from the AnkiHub DB" — distinct from `ah_nid=None`,
+# which is a real value meaning "this note has no AnkiHub counterpart yet" (new-note path).
+AH_NID_LOOKUP = object()
 
-def to_note_data(note: Note, set_new_id: bool = False, include_empty_fields: bool = False) -> NoteInfo:
+
+def to_note_data(
+    note: Note,
+    set_new_id: bool = False,
+    include_empty_fields: bool = False,
+    include_protected_fields: bool = False,
+    note_type_dict_cache: Optional[Dict[NotetypeId, NotetypeDict]] = None,
+    ah_nid: Any = AH_NID_LOOKUP,
+) -> NoteInfo:
     """Convert an Anki note to a NoteInfo object.
-    Tags and fields are altered (internal and optional tags are removed, ankihub id field is removed, etc.).
-    Protected fields are removed.
+    Tags and fields are altered (internal and optional tags are removed, ankihub id field is removed).
+
+    Personally-protected fields (those carrying `AnkiHub_Protect::FieldName` tags) are stripped
+    by default so that paths without an explicit user filter — most importantly
+    `deck_creation.create_ankihub_deck`'s upload — can't silently ship a user's local
+    annotations to other subscribers. Opt in (`True`) only when the caller filters at the
+    user's direction.
+
+    Pass `note_type_dict_cache` (and/or `ah_nid`) to skip the per-call AnkiHub DB lookups
+    in batched contexts where the caller has already resolved them.
     """
 
     if set_new_id:
-        ah_nid = uuid.uuid4()
+        resolved_ah_nid: Optional[uuid.UUID] = uuid.uuid4()
+    elif ah_nid is AH_NID_LOOKUP:
+        resolved_ah_nid = ankihub_db.ankihub_nid_for_anki_nid(note.id)
     else:
-        ah_nid = ankihub_db.ankihub_nid_for_anki_nid(note.id)
+        resolved_ah_nid = ah_nid
 
     tags = _prepare_tags(note)
-    fields = _prepare_fields(note, include_empty=include_empty_fields)
+    fields = _prepare_fields(
+        note,
+        include_empty=include_empty_fields,
+        include_protected=include_protected_fields,
+        note_type_dict_cache=note_type_dict_cache,
+    )
 
     return NoteInfo(
-        ah_nid=ah_nid,
+        ah_nid=resolved_ah_nid,
         anki_nid=note.id,
         mid=note.mid,
         fields=fields,
@@ -43,30 +69,37 @@ def to_note_data(note: Note, set_new_id: bool = False, include_empty_fields: boo
     )
 
 
-def _prepare_fields(note: Note, include_empty: bool = False) -> List[Field]:
-    note_type = ankihub_db.note_type_dict(note_type_id=NotetypeId(note.mid))
-    if note_type is None:
-        # When creating a deck the note type is not yet in the AnkiHub DB
-        note_type = note.note_type()
+def _prepare_fields(
+    note: Note,
+    include_empty: bool = False,
+    include_protected: bool = False,
+    note_type_dict_cache: Optional[Dict[NotetypeId, NotetypeDict]] = None,
+) -> List[Field]:
+    mid = NotetypeId(note.mid)
+    if note_type_dict_cache is not None and mid in note_type_dict_cache:
+        note_type = note_type_dict_cache[mid]
+    else:
+        note_type = ankihub_db.note_type_dict(note_type_id=mid)
+        if note_type is None:
+            # When creating a deck the note type is not yet in the AnkiHub DB
+            note_type = note.note_type()
+        if note_type_dict_cache is not None:
+            note_type_dict_cache[mid] = note_type
 
     note_fields_dict = dict(note.items())
-    fields_protected_by_tags = get_fields_protected_by_tags(note)
+    protected_to_strip = set() if include_protected else set(get_fields_protected_by_tags(note))
 
     result = []
     for field in note_type["flds"]:
         field_name = field["name"]
         value = note_fields_dict.get(field_name)
-        if (
-            field_name != ANKIHUB_NOTE_TYPE_FIELD_NAME
-            and field_name not in fields_protected_by_tags
-            and (include_empty or value)
-        ):
-            result.append(
-                Field(
-                    name=field_name,
-                    value=_prepared_field_html(value),
-                )
-            )
+        if field_name == ANKIHUB_NOTE_TYPE_FIELD_NAME:
+            continue
+        if field_name in protected_to_strip:
+            continue
+        if not (include_empty or value):
+            continue
+        result.append(Field(name=field_name, value=_prepared_field_html(value)))
 
     return result
 

--- a/ankihub/main/suggestions.py
+++ b/ankihub/main/suggestions.py
@@ -266,9 +266,9 @@ def suggest_note_update(
     Also renames media files in the Anki collection and the media folder and uploads them to AnkiHub.
     Returns a ChangeSuggestionResult enum value.
 
-    `filters` carries optional allowlists (fields, added/removed tags) and the
-    server-protected denylist. `None` for any list means "no filter for that
-    dimension"; the absent `filters` arg is equivalent to no filters at all.
+    `filters` carries the user's optional allowlists for fields and added/removed
+    tags. `None` for any list means "no filter for that dimension"; the absent
+    `filters` arg is equivalent to no filters at all.
     """
 
     # DELETE doesn't carry field content, so the empty-first-field requirement

--- a/ankihub/main/suggestions.py
+++ b/ankihub/main/suggestions.py
@@ -87,15 +87,16 @@ def _has_empty_first_field(note: Note) -> bool:
 
 @dataclass
 class PerNoteFilters:
-    """Allowlists and denylist that select what content goes into one note's
-    suggestion. `None` for any list means "no filter for this dimension"
-    (legacy behavior: ship everything the diff detected).
+    """Allowlists that select what content goes into one note's suggestion.
+    `None` for any list means "no filter for this dimension" (legacy
+    behavior: ship everything the diff detected). Globally-protected fields
+    are stripped *before* the dialog renders, so they never enter the
+    allowlist — server-side enforcement is the only backstop at submit.
     """
 
     fields_to_include: Optional[Collection[str]] = None
     tags_to_add: Optional[Collection[str]] = None
     tags_to_remove: Optional[Collection[str]] = None
-    globally_protected_fields: Optional[Collection[str]] = None
 
 
 @dataclass
@@ -108,7 +109,6 @@ class BulkSuggestionFilters:
     fields_to_include_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None
     tags_to_add: Optional[Collection[str]] = None
     tags_to_remove: Optional[Collection[str]] = None
-    globally_protected_fields_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None
 
     def for_mid(self, mid: NotetypeId) -> PerNoteFilters:
         # `fields_to_include_by_mid` non-None but missing this mid means the
@@ -121,11 +121,6 @@ class BulkSuggestionFilters:
             ),
             tags_to_add=self.tags_to_add,
             tags_to_remove=self.tags_to_remove,
-            globally_protected_fields=(
-                self.globally_protected_fields_by_mid.get(mid)
-                if self.globally_protected_fields_by_mid is not None
-                else None
-            ),
         )
 
 
@@ -544,23 +539,15 @@ def _suggestions_for_notes(
     )
 
 
-def _apply_field_filters(
-    fields: List[Field],
-    allowlist: Optional[Collection[str]],
-    denylist: Optional[Collection[str]],
-) -> List[Field]:
-    """Drop fields not in the user's allowlist, then drop any in the denylist.
-
-    `allowlist=None` means "no user filter" (legacy behavior); `denylist` carries
-    globally-protected names that the server would reject anyway.
+def _apply_field_allowlist(fields: List[Field], allowlist: Optional[Collection[str]]) -> List[Field]:
+    """Drop fields not in the user's allowlist. `allowlist=None` means "no user filter"
+    (legacy behavior — ships everything the diff detected). Globally-protected fields are
+    excluded by the dialog *before* the user picks; server-side enforcement is the backstop.
     """
-    if allowlist is not None:
-        allowed = set(allowlist)
-        fields = [f for f in fields if f.name in allowed]
-    if denylist:
-        denied = set(denylist)
-        fields = [f for f in fields if f.name not in denied]
-    return fields
+    if allowlist is None:
+        return fields
+    allowed = set(allowlist)
+    return [f for f in fields if f.name in allowed]
 
 
 def _apply_tag_allowlist(tags: List[str], allowlist: Optional[Collection[str]]) -> List[str]:
@@ -582,7 +569,7 @@ def _new_note_suggestion(
     note_data = to_note_data(
         note, set_new_id=True, include_protected_fields=config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False)
     )
-    fields = _apply_field_filters(list(note_data.fields), filters.fields_to_include, filters.globally_protected_fields)
+    fields = _apply_field_allowlist(list(note_data.fields), filters.fields_to_include)
     tags = _apply_tag_allowlist(list(note_data.tags or []), filters.tags_to_add)
 
     # The server requires the first field; user-deselect or globally-protected
@@ -639,9 +626,7 @@ def _change_note_suggestion(
             prev_fields=note_from_ah_db.fields, cur_fields=note_from_anki_db.fields
         )
 
-        fields_that_changed = _apply_field_filters(
-            fields_that_changed, filters.fields_to_include, filters.globally_protected_fields
-        )
+        fields_that_changed = _apply_field_allowlist(fields_that_changed, filters.fields_to_include)
         added_tags = _apply_tag_allowlist(added_tags, filters.tags_to_add)
         removed_tags = _apply_tag_allowlist(removed_tags, filters.tags_to_remove)
 

--- a/ankihub/main/suggestions.py
+++ b/ankihub/main/suggestions.py
@@ -14,6 +14,7 @@ from typing import (
     Collection,
     Dict,
     List,
+    Mapping,
     Optional,
     Protocol,
     Sequence,
@@ -23,7 +24,7 @@ from typing import (
 )
 
 import aqt
-from anki.models import NotetypeId
+from anki.models import NotetypeDict, NotetypeId
 from anki.notes import Note, NoteId
 from anki.utils import ids2str
 
@@ -35,6 +36,7 @@ from ..ankihub_client import (
     NoteInfo,
     NoteSuggestion,
     SuggestionType,
+    get_media_names_from_note_info,
     get_media_names_from_notes_data,
     get_media_names_from_suggestions,
 )
@@ -42,9 +44,16 @@ from ..ankihub_client.ankihub_client import AnkiHubHTTPError
 from ..db import ankihub_db
 from ..db.db import execute_list_query_in_chunks
 from ..db.models import AnkiHubNote
+from ..settings import config
 from .exporting import to_note_data
 from .media_utils import find_and_replace_text_in_fields_on_all_notes
 from .utils import get_anki_nid_to_mid_dict, is_tag_in_list, md5_file_hash
+
+# The Fields-to-Suggest selector and the auto-protect-on-edit hook share this
+# flag — auto-protect's silent tagging only makes sense if the dialog surfaces
+# those tags back to the user.
+AUTO_PROTECT_FEATURE_FLAG = "auto_protect_fields_when_edited"
+
 
 # string that is contained in the errors returned from the AnkiHub API when
 # there are no changes to the note for a change note suggestion
@@ -76,22 +85,203 @@ def _has_empty_first_field(note: Note) -> bool:
     return not note.fields[0].strip()
 
 
+@dataclass
+class PerNoteFilters:
+    """Allowlists and denylist that select what content goes into one note's
+    suggestion. `None` for any list means "no filter for this dimension"
+    (legacy behavior: ship everything the diff detected).
+    """
+
+    fields_to_include: Optional[Collection[str]] = None
+    tags_to_add: Optional[Collection[str]] = None
+    tags_to_remove: Optional[Collection[str]] = None
+    globally_protected_fields: Optional[Collection[str]] = None
+
+
+@dataclass
+class BulkSuggestionFilters:
+    """Same as `PerNoteFilters` but keyed by note type for the bulk-suggest
+    path — the dialog groups field selections by mid because the widget
+    has one section per note type. Tag filters apply across all notes.
+    """
+
+    fields_to_include_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None
+    tags_to_add: Optional[Collection[str]] = None
+    tags_to_remove: Optional[Collection[str]] = None
+    globally_protected_fields_by_mid: Optional[Mapping[NotetypeId, Collection[str]]] = None
+
+    def for_mid(self, mid: NotetypeId) -> PerNoteFilters:
+        # `fields_to_include_by_mid` non-None but missing this mid means the
+        # widget rendered no field section for it (every edit was globally
+        # protected). Treat that as an empty allowlist — NOT "no filter" —
+        # so the diff can't ship fields the user never saw or selected.
+        return PerNoteFilters(
+            fields_to_include=(
+                self.fields_to_include_by_mid.get(mid, ()) if self.fields_to_include_by_mid is not None else None
+            ),
+            tags_to_add=self.tags_to_add,
+            tags_to_remove=self.tags_to_remove,
+            globally_protected_fields=(
+                self.globally_protected_fields_by_mid.get(mid)
+                if self.globally_protected_fields_by_mid is not None
+                else None
+            ),
+        )
+
+
+@dataclass
+class NoteDiff:
+    """Per-note diff data: AH-DB membership, edited fields/tags, media changes.
+
+    Computed once by `compute_note_diffs` so callers needing several pieces
+    can share the per-note conversion work.
+    """
+
+    exists_in_ah_db: bool  # AH DB has a row for this note (deleted or not)
+    is_deleted_on_remote: bool  # row exists AND is marked deleted
+    ah_note: Optional[NoteInfo]  # AH-stored version; None for new-note candidates and deleted notes
+    # For change-note: field names whose value differs from AH.
+    # For new-note: all non-empty field names.
+    edited_fields: List[str]
+    added_tags: List[str]
+    removed_tags: List[str]
+    added_new_media: bool
+
+
+def compute_note_diffs(notes: Sequence[Note]) -> Dict[NoteId, NoteDiff]:
+    """Single-pass diff computation against the local AnkiHub DB.
+
+    Caches `note_type_dict` by mid for the batch and projects ah_nid from
+    the batched AH-DB rows, avoiding two per-note DB lookups inside
+    `to_note_data`.
+    """
+    anki_nids = [note.id for note in notes]
+    ah_db_rows: Dict[NoteId, AnkiHubNote] = {
+        NoteId(row.anki_note_id): row
+        for row in execute_list_query_in_chunks(
+            lambda nids: AnkiHubNote.filter(anki_note_id__in=nids),
+            ids=anki_nids,
+        )
+    }
+    ah_notes_by_nid: Dict[NoteId, NoteInfo] = {
+        NoteId(n.anki_nid): n for n in ankihub_db.notes_data_for_anki_nids(anki_nids)
+    }
+    note_type_dict_cache: Dict[NotetypeId, NotetypeDict] = {}
+
+    result: Dict[NoteId, NoteDiff] = {}
+    for note in notes:
+        nid = NoteId(note.id)
+        ah_db_row = ah_db_rows.get(nid)
+        ah_note = ah_notes_by_nid.get(nid)
+        is_deleted_on_remote = ah_db_row is not None and ah_db_row.was_deleted()
+
+        cur = to_note_data(
+            note,
+            include_empty_fields=True,
+            include_protected_fields=True,
+            note_type_dict_cache=note_type_dict_cache,
+            ah_nid=ah_db_row.ankihub_note_id if ah_db_row is not None else None,
+        )
+
+        if ah_note is None:
+            edited_fields = [f.name for f in cur.fields if f.value]
+            added_tags = list(cur.tags or [])
+            removed_tags: List[str] = []
+        else:
+            edited_fields = [f.name for f in _fields_that_changed(prev_fields=ah_note.fields, cur_fields=cur.fields)]
+            added_tags, removed_tags = _added_and_removed_tags(
+                prev_tags=ah_note.tags or [],
+                cur_tags=cur.tags or [],
+            )
+
+        anki_note_type = note.note_type()
+        media_anki = set(get_media_names_from_note_info(cur, anki_note_type))
+        media_ah = set() if ah_note is None else set(get_media_names_from_note_info(ah_note, anki_note_type))
+        added_new_media = bool(media_anki - media_ah)
+
+        result[nid] = NoteDiff(
+            exists_in_ah_db=ah_db_row is not None,
+            is_deleted_on_remote=is_deleted_on_remote,
+            ah_note=ah_note,
+            edited_fields=edited_fields,
+            added_tags=added_tags,
+            removed_tags=removed_tags,
+            added_new_media=added_new_media,
+        )
+
+    return result
+
+
+def _is_suggestible_from_diff(
+    note: Note,
+    diff: NoteDiff,
+    change_type: Optional[SuggestionType],
+    globally_protected_by_mid: Mapping[NotetypeId, Collection[str]],
+) -> bool:
+    if diff.is_deleted_on_remote:
+        return False
+    if change_type == SuggestionType.DELETE:
+        return diff.exists_in_ah_db
+    # The submit path drops these as EMPTY_FIRST_FIELD for non-DELETE
+    # change types; mirror that so we don't accept a note we'll just reject.
+    if _has_empty_first_field(note):
+        return False
+    denied = set(globally_protected_by_mid.get(NotetypeId(note.mid), ()))
+    if not diff.exists_in_ah_db and note.note_type()["flds"][0]["name"] in denied:
+        # New-note submission requires the first field server-side. If it's
+        # globally protected, the suggestion can never succeed regardless of
+        # what other fields or tags contribute — so the dialog shouldn't open.
+        return False
+    if set(diff.edited_fields) - denied:
+        return True
+    return bool(diff.added_tags or diff.removed_tags)
+
+
+def any_suggestible_from_diffs(
+    notes: Sequence[Note],
+    diffs: Mapping[NoteId, NoteDiff],
+    change_type: Optional[SuggestionType],
+    globally_protected_by_mid: Mapping[NotetypeId, Collection[str]],
+) -> bool:
+    """True if at least one note is suggestible under the given `change_type`.
+
+    Mirrors `_suggestions_for_notes()`'s classification:
+
+    - DELETE: existing AnkiHub notes that aren't deleted on remote (no
+      content check — DELETE doesn't carry field/tag content).
+    - Any other change_type: a not-deleted-on-remote note (new-note
+      candidate or existing) is suggestible if it has at least one field
+      edit outside the globally-protected denylist or any tag change.
+    """
+    return any(
+        _is_suggestible_from_diff(note, diffs[NoteId(note.id)], change_type, globally_protected_by_mid)
+        for note in notes
+    )
+
+
 def suggest_note_update(
     note: Note,
     change_type: SuggestionType,
     comment: str,
     media_upload_cb: MediaUploadCallback,
     auto_accept: bool = False,
+    filters: Optional[PerNoteFilters] = None,
 ) -> ChangeSuggestionResult:
     """Sends a ChangeNoteSuggestion to AnkiHub if the passed note has changes.
     Also renames media files in the Anki collection and the media folder and uploads them to AnkiHub.
     Returns a ChangeSuggestionResult enum value.
+
+    `filters` carries optional allowlists (fields, added/removed tags) and the
+    server-protected denylist. `None` for any list means "no filter for that
+    dimension"; the absent `filters` arg is equivalent to no filters at all.
     """
 
-    if _has_empty_first_field(note):
+    # DELETE doesn't carry field content, so the empty-first-field requirement
+    # doesn't apply — users should be able to delete malformed notes.
+    if _has_empty_first_field(note) and change_type != SuggestionType.DELETE:
         return ChangeSuggestionResult.EMPTY_FIRST_FIELD
 
-    suggestion = _change_note_suggestion(note, change_type, comment)
+    suggestion = _change_note_suggestion(note, change_type, comment, filters=filters)
     if suggestion is None:
         return ChangeSuggestionResult.NO_CHANGES
 
@@ -123,11 +313,17 @@ def suggest_new_note(
     ankihub_did: uuid.UUID,
     media_upload_cb: MediaUploadCallback,
     auto_accept: bool = False,
-) -> None:
-    """Sends a NewNoteSuggestion to AnkiHub.
-    Also renames media in the Anki collection and the media folder and uploads them to AnkiHub.
+    filters: Optional[PerNoteFilters] = None,
+) -> bool:
+    """Sends a NewNoteSuggestion to AnkiHub. Returns True on submit, False if
+    the user-selected filters left nothing to submit.
+
+    `filters.tags_to_remove` is ignored — new notes have no AH baseline to
+    remove tags from.
     """
-    suggestion = _new_note_suggestion(note, ankihub_did, comment)
+    suggestion = _new_note_suggestion(note, ankihub_did, comment, filters=filters)
+    if suggestion is None:
+        return False
 
     suggestion = cast(
         NewNoteSuggestion,
@@ -140,6 +336,7 @@ def suggest_new_note(
 
     client = AnkiHubClient()
     client.create_new_note_suggestion(new_note_suggestion=suggestion, auto_accept=auto_accept)
+    return True
 
 
 @dataclass
@@ -156,6 +353,7 @@ def suggest_notes_in_bulk(
     change_type: SuggestionType,
     comment: str,
     media_upload_cb: MediaUploadCallback,
+    filters: Optional[BulkSuggestionFilters] = None,
 ) -> BulkNoteSuggestionsResult:
     """
     Sends a NewNoteSuggestion or a ChangeNoteSuggestion to AnkiHub for each note in the list.
@@ -164,14 +362,15 @@ def suggest_notes_in_bulk(
     that the note has no changes when compared to the remote AnkiHub
     database. To create suggestions for notes that differ from the
     remote database but not from the local database, users have to
-    sync first (so that the local database is up to date)."""
+    sync first (so that the local database is up to date).
+    """
     (
         new_note_suggestions,
         change_note_suggestions,
         nids_without_changes,
         nids_deleted_on_remote,
         nids_with_empty_first_field,
-    ) = _suggestions_for_notes(notes, ankihub_did, change_type, comment)
+    ) = _suggestions_for_notes(notes, ankihub_did, change_type, comment, filters=filters)
 
     new_note_suggestions = cast(
         Sequence[NewNoteSuggestion],
@@ -243,7 +442,11 @@ def get_anki_nid_to_ah_dids_dict(
 
 
 def _suggestions_for_notes(
-    notes: List[Note], ankihub_did: uuid.UUID, change_type: SuggestionType, comment: str
+    notes: List[Note],
+    ankihub_did: uuid.UUID,
+    change_type: SuggestionType,
+    comment: str,
+    filters: Optional[BulkSuggestionFilters] = None,
 ) -> Tuple[
     Sequence[NewNoteSuggestion],
     Sequence[ChangeNoteSuggestion],
@@ -279,7 +482,8 @@ def _suggestions_for_notes(
     nids_deleted_on_remote = []
     nids_with_empty_first_field: List[NoteId] = []
     for note in notes:
-        if _has_empty_first_field(note):
+        # DELETE doesn't carry field content; allow notes with an empty first field through.
+        if _has_empty_first_field(note) and change_type != SuggestionType.DELETE:
             nids_with_empty_first_field.append(note.id)
             continue
 
@@ -292,30 +496,44 @@ def _suggestions_for_notes(
         else:
             notes_for_new_note_suggestions.append(note)
 
-    change_note_suggestion_or_none_by_anki_nid = {
-        note.id: _change_note_suggestion(
+    filters = filters or BulkSuggestionFilters()
+    # Cache per-mid projection across the two loops — same mid → same
+    # PerNoteFilters, so we only need one dict allocation per distinct mid.
+    per_mid_filters: Dict[NotetypeId, PerNoteFilters] = {}
+
+    def _filters_for(note: Note) -> PerNoteFilters:
+        mid = NotetypeId(note.mid)
+        if mid not in per_mid_filters:
+            per_mid_filters[mid] = filters.for_mid(mid)
+        return per_mid_filters[mid]
+
+    nids_without_changes: List[NoteId] = []
+
+    change_note_suggestions: List[ChangeNoteSuggestion] = []
+    for note in notes_for_change_note_suggestions:
+        change_suggestion = _change_note_suggestion(
             note=note,
             change_type=change_type,
             comment=comment,
+            filters=_filters_for(note),
         )
-        for note in notes_for_change_note_suggestions
-    }
-    change_note_suggestions = []
-    nids_without_changes = []
-    for nid, suggestion in change_note_suggestion_or_none_by_anki_nid.items():
-        if suggestion:
-            change_note_suggestions.append(suggestion)
+        if change_suggestion is not None:
+            change_note_suggestions.append(change_suggestion)
         else:
-            nids_without_changes.append(nid)
+            nids_without_changes.append(note.id)
 
-    new_note_suggestions = [
-        _new_note_suggestion(
+    new_note_suggestions: List[NewNoteSuggestion] = []
+    for note in notes_for_new_note_suggestions:
+        new_suggestion = _new_note_suggestion(
             note=note,
             ah_did=ankihub_did,
             comment=comment,
+            filters=_filters_for(note),
         )
-        for note in notes_for_new_note_suggestions
-    ]
+        if new_suggestion is not None:
+            new_note_suggestions.append(new_suggestion)
+        else:
+            nids_without_changes.append(note.id)
 
     return (
         new_note_suggestions,
@@ -326,15 +544,63 @@ def _suggestions_for_notes(
     )
 
 
-def _new_note_suggestion(note: Note, ah_did: uuid.UUID, comment: str) -> NewNoteSuggestion:
-    note_data = to_note_data(note, set_new_id=True)
+def _apply_field_filters(
+    fields: List[Field],
+    allowlist: Optional[Collection[str]],
+    denylist: Optional[Collection[str]],
+) -> List[Field]:
+    """Drop fields not in the user's allowlist, then drop any in the denylist.
+
+    `allowlist=None` means "no user filter" (legacy behavior); `denylist` carries
+    globally-protected names that the server would reject anyway.
+    """
+    if allowlist is not None:
+        allowed = set(allowlist)
+        fields = [f for f in fields if f.name in allowed]
+    if denylist:
+        denied = set(denylist)
+        fields = [f for f in fields if f.name not in denied]
+    return fields
+
+
+def _apply_tag_allowlist(tags: List[str], allowlist: Optional[Collection[str]]) -> List[str]:
+    if allowlist is None:
+        return tags
+    allowed = set(allowlist)
+    return [t for t in tags if t in allowed]
+
+
+def _new_note_suggestion(
+    note: Note,
+    ah_did: uuid.UUID,
+    comment: str,
+    filters: Optional[PerNoteFilters] = None,
+) -> Optional[NewNoteSuggestion]:
+    # `tags_to_remove` on `filters` is ignored — new notes have no AH baseline
+    # to remove tags from.
+    filters = filters or PerNoteFilters()
+    note_data = to_note_data(
+        note, set_new_id=True, include_protected_fields=config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False)
+    )
+    fields = _apply_field_filters(list(note_data.fields), filters.fields_to_include, filters.globally_protected_fields)
+    tags = _apply_tag_allowlist(list(note_data.tags or []), filters.tags_to_add)
+
+    # The server requires the first field; user-deselect or globally-protected
+    # filtering can drop it. Reject here rather than letting the server return
+    # EMPTY_FIRST_FIELD on submit.
+    first_field_name = note.note_type()["flds"][0]["name"]
+    if not any(f.name == first_field_name and f.value for f in fields):
+        return None
+
+    if not fields and not tags:
+        return None
 
     return NewNoteSuggestion(
         ah_did=ah_did,
         ah_nid=note_data.ah_nid,
         anki_nid=note.id,
-        fields=note_data.fields,
-        tags=note_data.tags,
+        fields=fields,
+        tags=tags,
         note_type_name=note.note_type()["name"],
         anki_note_type_id=note.mid,
         guid=note.guid,
@@ -342,8 +608,18 @@ def _new_note_suggestion(note: Note, ah_did: uuid.UUID, comment: str) -> NewNote
     )
 
 
-def _change_note_suggestion(note: Note, change_type: SuggestionType, comment: str) -> Optional[ChangeNoteSuggestion]:
-    note_from_anki_db = to_note_data(note, include_empty_fields=True)
+def _change_note_suggestion(
+    note: Note,
+    change_type: SuggestionType,
+    comment: str,
+    filters: Optional[PerNoteFilters] = None,
+) -> Optional[ChangeNoteSuggestion]:
+    filters = filters or PerNoteFilters()
+    note_from_anki_db = to_note_data(
+        note,
+        include_empty_fields=True,
+        include_protected_fields=config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False),
+    )
     assert isinstance(note_from_anki_db, NoteInfo)
     assert note_from_anki_db.ah_nid is not None
     assert note_from_anki_db.tags is not None
@@ -362,6 +638,12 @@ def _change_note_suggestion(note: Note, change_type: SuggestionType, comment: st
         fields_that_changed = _fields_that_changed(
             prev_fields=note_from_ah_db.fields, cur_fields=note_from_anki_db.fields
         )
+
+        fields_that_changed = _apply_field_filters(
+            fields_that_changed, filters.fields_to_include, filters.globally_protected_fields
+        )
+        added_tags = _apply_tag_allowlist(added_tags, filters.tags_to_add)
+        removed_tags = _apply_tag_allowlist(removed_tags, filters.tags_to_remove)
 
         if not added_tags and not removed_tags and not fields_that_changed:
             return None

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -143,6 +143,10 @@ class DeckConfig(DataClassJSONMixin):
     has_note_embeddings: bool = False
     auto_protect_fields_when_edited: bool = True
     globally_protected_fields: Dict[int, List[str]] = dataclasses.field(default_factory=dict)
+    # Per-note-type record of fields the user explicitly deselected in the Suggest dialog.
+    # Storing deselected (rather than selected) means a field edited for the first time
+    # defaults to checked, while a field the user previously unchecked stays unchecked.
+    last_deselected_fields_per_note_type: Dict[int, List[str]] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def suspend_new_cards_of_new_notes_default(ah_did: uuid.UUID) -> bool:
@@ -410,9 +414,24 @@ class _Config:
         deck_config.globally_protected_fields = protected_fields
         self._update_private_config()
 
-    def globally_protected_fields_for_note_type(self, ankihub_did: uuid.UUID, mid: int) -> List[str]:
+    def globally_protected_fields(self, ankihub_did: uuid.UUID) -> Dict[int, List[str]]:
+        # Return a copy so callers can't mutate the cached map.
+        return {mid: list(names) for mid, names in self.deck_config(ankihub_did).globally_protected_fields.items()}
+
+    def set_last_deselected_fields(self, ankihub_did: uuid.UUID, mid: int, fields: List[str]) -> None:
+        """Remember which fields the user explicitly deselected in the Suggest dialog for this
+        (deck, note type), so a subsequent open keeps those fields unchecked while newly-edited
+        fields default to checked.
+        """
+        store = self.deck_config(ankihub_did).last_deselected_fields_per_note_type
+        if store.get(mid) == fields:
+            return
+        store[mid] = list(fields)
+        self._update_private_config()
+
+    def last_deselected_fields(self, ankihub_did: uuid.UUID, mid: int) -> List[str]:
         # Return a copy so callers can't mutate the cached list.
-        return list(self.deck_config(ankihub_did).globally_protected_fields.get(mid, []))
+        return list(self.deck_config(ankihub_did).last_deselected_fields_per_note_type.get(mid, []))
 
     def set_ankihub_deleted_notes_behavior(
         self, ankihub_did: uuid.UUID, note_delete_behavior: BehaviorOnRemoteNoteDeleted

--- a/tests/addon/performance/test_suggestion_dialog.py
+++ b/tests/addon/performance/test_suggestion_dialog.py
@@ -1,0 +1,81 @@
+import os
+import uuid
+from typing import Callable, Dict, List
+
+import pytest
+from anki.models import NotetypeDict, NotetypeId
+from pytest_anki import AnkiSession
+
+from .conftest import Profile
+
+# workaround for vscode test discovery not using pytest.ini which sets this env var
+# has to be set before importing ankihub
+os.environ["SKIP_INIT"] = "1"
+
+from ankihub.ankihub_client import NoteInfo, SuggestionType
+from ankihub.main.importing import AnkiHubImporter
+from ankihub.main.suggestions import (
+    any_suggestible_from_diffs,
+    compute_note_diffs,
+)
+from ankihub.settings import BehaviorOnRemoteNoteDeleted, DeckConfig
+
+
+@pytest.mark.performance
+def test_bulk_suggestion_dialog_open_diff_pipeline(
+    anki_session_with_addon_data: AnkiSession,
+    next_deterministic_uuid: Callable[[], uuid.UUID],
+    anking_notes_data: List[NoteInfo],
+    anking_note_types: Dict[NotetypeId, NotetypeDict],
+    profile: Profile,
+):
+    """Measures the per-note work that runs synchronously on the UI thread
+    when the user opens the bulk Suggest-a-change dialog at the 500-note cap.
+    Exercises `compute_note_diffs` once and feeds its result through the
+    bulk-suggestible gate and the media check. The widget's `_populate` is
+    explicitly excluded — it's cheap per-note filtering off already-computed
+    diffs — and isn't covered by this test.
+    """
+    with anki_session_with_addon_data.profile_loaded():
+        mw = anki_session_with_addon_data.mw
+        notes_amount = 500  # matches the per-bulk-suggestion cap
+
+        ankihub_did = next_deterministic_uuid()
+        importer = AnkiHubImporter()
+        importer.import_ankihub_deck(
+            ankihub_did=ankihub_did,
+            notes=anking_notes_data[:notes_amount],
+            deck_name="test",
+            is_first_import_of_deck=True,
+            behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+            note_types=anking_note_types,
+            protected_fields={},
+            protected_tags=[],
+            suspend_new_cards_of_new_notes=False,
+            suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
+        )
+
+        notes = [mw.col.get_note(nid) for nid in mw.col.find_notes("")]
+        assert len(notes) == notes_amount  # sanity check
+
+        # Realistic worst case: every note has a field edit and a tag change,
+        # so the gate short-circuits fast but the widget's per-note diff
+        # still runs over the full set.
+        for note in notes:
+            note.fields[0] = note.fields[0] + " edit"
+            note.tags = list(note.tags) + ["perf-test-tag"]
+            mw.col.update_note(note)
+
+        def dialog_open_diff_pipeline() -> None:
+            diffs = compute_note_diffs(notes)
+            any_suggestible_from_diffs(notes, diffs, SuggestionType.UPDATED_CONTENT, {})
+            any(d.added_new_media for d in diffs.values())
+            # Widget _populate is omitted: it's per-note field/tag filtering off the
+            # already-computed diffs, which adds negligible cost.
+
+        duration = profile(dialog_open_diff_pipeline)
+        print(f"Bulk dialog-open diff pipeline over {len(notes)} notes took {duration:.3f} seconds")
+        # Soft regression gate: CI baseline is ~0.2s, so 2.0s leaves ~10×
+        # headroom against unrelated runner slowness while still catching a
+        # ~5× regression. Bump if CI hardware changes substantially.
+        assert duration < 2.0

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -175,7 +175,12 @@ from ankihub.gui.operations.new_deck_subscriptions import check_and_install_new_
 from ankihub.gui.operations.utils import future_with_result
 from ankihub.gui.optional_tag_suggestion_dialog import OptionalTagsSuggestionDialog
 from ankihub.gui.overview import FLASHCARD_SELECTOR_OPEN_BUTTON_ID, FLASHCARD_SELECTOR_SYNC_NOTES_ACTIONS_PYCMD
-from ankihub.gui.suggestion_dialog import SuggestionDialog
+from ankihub.gui.suggestion_dialog import (
+    IncludeInSuggestionWidget,
+    SuggestionDialog,
+    open_suggestion_dialog_for_bulk_suggestion,
+    open_suggestion_dialog_for_single_suggestion,
+)
 from ankihub.gui.utils import _Dialog, robust_filter
 from ankihub.main.deck_creation import create_ankihub_deck, modified_note_type
 from ankihub.main.deck_options import ANKIHUB_PRESET_NAME, get_fsrs_parameters
@@ -199,6 +204,10 @@ from ankihub.main.suggestions import (
     ANKIHUB_NO_CHANGE_ERROR,
     ANKIHUB_NOTE_DOES_NOT_EXIST_ERROR,
     BulkNoteSuggestionsResult,
+    BulkSuggestionFilters,
+    PerNoteFilters,
+    any_suggestible_from_diffs,
+    compute_note_diffs,
     suggest_new_note,
     suggest_note_update,
     suggest_notes_in_bulk,
@@ -888,6 +897,43 @@ def test_create_collaborative_deck_and_upload(
 
         # check that note mod value is in database
         assert AnkiHubNote.get(AnkiHubNote.anki_note_id == note.id).mod == note.mod
+
+
+def test_create_collaborative_deck_strips_personally_protected_fields(
+    anki_session_with_addon_data: AnkiSession,
+    mocker: MockerFixture,
+    next_deterministic_uuid: Callable[[], uuid.UUID],
+):
+    """Data-safety guard: the deck-creation upload must not ship the contents of personally-
+    protected fields (those carrying an `AnkiHub_Protect::Field` tag). This pins the
+    `to_note_data(include_protected_fields=False)` default that `create_ankihub_deck` relies on —
+    a future caller flipping that default would leak local annotations to other subscribers.
+    """
+    with anki_session_with_addon_data.profile_loaded():
+        mw = anki_session_with_addon_data.mw
+
+        deck_name = "Protected Deck"
+        mw.col.decks.add_normal_deck_with_name(deck_name)
+        anki_did = mw.col.decks.id_for_name(deck_name)
+
+        note = mw.col.new_note(mw.col.models.by_name("Basic"))
+        note["Front"] = "front"
+        note["Back"] = "secret local annotation"
+        note.tags = [f"{TAG_FOR_PROTECTING_FIELDS}::Back"]
+        mw.col.add_note(note, anki_did)
+
+        ah_did = next_deterministic_uuid()
+        ah_nid = next_deterministic_uuid()
+        upload_deck_mock = mocker.patch.object(AnkiHubClient, "upload_deck", return_value=ah_did)
+        mocker.patch("uuid.uuid4", return_value=ah_nid)
+
+        create_ankihub_deck(deck_name, private=False)
+
+        (uploaded,) = upload_deck_mock.call_args.kwargs["notes_data"]
+        field_names = [f.name for f in uploaded.fields]
+        assert "Back" not in field_names  # personally-protected field stripped before upload
+        assert "Front" in field_names  # unprotected field still shipped
+        assert uploaded.tags == []  # internal protect tag not shipped either
 
 
 def test_create_note_type(
@@ -1592,6 +1638,9 @@ def test_suggest_new_note(
 
         _, ah_did = install_sample_ah_deck()
         note = mw.col.new_note(mw.col.models.by_name("Basic (Testdeck / user1)"))
+        # The first field must be non-empty — server (and the local pre-submit
+        # gate in _new_note_suggestion) rejects new-note suggestions otherwise.
+        note["Front"] = "front_value"
 
         adapter = requests_mock.post(
             f"{config.api_url}/decks/{ah_did}/note-suggestion/",
@@ -1638,6 +1687,445 @@ def test_suggest_new_note(
         except AnkiHubHTTPError as e:
             exc = e
         assert exc is not None and exc.response.status_code == 403
+
+
+class TestFieldsToSuggestFilters:
+    """Covers the user-controlled filter introduced for the suggestion-dialog overhaul:
+    compute_note_diffs + the fields_to_include / tags_to_add / tags_to_remove allowlists.
+    """
+
+    def test_diff_edited_fields_includes_personally_protected_fields(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            # Personally protect the Front field and edit it. The previous _prepare_fields
+            # behavior would have stripped Front from the diff; the dialog needs to see it.
+            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+            note["Front"] = "edited"
+            aqt.mw.col.update_note(note)
+
+            diffs = compute_note_diffs([note])
+            assert "Front" in diffs[note.id].edited_fields
+
+    def test_suggest_note_update_user_allowlists_strip_outside_changes(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+        mocker: MockerFixture,
+    ):
+        """`suggest_note_update` honours per-field and per-tag user allowlists,
+        stripping anything outside the lists before the API call.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            _, ah_did = install_sample_ah_deck()
+            nid = aqt.mw.col.find_notes("")[0]
+            note = aqt.mw.col.get_note(nid)
+            note.tags = ["stays", "removed_a", "removed_b"]
+            ankihub_db.upsert_notes_data(ankihub_did=ah_did, notes_data=[to_note_data(note)])
+
+            field_names = list(note.keys())
+            note[field_names[0]] = "front_updated"
+            note[field_names[1]] = "back_updated"
+            note.tags = ["stays", "added_a", "added_b"]
+
+            create_mock = mocker.patch.object(AnkiHubClient, "create_change_note_suggestion")
+
+            suggest_note_update(
+                note=note,
+                change_type=SuggestionType.NEW_CONTENT,
+                comment="test",
+                media_upload_cb=mocker.stub(),
+                filters=PerNoteFilters(
+                    fields_to_include=[field_names[0]],
+                    tags_to_add=["added_a"],
+                    tags_to_remove=["removed_a"],
+                ),
+            )
+
+            sent = create_mock.call_args.kwargs["change_note_suggestion"]
+            assert [f.name for f in sent.fields] == [field_names[0]]
+            assert sent.added_tags == ["added_a"]
+            assert sent.removed_tags == ["removed_a"]
+
+    def test_protected_fields_stripped_when_feature_flag_off(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+        mocker: MockerFixture,
+    ):
+        """With the feature flag off, the suggestion path keeps the legacy behavior:
+        fields carrying personal AnkiHub_Protect tags are stripped from the outgoing
+        suggestion. (When on, the dialog filters at the user's direction instead.)
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            _, ah_did = install_sample_ah_deck()
+            nid = aqt.mw.col.find_notes("")[0]
+            note = aqt.mw.col.get_note(nid)
+            ankihub_db.upsert_notes_data(ankihub_did=ah_did, notes_data=[to_note_data(note)])
+
+            field_names = list(note.keys())
+            note[field_names[0]] = "front_updated"
+            note[field_names[1]] = "back_updated"
+            note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::{field_names[0]}")
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": False})
+
+            create_mock = mocker.patch.object(AnkiHubClient, "create_change_note_suggestion")
+
+            suggest_note_update(
+                note=note,
+                change_type=SuggestionType.NEW_CONTENT,
+                comment="test",
+                media_upload_cb=mocker.stub(),
+            )
+
+            sent = create_mock.call_args.kwargs["change_note_suggestion"]
+            sent_field_names = [f.name for f in sent.fields]
+            # Protected field is stripped; the other change still goes out.
+            assert field_names[0] not in sent_field_names
+            assert field_names[1] in sent_field_names
+
+    def test_widget_populates_for_new_note_candidates(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        add_anki_note: AddAnkiNote,
+    ):
+        """New-note candidates (no AH DB row) populate the widget with all non-empty
+        fields and all current tags — parent spec edit 2026-05-18: the section
+        appears for every change type except DELETE, new-note included.
+
+        Also pins down that internal `AnkiHub_Protect::*` tags don't surface as
+        `+ tag` checkboxes (`_prepare_tags` strips them).
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_type = import_ah_note_type(ah_did=ah_did)
+            note = add_anki_note(note_type=note_type)
+            note["Front"] = "front_value"
+            # leave "Back" empty
+            note.tags = ["alpha", f"{TAG_FOR_PROTECTING_FIELDS}::Front", "beta"]
+            aqt.mw.col.update_note(note)
+
+            widget = IncludeInSuggestionWidget(notes=[note], note_diffs=compute_note_diffs([note]))
+
+            field_checkboxes = widget._field_checkboxes[NotetypeId(note.mid)]
+            assert "Front" in field_checkboxes
+            assert "Back" not in field_checkboxes  # empty field skipped
+            assert set(widget._added_tag_boxes.keys()) == {"alpha", "beta"}  # protect tag stripped
+            assert widget._removed_tag_boxes == {}  # no AH baseline → nothing to remove
+
+            # First field is server-required for new-note suggestions, so the widget locks
+            # its checkbox: checked + disabled + tooltip explaining why.
+            front_cb = field_checkboxes["Front"]
+            assert front_cb.isChecked()
+            assert not front_cb.isEnabled()
+            assert "first field is required" in front_cb.toolTip().lower()
+
+    def test_suggest_new_note_bulk_per_mid_filters(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        add_anki_note: AddAnkiNote,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        """Bulk new-note: per-mid allowlists from the dialog selection thread
+        through `_suggestions_for_notes` into each `_new_note_suggestion`.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_type = import_ah_note_type(ah_did=ah_did)
+            note = add_anki_note(note_type=note_type)
+            note["Front"] = "front_value"
+            note["Back"] = "back_value"
+            note.tags = ["alpha", "beta"]
+            aqt.mw.col.update_note(note)
+
+            mocker.patch("uuid.uuid4", return_value=next_deterministic_uuid())
+            bulk_mock = mocker.patch.object(AnkiHubClient, "create_suggestions_in_bulk", return_value={})
+
+            suggest_notes_in_bulk(
+                ankihub_did=ah_did,
+                notes=[note],
+                auto_accept=False,
+                change_type=SuggestionType.NEW_CONTENT,
+                comment="test",
+                media_upload_cb=mocker.stub(),
+                filters=BulkSuggestionFilters(
+                    fields_to_include_by_mid={NotetypeId(note.mid): ["Front"]},
+                    tags_to_add=["alpha"],
+                ),
+            )
+
+            sent = bulk_mock.call_args.kwargs["new_note_suggestions"][0]
+            assert [f.name for f in sent.fields] == ["Front"]
+            assert sent.tags == ["alpha"]
+
+    def test_bulk_new_note_skipped_when_mid_missing_from_allowlist(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        add_anki_note: AddAnkiNote,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        """When `fields_to_include_by_mid` is provided but doesn't cover a
+        note's mid (e.g., the widget rendered no section for it because every
+        edit was globally-protected), `for_mid` returns an empty allowlist
+        rather than 'no filter'. Result: no fields ship, the new-note
+        suggestion is dropped client-side.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_type = import_ah_note_type(ah_did=ah_did)
+            note = add_anki_note(note_type=note_type)
+            note["Front"] = "front_value"
+            note["Back"] = "back_value"
+            aqt.mw.col.update_note(note)
+
+            mocker.patch("uuid.uuid4", return_value=next_deterministic_uuid())
+            bulk_mock = mocker.patch.object(AnkiHubClient, "create_suggestions_in_bulk", return_value={})
+
+            suggest_notes_in_bulk(
+                ankihub_did=ah_did,
+                notes=[note],
+                auto_accept=False,
+                change_type=SuggestionType.NEW_CONTENT,
+                comment="test",
+                media_upload_cb=mocker.stub(),
+                filters=BulkSuggestionFilters(
+                    # Allowlist is provided but doesn't cover this mid → for_mid
+                    # returns an empty allowlist → no fields pass through.
+                    fields_to_include_by_mid={NotetypeId(99999): ["does-not-matter"]},
+                ),
+            )
+
+            # No suggestion submitted: the empty allowlist excludes every
+            # field, so _new_note_suggestion returns None.
+            bulk_mock.assert_not_called()
+
+    def test_dialog_filters_globally_protected_fields_from_config_cache(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        mocker: MockerFixture,
+    ):
+        """End-to-end seam: `config.set_globally_protected_fields` →
+        `open_suggestion_dialog_for_single_suggestion` → `SuggestionDialog`
+        receives the `{NotetypeId: Set[str]}` kwarg the widget consumes.
+        Catches the helper's coercion AND the dialog's plumbing of the kwarg.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            mid = note_info.mid
+
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note["Front"] = "front_edit"
+            note["Back"] = "back_edit"
+            aqt.mw.col.update_note(note)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_globally_protected_fields(ah_did, {mid: ["Front"]})
+
+            dialog_mock = mocker.patch("ankihub.gui.suggestion_dialog.SuggestionDialog")
+            open_suggestion_dialog_for_single_suggestion(note=note, parent=None)
+
+            dialog_mock.assert_called_once()
+            kwargs = dialog_mock.call_args.kwargs
+            assert kwargs["globally_protected_fields_by_mid"] == {NotetypeId(mid): {"Front"}}
+
+    @pytest.mark.parametrize(
+        "preselected_change_type,expects_toast",
+        [
+            # Generic "Bulk suggest notes" over unchanged notes → empty-state toast.
+            (None, True),
+            # "Suggest to delete note" preselects DELETE → dialog opens (delete doesn't need changes).
+            (SuggestionType.DELETE, False),
+        ],
+    )
+    def test_bulk_suggest_empty_state_gate(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        mocker: MockerFixture,
+        preselected_change_type: Optional[SuggestionType],
+        expects_toast: bool,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            toast_mock = mocker.patch("ankihub.gui.suggestion_dialog.show_tooltip")
+            dialog_mock = mocker.patch("ankihub.gui.suggestion_dialog.SuggestionDialog")
+
+            open_suggestion_dialog_for_bulk_suggestion(
+                anki_nids=[nid], parent=None, preselected_change_type=preselected_change_type
+            )
+
+            if expects_toast:
+                toast_mock.assert_called_once()
+                assert "no changes" in toast_mock.call_args[0][0].lower()
+                dialog_mock.assert_not_called()
+            else:
+                toast_mock.assert_not_called()
+                dialog_mock.assert_called_once()
+
+    def test_any_suggestible_from_diffs_by_change_type(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        add_anki_note: AddAnkiNote,
+    ):
+        """The bulk-gate helper must agree with the submit-path classification.
+
+        - DELETE only passes for existing-and-not-deleted AH notes.
+        - NEW_CONTENT / UPDATED_CONTENT (and None, since the browser's generic
+          "Bulk suggest notes" menu preselects None and is for changes) pass
+          for new-note candidates or notes with field/tag edits.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            mid = note_info.mid
+            existing_nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            existing_unchanged = aqt.mw.col.get_note(existing_nid)
+            # A second AnkiHub note we'll then mark deleted-on-remote.
+            deleted_info = import_ah_note(ah_did=ah_did)
+            deleted_nid = ankihub_db.anki_nid_for_ankihub_nid(deleted_info.ah_nid)
+            AnkiHubNote.update(last_update_type=SuggestionType.DELETE.value[0]).where(
+                AnkiHubNote.ankihub_note_id == deleted_info.ah_nid
+            ).execute()
+            deleted_note = aqt.mw.col.get_note(deleted_nid)
+            # A note Anki knows about that has no AH DB row at all → new-note candidate.
+            new_note = add_anki_note(
+                note_type=aqt.mw.col.models.get(NotetypeId(mid)),
+            )
+
+            def is_suggestible(notes: List[Note], change_type: Optional[SuggestionType]) -> bool:
+                return any_suggestible_from_diffs(notes, compute_note_diffs(notes), change_type, {})
+
+            # DELETE: only the existing-and-not-deleted note qualifies.
+            assert is_suggestible([existing_unchanged], SuggestionType.DELETE)
+            assert not is_suggestible([deleted_note], SuggestionType.DELETE)
+            assert not is_suggestible([new_note], SuggestionType.DELETE)
+
+            # NEW_CONTENT on an unchanged existing note → no changes, no.
+            assert not is_suggestible([existing_unchanged], SuggestionType.NEW_CONTENT)
+            # NEW_CONTENT on a brand-new note → new-note candidate, yes.
+            assert is_suggestible([new_note], SuggestionType.NEW_CONTENT)
+
+            # None (the browser's generic "Bulk suggest notes" menu) behaves like
+            # NEW_CONTENT/UPDATED_CONTENT — gated on changes vs. local AH DB.
+            assert not is_suggestible([existing_unchanged], None)
+            assert is_suggestible([new_note], None)
+            assert not is_suggestible([deleted_note], None)
+
+            # New-note candidate whose only non-empty fields are all globally-protected,
+            # with no tags → not suggestible. (Otherwise the dialog would open with an
+            # empty "Include in suggestion" panel that the user can't submit from.)
+            new_note_protected = add_anki_note(note_type=aqt.mw.col.models.get(NotetypeId(mid)))
+            first_field_name = new_note_protected.note_type()["flds"][0]["name"]
+            assert not any_suggestible_from_diffs(
+                [new_note_protected],
+                compute_note_diffs([new_note_protected]),
+                SuggestionType.NEW_CONTENT,
+                {NotetypeId(mid): {first_field_name}},
+            )
+
+            # New-note candidate where the server-required first field is globally-protected
+            # but a second field has content → still not suggestible. The widget would render
+            # the second field as selectable but `_new_note_suggestion` rejects on the empty
+            # first field, so the submit silently drops.
+            new_note_first_protected = add_anki_note(note_type=aqt.mw.col.models.get(NotetypeId(mid)))
+            field_names = list(new_note_first_protected.keys())
+            new_note_first_protected[field_names[1]] = "back content"
+            aqt.mw.col.update_note(new_note_first_protected)
+            assert not any_suggestible_from_diffs(
+                [new_note_first_protected],
+                compute_note_diffs([new_note_first_protected]),
+                SuggestionType.NEW_CONTENT,
+                {NotetypeId(mid): {field_names[0]}},
+            )
+
+    def test_dialog_save_deselections_merges_with_prior(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+    ):
+        """A field deselected in a prior session should stay deselected even when it's not
+        shown in the current widget (because the user hasn't edited it this time). Re-checking
+        a field explicitly clears its deselection. The dialog snapshots priors at construction
+        and merges them with the widget's current state on accept.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            note_info = import_ah_note(ah_did=ah_did)
+            mid = note_info.mid
+
+            # Prior session: user deselected "Back" for this mid AND deselected fields
+            # under an unrelated mid that isn't in today's batch. The unrelated mid's
+            # prior must survive untouched — `_save_deselections` only writes back mids
+            # whose fields the widget actually rendered.
+            other_mid = mid + 999_999
+            config.set_last_deselected_fields(ah_did, mid, ["Back"])
+            config.set_last_deselected_fields(ah_did, other_mid, ["Stale"])
+
+            # Current session: only "Front" is edited (Back isn't shown in the widget).
+            nid = ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid)
+            note = aqt.mw.col.get_note(nid)
+            note["Front"] = "edited"
+            aqt.mw.col.update_note(note)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            def build_dialog() -> SuggestionDialog:
+                return SuggestionDialog(
+                    is_new_note_suggestion=False,
+                    is_for_anking_deck=False,
+                    can_submit_without_review=False,
+                    added_new_media=False,
+                    callback=lambda _meta: None,
+                    notes=[note],
+                    note_diffs=compute_note_diffs([note]),
+                    ah_did=ah_did,
+                )
+
+            # Session 1: open dialog, deselect Front, save. Prior Back deselection must survive.
+            dialog = build_dialog()
+            assert "Back" not in dialog._fields_widget._field_checkboxes[NotetypeId(mid)]
+            dialog._fields_widget._field_checkboxes[NotetypeId(mid)]["Front"].setChecked(False)
+            dialog._save_deselections()
+            assert sorted(config.last_deselected_fields(ah_did, mid)) == ["Back", "Front"]
+
+            # Session 2: open a fresh dialog so the construction-time snapshot is `{"Back", "Front"}`.
+            # Re-check Front and save — Front's persisted deselection should clear; Back stays.
+            dialog = build_dialog()
+            dialog._fields_widget._field_checkboxes[NotetypeId(mid)]["Front"].setChecked(True)
+            dialog._save_deselections()
+            assert config.last_deselected_fields(ah_did, mid) == ["Back"]
+
+            # And `other_mid`'s prior is untouched throughout — neither session rendered fields
+            # under it, so `_save_deselections` never wrote it back.
+            assert config.last_deselected_fields(ah_did, other_mid) == ["Stale"]
 
 
 class TestSuggestNotesInBulk:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -20,7 +20,7 @@ from anki.models import NotetypeDict
 from anki.notes import Note, NoteId
 from approvaltests.approvals import verify  # type: ignore
 from approvaltests.namer import NamerFactory  # type: ignore
-from aqt.qt import QDialog, QDialogButtonBox, QLineEdit, QMenu, Qt, QTimer, QWidget
+from aqt.qt import QCheckBox, QDialog, QDialogButtonBox, QLineEdit, QMenu, Qt, QTimer, QWidget
 from pytest import MonkeyPatch
 from pytest_anki import AnkiSession
 from pytest_mock import MockerFixture
@@ -122,7 +122,10 @@ from ankihub.gui.suggestion_dialog import (
     SuggestionDialog,
     SuggestionMetadata,
     SuggestionSource,
+    _GroupController,
     _on_suggest_notes_in_bulk_done,
+    _SelectAllCheckBox,
+    _TagLabel,
     get_anki_nid_to_ah_dids_dict,
     open_suggestion_dialog_for_bulk_suggestion,
     open_suggestion_dialog_for_single_suggestion,
@@ -552,6 +555,33 @@ def test_prepared_field_html():
     assert _prepared_field_html('<img src="foo.jpg" data-editor-shrink="true">') == '<img src="foo.jpg">'
 
 
+def test_tag_label_elide():
+    elide = _TagLabel._elide
+
+    # Short tag → as-is.
+    assert elide("Pathology") == "Pathology"
+    assert elide("Hierarchy::A::B") == "Hierarchy::A::B"
+
+    # Long hierarchical tag → `…::leaf`.
+    long_hierarchical = (
+        "AnkiHub::Internal::AnKing::Pharmacology::Antiarrhythmics::Class_III::Amiodarone::Cardiovascular::Specifics"
+    )
+    assert elide(long_hierarchical) == "…::Specifics"
+
+    # Long flat tag (no `::`) → plain ellipsis at the end.
+    long_flat = "x" * 120
+    flat_result = elide(long_flat)
+    assert flat_result.endswith("…")
+    assert len(flat_result) <= 85
+
+    # Long hierarchical tag whose leaf alone exceeds the budget → leaf truncated too.
+    bulky_leaf = "y" * 120
+    leaf_result = elide(f"Hierarchy::{bulky_leaf}")
+    assert leaf_result.startswith("…::")
+    assert leaf_result.endswith("…")
+    assert len(leaf_result) <= 85
+
+
 def test_remove_note_type_name_modifications():
     name = "Basic (deck_name / user_name)"
     assert note_type_name_without_ankihub_modifications(name) == "Basic"
@@ -900,6 +930,85 @@ class TestSuggestionDialog:
         dialog.show()
 
         assert dialog.auto_accept_cb.isVisible() == can_submit_without_review
+
+
+class TestSelectAllGroupController:
+    """Pin down the tri-state interaction in `_GroupController` + `_SelectAllCheckBox`.
+
+    The custom `nextCheckState` override is the bit that fixes Qt's default
+    Unchecked → PartiallyChecked cycle on user click, so without these tests a
+    'simplification' that drops the override would regress silently.
+    """
+
+    def _build(self, qtbot: QtBot, initial_checked):
+        toggles: List[bool] = []
+        parent = _SelectAllCheckBox("Select all")
+        qtbot.add_widget(parent)
+        controller = _GroupController(parent, on_child_toggle=lambda: toggles.append(True))
+        # Anchor the controller to the qtbot-tracked parent so it doesn't get GC'd
+        # mid-test; Qt drops the bound-method `toggled` connections when the Python
+        # controller dies and child→parent state propagation silently stops.
+        parent._test_controller_ref = controller  # type: ignore[attr-defined]
+        children = []
+        for state in initial_checked:
+            cb = QCheckBox("child")
+            cb.setChecked(state)
+            qtbot.add_widget(cb)
+            controller.add_child(cb)
+            children.append(cb)
+        controller.refresh_parent()
+        return parent, children, controller, toggles, Qt.CheckState
+
+    def test_select_all_check_box_user_click_skips_partially_checked(self, qtbot: QtBot):
+        """The override is the load-bearing bit — without it, an unchecked-group click
+        lands on PartiallyChecked and the controller treats that as "uncheck all"."""
+        cb = _SelectAllCheckBox("Select all")
+        qtbot.add_widget(cb)
+
+        # Unchecked → click → Checked (default Qt cycle would have gone to PartiallyChecked).
+        assert cb.checkState() == Qt.CheckState.Unchecked
+        cb.click()
+        assert cb.checkState() == Qt.CheckState.Checked
+
+        # Programmatic PartiallyChecked → click → Checked (also not the default).
+        cb.setCheckState(Qt.CheckState.PartiallyChecked)
+        cb.click()
+        assert cb.checkState() == Qt.CheckState.Checked
+
+        # Checked → click → Unchecked (same as default).
+        cb.click()
+        assert cb.checkState() == Qt.CheckState.Unchecked
+
+    @pytest.mark.parametrize(
+        "initial,target",
+        [
+            ([False, False, False], True),  # unchecked group → select all
+            ([True, True, True], False),  # checked group → clear all
+            ([True, False, True], True),  # partial group → select all (Qt fix: not "clear")
+        ],
+    )
+    def test_parent_click_sets_all_children(self, qtbot: QtBot, initial, target):
+        parent, children, controller, toggles, _ = self._build(qtbot, initial)
+        # Simulate the post-`nextCheckState` state Qt puts us in after a user click.
+        parent.setCheckState(Qt.CheckState.Checked if target else Qt.CheckState.Unchecked)
+        controller._on_parent_clicked(target)
+        assert all(c.isChecked() == target for c in children)
+        expected = Qt.CheckState.Checked if target else Qt.CheckState.Unchecked
+        assert parent.checkState() == expected
+        assert toggles
+
+    @pytest.mark.parametrize(
+        "initial,child_idx,new_state,expected_parent",
+        [
+            ([True, True, True], 1, False, "PartiallyChecked"),  # un-check one → partial
+            ([True, False, True], 1, True, "Checked"),  # complete the set → checked
+            ([True, False, False], 0, False, "Unchecked"),  # last one off → unchecked
+        ],
+    )
+    def test_child_toggle_propagates_to_parent(self, qtbot: QtBot, initial, child_idx, new_state, expected_parent):
+        parent, children, _, _, _ = self._build(qtbot, initial)
+        children[child_idx].setChecked(new_state)
+        assert parent.checkState() == getattr(Qt.CheckState, expected_parent)
 
 
 class TestSuggestionDialogGetAnkiNidToAHDidsDict:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -885,6 +885,10 @@ class TestSuggestionDialog:
         assert dialog.change_type_select.isVisible() == change_type_needed
         assert dialog.source_widget_group_box.isVisible() == source_needed
         assert dialog.hint_for_note_deletions.isVisible() == (suggestion_type == SuggestionType.DELETE)
+        if source_needed:
+            # DELETE's source (Duplicate Note) is optional, so its group box must not claim "(Required)".
+            expected_title = "Source" if suggestion_type == SuggestionType.DELETE else "Source (Required)"
+            assert dialog.source_widget_group_box.title() == expected_title
 
         # Assert that the form submit button is enabled (it is disabled if the form input is invalid)
         assert dialog.button_box.button(QDialogButtonBox.StandardButton.Ok).isEnabled()
@@ -910,6 +914,34 @@ class TestSuggestionDialog:
                 source=expected_source,
             )
         )
+
+    def test_delete_suggestion_source_is_optional(self, qtbot: QtBot, mocker: MockerFixture):
+        """DELETE's Duplicate-Note source is optional: the OK button enables with an empty
+        source (just a rationale), and the group box drops the "(Required)" label.
+        """
+        callback_mock = mocker.stub()
+        dialog = SuggestionDialog(
+            is_for_anking_deck=False,
+            is_new_note_suggestion=False,
+            added_new_media=False,
+            can_submit_without_review=True,
+            callback=callback_mock,
+        )
+        dialog.show()
+        dialog.change_type_select.setCurrentText(SuggestionType.DELETE.value[1])
+
+        assert dialog.source_widget_group_box.isVisible()
+        assert dialog.source_widget_group_box.title() == "Source"
+
+        # Rationale only — source left empty. OK must enable.
+        dialog.rationale_edit.setPlainText("dupe of another note")
+        assert dialog.button_box.button(QDialogButtonBox.StandardButton.Ok).isEnabled()
+
+        dialog.accept()
+        qtbot.wait_until(lambda: callback_mock.called)
+        meta = callback_mock.call_args.args[0]
+        assert meta.change_type == SuggestionType.DELETE
+        assert meta.source.source_text == ""
 
     @pytest.mark.parametrize(
         "can_submit_without_review",


### PR DESCRIPTION
Replaces the silent "strip personally-protected fields from outgoing suggestions" behavior with an explicit per-field selector. Every edited field (change-note) or every non-empty field (new-note) plus every tag change surfaces in the dialog and the user picks what to include. Globally-protected fields are excluded from the picker at dialog-open time (so they never enter the user's allowlist); server-side enforcement is the backstop at submit.

## Screenshots

<table><tr>
<td><img width="450" alt="Redesigned Suggest-a-change dialog (AnKing change-note)" src="https://github.com/user-attachments/assets/2cdbcd1a-788e-4d4b-ac5e-19021db11941" /></td>
<td><img width="450" alt="Non-AnKing new-note suggestion dialog with locked first-field tooltip" src="https://github.com/user-attachments/assets/694fe4db-958e-43a8-ad4b-4897fb9ee562" /></td>
</tr><tr>
<td align="center"><em>AnKing deck — change-note with Source widget</em></td>
<td align="center"><em>Non-AnKing deck — new-note flow; first-field checkbox is locked-checked (tooltip visible)</em></td>
</tr></table>

## Related issues

- [NRT-749](https://ankihub.atlassian.net/browse/NRT-749) (subtask of [NRT-508](https://ankihub.atlassian.net/browse/NRT-508))

## ⚠️ Rollout

Gated on the server feature flag `auto_protect_fields_when_edited` (shared with the auto-protect-on-edit work that already landed). Flip *after* that work has been deployed long enough for users to autosync once — the globally-protected-fields cache the dialog reads is seeded on install + every sync. The server still enforces protection on submit, so a cold cache only makes the dialog noisy, not unsafe.

## Data flow

Three phases for both single and bulk paths:

**1. Open (data shaping)**
- Entry point computes `compute_note_diffs(notes)` once, producing `Dict[NoteId, NoteDiff]` — edited fields, added/removed tags, AH-DB existence, media delta.
- Bulk path runs `any_suggestible_from_diffs` as an empty-state gate; if nothing's suggestible (incl. new-note candidates whose first field is globally-protected), a toast fires and the dialog never opens.

**2. Dialog (selection)**
- `SuggestionDialog` receives notes + diffs + the globally-protected-fields map.
- It snapshots prior per-(deck, note-type) deselections from `config.last_deselected_fields` and threads everything into `IncludeInSuggestionWidget`.
- The widget renders one section per note type for fields, plus separate Added/Removed Tags sections; the user toggles.

**3. Submit**
- On accept the dialog emits `SuggestionMetadata(change_type, comment, source, auto_accept, filters: BulkSuggestionFilters)` and persists the user's per-note-type deselections back to config.
- The closure that `open_suggestion_dialog_for_*` passed in as the dialog's `callback=` combines the dialog's filters with the original notes and calls `suggest_note_update` / `suggest_new_note` (single) or `suggest_notes_in_bulk` → `_suggestions_for_notes` (bulk).
- The per-note builders (`_change_note_suggestion` / `_new_note_suggestion`) emit one `NewNoteSuggestion` / `ChangeNoteSuggestion` per note via the per-note-type allowlist.

The diffs are widget-only — the submit-side builders re-derive equivalent data from each note. Threading `NoteDiff` through to the submit path is tracked in [NRT-771](https://ankihub.atlassian.net/browse/NRT-771) as part of the post-flag-flip cleanup.

## Proposed changes

> Dependency direction: the data-layer subsections (`main/suggestions.py` / `main/exporting.py` / `settings.py`) are additive with safe defaults; the GUI subsections consume them. Kept as one PR rather than split because everything is gated behind `AUTO_PROTECT_FEATURE_FLAG` (so it merges dark, no blast radius), and the data layer is only exercised by the GUI that lands with it — splitting would land a batch of functions nothing calls yet.

### "Include in suggestion" panel (`gui/suggestion_dialog.py`)

- New `IncludeInSuggestionWidget` in a bordered, palette-aware frame.
- Header: bold *"Include in suggestion"* + compact counter (`8/8`) + a *"Select which fields you want to submit changes for"* subtitle.
- One section per note type (Anki suffix `(<deck> / <user>)` stripped via the existing helper) plus separate **"Added Tags"** / **"Removed Tags"** sections.
- Section title sits on the section's select-all checkbox; clicking the title toggles the section. Long titles **dynamically elide** to fit the available width (full text on hover only when elided).
- Long tag names wrap to multiple lines; tag tooltips wrap as rich text.
- Tag names sort alphabetically; very long names show `…::leaf` with the full tag in the tooltip.
- Globally-protected fields are excluded from the picker by the widget at `_populate` time, so the user's resulting allowlist already omits them. Server enforces at submit; no client-side denylist re-application.

### Dialog-level UX

- Outer layout is `[content_row, button_box]` so the left panel stops at the bottom of the right column's content (above the buttons), not at the dialog's bottom edge. 2:3 column stretch; left column capped at 360px so a pathological note-type name can't push the dialog wide.
- Source label: "Source" → **"Source (Required)"**. For source `Other`: label → "Details", placeholder → "Describe the source and include relevant details...". Rationale placeholder → "Explain why this change should be made...".
- `QDialogButtonBox` gains `Cancel`. Post-submit *"No field or tag changes were detected"* dialog removed — in-dialog gating makes it unreachable; a tooltip fallback covers the rare sync-race case.
- On accept, the user's deselected fields are persisted per-(deck, note-type) via `DeckConfig.last_deselected_fields_per_note_type`. Re-checking a field clears its deselection; deselections persist across sessions even when the field isn't re-edited.

### Suggestion API (`main/suggestions.py`)

- New `PerNoteFilters(fields_to_include, tags_to_add, tags_to_remove)` and `BulkSuggestionFilters(fields_to_include_by_mid, tags_to_add, tags_to_remove)` carry the dialog's per-note-type selection through `suggest_note_update` / `suggest_new_note` / `suggest_notes_in_bulk` into the per-note builders. The widget excludes globally-protected fields at populate time, so they never enter the allowlist; the submit layer applies only the user's allowlist and leaves global protection to the server (matches main's pre-PR behavior at the submit layer).
- New `compute_note_diffs(notes) -> Dict[NoteId, NoteDiff]` runs the per-note diff against the local AnkiHub DB once per dialog-open (was three `to_note_data` calls per note previously) and is shared by the bulk-gate, the media-added check, and the widget.
- New `any_suggestible_from_diffs(notes, diffs, change_type, globally_protected_by_mid)` is the bulk-suggest empty-state gate; it mirrors `_suggestions_for_notes`'s classification (DELETE → existing-and-not-deleted AH notes; everything else → notes with at least one non-protected field edit or tag change, with new-note candidates also requiring the first field to be non-empty and non-protected). On miss, the entry point shows *"No changes to suggest. Try syncing with AnkiHub first."* and doesn't open the dialog.

### `to_note_data` opt-in (`main/exporting.py`)

- `to_note_data` / `_prepare_fields` gain `include_protected_fields=False`. The default keeps the legacy auto-strip behavior; suggestion paths set it to `True` when `AUTO_PROTECT_FEATURE_FLAG` is on, so the user picks what to send via the dialog instead of having fields silently dropped before the dialog ever sees them.

### `_Config` API (`settings.py`)

- `globally_protected_fields(ah_did) -> Dict[int, List[str]]` whole-map getter (defensive copy). Per-mid callers (`editor.py`, `browser.py`) do `.get(note.mid, [])` on the result; the dialog reads the whole map for widget construction.
- `set_last_deselected_fields` / `last_deselected_fields` for the deselection-persistence cache.

## How to reproduce

The dialog's **OK/submit button** stays disabled until **rationale + source (when required) are filled AND at least one field/tag is selected**. The "Source (Required)" widget only renders for notes in the AnKing deck — non-AnKing dialogs go straight from Change Type to Rationale.

1. Edit any field on an AnkiHub note → open suggestion dialog → confirm only the edited field appears under "Include in suggestion", pre-selected.
2. Bulk-suggest across notes from two note types → confirm one section per note type, only edited fields shown.
3. Add a new (non-AnkiHub) note in a deck whose note types are AnkiHub-managed → open suggestion dialog → confirm **all non-empty fields** appear (no diff baseline), tags appear in "Added Tags" only.
4. Edit a globally-protected field → confirm it's not listed in the dialog and not sent.
5. Bulk-suggest a set of notes with no local changes → toast fires, dialog doesn't open.
6. Same set with "Suggest to delete note" → dialog opens (DELETE doesn't need changes).
7. Click the section title text (not just its checkbox) → confirm it toggles the section.
8. Hover a long tag → tooltip wraps to multiple lines instead of one long line.
9. On an AnKing note, set Source = "Other" → label becomes "Details" with the new placeholder.
10. Click Cancel → dialog closes without applying changes.

## Tests

`TestFieldsToSuggestFilters` in `test_integration.py` covers the filter allowlists (single + bulk, change-note + new-note), deselection persistence + merge, flag-off legacy path, globally-protected exclusion + bulk-gate backstop, the bulk empty-state toast, and the end-to-end `config → dialog kwarg` seam. `TestSelectAllGroupController` in `test_unit.py` (qtbot) pins down `_SelectAllCheckBox` tri-state interactions.

## Out of scope (deferred)

- Editor toolbar Suggest-button gating ([NRT-751](https://ankihub.atlassian.net/browse/NRT-751)).

[NRT-749]: https://ankihub.atlassian.net/browse/NRT-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-508]: https://ankihub.atlassian.net/browse/NRT-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-751]: https://ankihub.atlassian.net/browse/NRT-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ










