### PR TITLE
[NRT-748] Refactor choose_subset into a class-based dialog

### DIFF
--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -111,24 +111,25 @@ class _ChooseSubsetDialog(QDialog):
         checked_and_disabled_choices_tooltip: Optional[str],
     ):
         super().__init__(parent)
-        self._locked_set = set(checked_and_disabled_choices or [])
         self._interactive_items: List[QListWidgetItem] = []
-        self._require_at_least_one = require_at_least_one
-        self._disable_ok_when_unchanged = disable_ok_when_unchanged
-        self._baseline_selection = sorted(c for c in current if c not in self._locked_set)
+        locked_set = set(checked_and_disabled_choices or [])
 
         self._setup_window(title)
         layout = QVBoxLayout()
         self.setLayout(layout)
         self._add_prompt(layout, prompt)
-        self._add_list(layout, choices, current, checked_and_disabled_choices_tooltip)
+        self._add_list(layout, choices, current, locked_set, checked_and_disabled_choices_tooltip)
         self._add_description(layout, description_html)
         self._add_buttons(layout, buttons, select_all_text)
 
         if adjust_height_to_content:
             self._adjust_list_height()
         if require_at_least_one or disable_ok_when_unchanged:
-            self._wire_accept_button_state()
+            self._wire_accept_button_state(
+                require_at_least_one=require_at_least_one,
+                disable_ok_when_unchanged=disable_ok_when_unchanged,
+                baseline_selection=sorted(c for c in current if c not in locked_set),
+            )
 
     def _setup_window(self, title: str) -> None:
         disable_help_button(self)
@@ -147,12 +148,13 @@ class _ChooseSubsetDialog(QDialog):
         layout: QVBoxLayout,
         choices: List[str],
         current: List[str],
+        locked_set: set,
         locked_tooltip: Optional[str],
     ) -> None:
         self._list_widget = CustomListWidget()
         for choice in choices:
             item = QListWidgetItem(choice)
-            if choice in self._locked_set:
+            if choice in locked_set:
                 item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable & ~Qt.ItemFlag.ItemIsEnabled)  # type: ignore
                 item.setCheckState(Qt.CheckState.Checked)
                 if locked_tooltip:
@@ -179,7 +181,6 @@ class _ChooseSubsetDialog(QDialog):
         select_all_button = QPushButton(select_all_text)
         qconnect(select_all_button.clicked, self._select_all)
 
-        # Accept/reject buttons live in a standard button box on the right
         self._button_box = QDialogButtonBox()
         if buttons:
             for button_param in buttons:
@@ -201,15 +202,19 @@ class _ChooseSubsetDialog(QDialog):
         self._list_widget.setMinimumHeight(self._list_widget.sizeHintForRow(0) * self._list_widget.count() + 20)
 
     def _select_all(self) -> None:
-        """Toggle all interactive items; deselect all if they're already all selected."""
         all_selected = all(item.checkState() == Qt.CheckState.Checked for item in self._interactive_items)
         new_state = Qt.CheckState.Unchecked if all_selected else Qt.CheckState.Checked
         for item in self._interactive_items:
             item.setCheckState(new_state)
 
