### PR TITLE
NRT-713: focus chatbot webview on open

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -186,6 +186,7 @@ class ReviewerSidebar:
         self.set_content_url(url)
 
         self._update_header_webview()
+        self.content_webview.setFocus()
 
     def _update_header_button_state(self):
         if not self.resources:
@@ -286,6 +287,8 @@ class ReviewerSidebar:
             return
 
         if ok:
+            if self.page_type == SidebarPageType.CHATBOT:
+                self.content_webview.setFocus()
             return
 
         def check_auth_failure_callback(value: str) -> None:


### PR DESCRIPTION
## Related issues
- [x] Closes [NRT-713](https://ankihub.atlassian.net/browse/NRT-713)

## Dependencies
- Requires [ankihub PR #3673](https://github.com/AnkiHubSoftware/ankihub/pull/3673) — adds the `x-init` autofocus on `#chatbot-user-input` in the chatbot template. Without the web PR the input never calls `.focus()`; without this addon PR the input call has no effect because the QtWebEngine host widget lacks focus. Both must ship together.

## Proposed changes
Calls `self.content_webview.setFocus()` in `ReviewerSidebar.show_chatbot` and again from `_on_content_page_loaded` when the loaded page is the chatbot. QtWebEngine blocks programmatic focus on the input element until the host webview widget itself has focus — without this the cursor never lands in the chat input on open, forcing users to click the box before typing.

## How to reproduce
1. Check out this branch in the addon repo and the matching [ankihub PR #3673](https://github.com/AnkiHubSoftware/ankihub/pull/3673) branch in the web app
2. Run both locally (addon loaded in Anki, web app pointed at by `app_url`)
3. Open Anki with a deck that has the AnkiHub AI chatbot enabled
4. Start a review and click the chatbot button to open the sidebar
5. Before: cursor not in the text box — user has to click the input before typing
6. After: cursor blinks in the chat input as soon as the sidebar opens; typing works immediately

## Screenshots and videos
N/A — focus behavior; verify by opening the chatbot sidebar and typing without clicking.

## Further comments
Two \`setFocus()\` calls (one synchronous on open, one on loadFinished) cover both the initial navigation and the case where the page finishes loading after the open call returns. Scoped to \`SidebarPageType.CHATBOT\` in the load callback so other sidebar pages (B&B, FA) are unaffected.

[NRT-713]: https://ankihub.atlassian.net/browse/NRT-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