-    def _wire_accept_button_state(self) -> None:
-        """Keep the accept button enabled/disabled in sync with the current
-        selection, based on require_at_least_one and disable_ok_when_unchanged."""
+    def _wire_accept_button_state(
+        self,
+        *,
+        require_at_least_one: bool,
+        disable_ok_when_unchanged: bool,
+        baseline_selection: List[str],
+    ) -> None:
+        """Keep the accept button enabled/disabled in sync with the current selection."""
         accept_button = next(
             (
                 button
@@ -222,16 +227,16 @@ class _ChooseSubsetDialog(QDialog):
             return
 
         def update() -> None:
-            if self._require_at_least_one and not any(
+            if require_at_least_one and not any(
                 item.checkState() == Qt.CheckState.Checked for item in self._interactive_items
             ):
                 accept_button.setEnabled(False)
                 return
-            if self._disable_ok_when_unchanged:
+            if disable_ok_when_unchanged:
                 current_selection = sorted(
                     item.text() for item in self._interactive_items if item.checkState() == Qt.CheckState.Checked
                 )
-                if current_selection == self._baseline_selection:
+                if current_selection == baseline_selection:
                     accept_button.setEnabled(False)
                     return
             accept_button.setEnabled(True)

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -89,6 +89,160 @@ def _show_tooltip(message: str, *args, **kwargs) -> None:
             raise e
 
 
+class _ChooseSubsetDialog(QDialog):
+    """Modal dialog backing choose_subset(). Pre-fills checkboxes from `current`,
+    supports a locked (checked + non-interactive) subset, and exposes the user's
+    final selection via selected_choices()."""
+
+    def __init__(
+        self,
+        prompt: str,
+        choices: List[str],
+        current: List[str],
+        adjust_height_to_content: bool,
+        description_html: Optional[str],
+        buttons: Optional[Sequence[ButtonParam]],
+        title: str,
+        parent: Any,
+        require_at_least_one: bool,
+        select_all_text: str,
+        disable_ok_when_unchanged: bool,
+        checked_and_disabled_choices: Optional[List[str]],
+        checked_and_disabled_choices_tooltip: Optional[str],
+    ):
+        super().__init__(parent)
+        self._locked_set = set(checked_and_disabled_choices or [])
+        self._interactive_items: List[QListWidgetItem] = []
+        self._require_at_least_one = require_at_least_one
+        self._disable_ok_when_unchanged = disable_ok_when_unchanged
+        self._baseline_selection = sorted(c for c in current if c not in self._locked_set)
+
+        self._setup_window(title)
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        self._add_prompt(layout, prompt)
+        self._add_list(layout, choices, current, checked_and_disabled_choices_tooltip)
+        self._add_description(layout, description_html)
+        self._add_buttons(layout, buttons, select_all_text)
+
+        if adjust_height_to_content:
+            self._adjust_list_height()
+        if require_at_least_one or disable_ok_when_unchanged:
+            self._wire_accept_button_state()
+
+    def _setup_window(self, title: str) -> None:
+        disable_help_button(self)
+        self.setWindowTitle(title)
+        self.setMinimumWidth(350)
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+
+    def _add_prompt(self, layout: QVBoxLayout, prompt: str) -> None:
+        label = QLabel(prompt)
+        label.setOpenExternalLinks(True)
+        label.setWordWrap(True)
+        layout.addWidget(label)
+
+    def _add_list(
+        self,
+        layout: QVBoxLayout,
+        choices: List[str],
+        current: List[str],
+        locked_tooltip: Optional[str],
+    ) -> None:
+        self._list_widget = CustomListWidget()
+        for choice in choices:
+            item = QListWidgetItem(choice)
+            if choice in self._locked_set:
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable & ~Qt.ItemFlag.ItemIsEnabled)  # type: ignore
+                item.setCheckState(Qt.CheckState.Checked)
+                if locked_tooltip:
+                    item.setToolTip(locked_tooltip)
+            else:
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
+                item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)
+                self._interactive_items.append(item)
+            self._list_widget.addItem(item)
+        layout.addWidget(self._list_widget)
+        layout.addSpacing(5)
+
+    def _add_description(self, layout: QVBoxLayout, description_html: Optional[str]) -> None:
+        if description_html:
+            layout.addWidget(QLabel(f"<i>{description_html}</i>"))
+        layout.addSpacing(10)
+
+    def _add_buttons(
+        self,
+        layout: QVBoxLayout,
+        buttons: Optional[Sequence[ButtonParam]],
+        select_all_text: str,
+    ) -> None:
+        select_all_button = QPushButton(select_all_text)
+        qconnect(select_all_button.clicked, self._select_all)
+
+        # Accept/reject buttons live in a standard button box on the right
+        self._button_box = QDialogButtonBox()
+        if buttons:
+            for button_param in buttons:
+                add_button_from_param(self._button_box, button_param)
+        else:
+            self._button_box.addButton(QDialogButtonBox.StandardButton.Cancel)
+            self._button_box.addButton(QDialogButtonBox.StandardButton.Ok)
+        qconnect(self._button_box.accepted, self.accept)
+        qconnect(self._button_box.rejected, self.reject)
+
+        # Select All on the left, accept/reject on the right
+        button_row = QHBoxLayout()
+        button_row.addWidget(select_all_button)
+        button_row.addStretch()
+        button_row.addWidget(self._button_box)
+        layout.addLayout(button_row)
+
+    def _adjust_list_height(self) -> None:
+        self._list_widget.setMinimumHeight(self._list_widget.sizeHintForRow(0) * self._list_widget.count() + 20)
+
+    def _select_all(self) -> None:
+        """Toggle all interactive items; deselect all if they're already all selected."""
+        all_selected = all(item.checkState() == Qt.CheckState.Checked for item in self._interactive_items)
+        new_state = Qt.CheckState.Unchecked if all_selected else Qt.CheckState.Checked
+        for item in self._interactive_items:
+            item.setCheckState(new_state)
+
+    def _wire_accept_button_state(self) -> None:
+        """Keep the accept button enabled/disabled in sync with the current
+        selection, based on require_at_least_one and disable_ok_when_unchanged."""
+        accept_button = next(
+            (
+                button
+                for button in self._button_box.buttons()
+                if self._button_box.buttonRole(button) == QDialogButtonBox.ButtonRole.AcceptRole
+            ),
+            None,
+        )
+        if not accept_button:
+            return
+
+        def update() -> None:
+            if self._require_at_least_one and not any(
+                item.checkState() == Qt.CheckState.Checked for item in self._interactive_items
+            ):
+                accept_button.setEnabled(False)
+                return
+            if self._disable_ok_when_unchanged:
+                current_selection = sorted(
+                    item.text() for item in self._interactive_items if item.checkState() == Qt.CheckState.Checked
+                )
+                if current_selection == self._baseline_selection:
+                    accept_button.setEnabled(False)
+                    return
+            accept_button.setEnabled(True)
+
+        qconnect(self._list_widget.itemChanged, lambda _: update())
+        update()
+
+    def selected_choices(self) -> List[str]:
+        return [item.text() for item in self._interactive_items if item.checkState() == Qt.CheckState.Checked]
+
+
 def choose_subset(
     prompt: str,
     choices: List[str],
@@ -112,121 +266,24 @@ def choose_subset(
 
     Returns the selected choices, or None if the dialog was cancelled.
     """
-    if not parent:
-        parent = active_window_or_mw()
-
-    locked_set = set(checked_and_disabled_choices or [])
-
-    dialog = QDialog(parent)
-    disable_help_button(dialog)
-    dialog.setWindowTitle(title)
-    dialog.setMinimumWidth(350)
-
-    dialog.setWindowModality(Qt.WindowModality.ApplicationModal)
-    layout = QVBoxLayout()
-    dialog.setLayout(layout)
-
-    label = QLabel(prompt)
-    label.setOpenExternalLinks(True)
-    label.setWordWrap(True)
-    layout.addWidget(label)
-    list_widget = CustomListWidget()
-    layout.addWidget(list_widget)
-    layout.addSpacing(5)
-
-    # Populate list items; disabled choices appear checked and non-interactive
-    interactive_items: List[QListWidgetItem] = []
-    for choice in choices:
-        item = QListWidgetItem(choice)
-        if choice in locked_set:
-            item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable & ~Qt.ItemFlag.ItemIsEnabled)  # type: ignore
-            item.setCheckState(Qt.CheckState.Checked)
-            if checked_and_disabled_choices_tooltip:
-                item.setToolTip(checked_and_disabled_choices_tooltip)
-        else:
-            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
-            item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)
-            interactive_items.append(item)
-        list_widget.addItem(item)
-
-    if description_html:
-        label = QLabel(f"<i>{description_html}</i>")
-        layout.addWidget(label)
-
-    layout.addSpacing(10)
-
-    # "Select All" toggles all interactive items; deselects all if all are already selected
-    def select_all() -> None:
-        all_selected = all(item.checkState() == Qt.CheckState.Checked for item in interactive_items)
-        new_state = Qt.CheckState.Unchecked if all_selected else Qt.CheckState.Checked
-        for item in interactive_items:
-            item.setCheckState(new_state)
-
-    select_all_button = QPushButton(select_all_text)
-    qconnect(select_all_button.clicked, select_all)
-
-    # Accept/reject buttons live in a standard button box on the right
-    button_box = QDialogButtonBox()
-    if buttons:
-        for button_param in buttons:
-            add_button_from_param(button_box, button_param)
-    else:
-        button_box.addButton(QDialogButtonBox.StandardButton.Cancel)
-        button_box.addButton(QDialogButtonBox.StandardButton.Ok)
-    qconnect(button_box.accepted, dialog.accept)
-    qconnect(button_box.rejected, dialog.reject)
-
-    # Select All on the left, accept/reject on the right
-    button_row = QHBoxLayout()
-    button_row.addWidget(select_all_button)
-    button_row.addStretch()
-    button_row.addWidget(button_box)
-    layout.addLayout(button_row)
-
-    if adjust_height_to_content:
-        list_widget.setMinimumHeight(list_widget.sizeHintForRow(0) * list_widget.count() + 20)
-        # Pin the dialog's min height to its content-fitting size; otherwise the user can
-        # drag the dialog shorter than the list's minimum and Qt lets the description label
-        # / buttons overlap the bottom list rows.
-        dialog.adjustSize()
-        dialog.setMinimumHeight(dialog.height())
-
-    # Manage OK button enabled state based on require_at_least_one / disable_ok_when_unchanged
-    if require_at_least_one or disable_ok_when_unchanged:
-        accept_button = next(
-            (
-                button
-                for button in button_box.buttons()
-                if button_box.buttonRole(button) == QDialogButtonBox.ButtonRole.AcceptRole
-            ),
-            None,
-        )
-        baseline_selection = sorted(c for c in current if c not in locked_set)
-
-        def update_accept_button_state():
-            if not accept_button:
-                return
-            if require_at_least_one and not any(
-                item.checkState() == Qt.CheckState.Checked for item in interactive_items
-            ):
-                accept_button.setEnabled(False)
-                return
-            if disable_ok_when_unchanged:
-                current_selection = sorted(
-                    item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked
-                )
-                if current_selection == baseline_selection:
-                    accept_button.setEnabled(False)
-                    return
-            accept_button.setEnabled(True)
-
-        qconnect(list_widget.itemChanged, lambda _: update_accept_button_state())
-        update_accept_button_state()
-
+    dialog = _ChooseSubsetDialog(
+        prompt=prompt,
+        choices=choices,
+        current=current,
+        adjust_height_to_content=adjust_height_to_content,
+        description_html=description_html,
+        buttons=buttons,
+        title=title,
+        parent=parent or active_window_or_mw(),
+        require_at_least_one=require_at_least_one,
+        select_all_text=select_all_text,
+        disable_ok_when_unchanged=disable_ok_when_unchanged,
+        checked_and_disabled_choices=checked_and_disabled_choices,
+        checked_and_disabled_choices_tooltip=checked_and_disabled_choices_tooltip,
+    )
     if dialog.exec() != QDialog.DialogCode.Accepted:
         return None
-
-    return [item.text() for item in interactive_items if item.checkState() == Qt.CheckState.Checked]
+    return dialog.selected_choices()
 
 
 class SearchableSelectionDialog(StudyDeck):

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -181,21 +181,21 @@ class _ChooseSubsetDialog(QDialog):
         select_all_button = QPushButton(select_all_text)
         qconnect(select_all_button.clicked, self._select_all)
 
-        self._button_box = QDialogButtonBox()
+        self.button_box = QDialogButtonBox()
         if buttons:
             for button_param in buttons:
-                add_button_from_param(self._button_box, button_param)
+                add_button_from_param(self.button_box, button_param)
         else:
-            self._button_box.addButton(QDialogButtonBox.StandardButton.Cancel)
-            self._button_box.addButton(QDialogButtonBox.StandardButton.Ok)
-        qconnect(self._button_box.accepted, self.accept)
-        qconnect(self._button_box.rejected, self.reject)
+            self.button_box.addButton(QDialogButtonBox.StandardButton.Cancel)
+            self.button_box.addButton(QDialogButtonBox.StandardButton.Ok)
+        qconnect(self.button_box.accepted, self.accept)
+        qconnect(self.button_box.rejected, self.reject)
 
         # Select All on the left, accept/reject on the right
         button_row = QHBoxLayout()
         button_row.addWidget(select_all_button)
         button_row.addStretch()
-        button_row.addWidget(self._button_box)
+        button_row.addWidget(self.button_box)
         layout.addLayout(button_row)
 
     def _adjust_list_height(self) -> None:
@@ -218,13 +218,15 @@ class _ChooseSubsetDialog(QDialog):
         accept_button = next(
             (
                 button
-                for button in self._button_box.buttons()
-                if self._button_box.buttonRole(button) == QDialogButtonBox.ButtonRole.AcceptRole
+                for button in self.button_box.buttons()
+                if self.button_box.buttonRole(button) == QDialogButtonBox.ButtonRole.AcceptRole
             ),
             None,
         )
-        if not accept_button:
-            return
+        assert accept_button is not None, (
+            "require_at_least_one / disable_ok_when_unchanged need a button with AcceptRole; "
+            "custom `buttons` lists must include one."
+        )
 
         def update() -> None:
             if require_at_least_one and not any(

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -2,7 +2,7 @@ import inspect
 import uuid
 from functools import partial, wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union
 
 import aqt
 from anki.decks import DeckId
@@ -148,7 +148,7 @@ class _ChooseSubsetDialog(QDialog):
         layout: QVBoxLayout,
         choices: List[str],
         current: List[str],
-        locked_set: set,
+        locked_set: Set[str],
         locked_tooltip: Optional[str],
     ) -> None:
         self._list_widget = CustomListWidget()

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -200,6 +200,11 @@ class _ChooseSubsetDialog(QDialog):
 
     def _adjust_list_height(self) -> None:
         self._list_widget.setMinimumHeight(self._list_widget.sizeHintForRow(0) * self._list_widget.count() + 20)
+        # Pin the dialog's min height to its content-fitting size; otherwise the
+        # user can drag the dialog shorter than the list's minimum and Qt will
+        # let the description label / buttons overlap the bottom rows.
+        self.adjustSize()
+        self.setMinimumHeight(self.height())
 
     def _select_all(self) -> None:
         all_selected = all(item.checkState() == Qt.CheckState.Checked for item in self._interactive_items)


### PR DESCRIPTION
Reviewability follow-up surfaced during the review of [#1259](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1259) (now merged); rebased onto `main`.

## Related issues
- [NRT-748](https://ankihub.atlassian.net/browse/NRT-748) (subtask of [NRT-508](https://ankihub.atlassian.net/browse/NRT-508); this PR is a reviewability follow-up surfaced during the NRT-748 review)

## Why

`choose_subset` was ~130 lines of linear dialog setup (window config, list population, button row, Select All wiring, accept-button state validation, exec) all in one function. It was on the long side for review — hard to skim, hard to see where each concern lives.

The codebase already has a class-based pattern for this in `_Dialog` at `gui/utils.py`. Applying the same pattern here.

## What

- Extract `_ChooseSubsetDialog(QDialog)` with one method per setup step: `_setup_window`, `_add_prompt`, `_add_list`, `_add_description`, `_add_buttons`, `_adjust_list_height`, `_select_all`, `_wire_accept_button_state`, plus a `selected_choices()` accessor.
- `choose_subset()` becomes a thin facade: construct the dialog, exec, return the selection.
- Per-init state (`locked_set`, `baseline_selection`, validation flags) is passed as args rather than stored on `self`, since each is consumed by exactly one downstream method.
- Naming aligns with `_Dialog` (`self.button_box`, not `self._button_box`).

## Behavior changes

The refactor is mostly behavior-neutral, with one defensive change: `_wire_accept_button_state` now asserts a button with `AcceptRole` exists. Previously, if a caller passed a custom `buttons` list without `AcceptRole` while also setting `require_at_least_one` / `disable_ok_when_unchanged`, the constraint silently no-op'd. No current caller hits this; the assert is a forward-looking guardrail.

## Test plan

- [ ] Existing test coverage of callers (`_on_protect_fields_action` in `TestProtectFields*`, "Publish fields" flow in deck management) continues to pass.
- [ ] Manual: open Protect fields from the browser — confirm dialog renders, OK disabled when nothing changes, Cancel closes without applying, Select All toggles, locked items are greyed out.

[NRT-508]: https://ankihub.atlassian.net/browse/NRT-508


[NRT-748]: https://ankihub.atlassian.net/browse/NRT-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


