### PR TITLE
[NRT-769] Fix: 'Reset local changes' doesn't reset fields with AnkiHub_Protect tags

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -55,6 +55,7 @@ from ...main.importing import get_fields_protected_by_tags
 from ...main.note_conversion import (
     TAG_FOR_PROTECTING_ALL_FIELDS,
     TAG_FOR_PROTECTING_FIELDS,
+    is_protect_tag,
     optional_tag_prefix_for_group,
     protection_tag_for_field,
 )
@@ -399,7 +400,7 @@ def _on_protect_fields_action(browser: Browser, nids: Sequence[NoteId]) -> None:
         for note in notes:
             preserved_tags = [tag for tag in note.tags if tag.lower() in globally_protected_tag_set_lower]
             # remove old tags for protecting fields
-            note.tags = [tag for tag in note.tags if not tag.lower().startswith(TAG_FOR_PROTECTING_FIELDS.lower())]
+            note.tags = [tag for tag in note.tags if not is_protect_tag(tag)]
 
             # add new tags for protecting fields, plus tags preserved for globally-protected fields
             note.tags += new_tags_for_protecting_fields + preserved_tags

--- a/ankihub/main/note_conversion.py
+++ b/ankihub/main/note_conversion.py
@@ -41,6 +41,15 @@ def is_internal_tag(tag: str) -> bool:
     return bool(INTERNAL_TAGS_REGEX.match(tag))
 
 
+def is_protect_tag(tag: str) -> bool:
+    """True for `AnkiHub_Protect::<field>` and `AnkiHub_Protect::All` (case-insensitive).
+
+    Does not match the bare `AnkiHub_Protect` top-level tag — `protection_tag_for_field`
+    always appends `::<field>`.
+    """
+    return tag.lower().startswith(f"{TAG_FOR_PROTECTING_FIELDS}::".lower())
+
+
 def is_optional_tag(tag: str) -> bool:
     return bool(OPTIONAL_TAG_REGEX.match(tag))
 

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -13,7 +13,7 @@ from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
 from .importing import AnkiHubImporter
-from .note_conversion import is_protect_tag
+from .note_conversion import is_protect_tag, protection_tag_for_field
 
 
 def reset_local_changes_to_notes(
@@ -32,8 +32,11 @@ def reset_local_changes_to_notes(
     # by the user or the auto-protect-on-edit hook to keep specific fields from
     # being overwritten on sync. "Reset local changes" wipes local state, so strip
     # them first; otherwise the importer's `_prepare_fields` honours them and
-    # refuses to reset the very fields the user edited.
-    _strip_personal_protect_tags(nids)
+    # refuses to reset the very fields the user edited. Tags matching a currently
+    # globally-protected field are preserved — they encode user intent that should
+    # survive if global protection is later removed (same convention as the
+    # browser "Protect Fields" dialog).
+    _strip_personal_protect_tags(nids, ah_did)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)
     note_types = {
@@ -63,7 +66,7 @@ def reset_local_changes_to_notes(
     ankihub_db.reset_mod_values_in_anki_db(list(nids))
 
 
-def _strip_personal_protect_tags(nids: Sequence[NoteId]) -> None:
+def _strip_personal_protect_tags(nids: Sequence[NoteId], ah_did: uuid.UUID) -> None:
     # Some nids may refer to locally-deleted notes — the importer recreates them
     # later in the reset flow, so silently skip them here.
     changed = []
@@ -72,7 +75,11 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId]) -> None:
             note = aqt.mw.col.get_note(nid)
         except NotFoundError:
             continue
-        new_tags = [t for t in note.tags if not is_protect_tag(t)]
+        preserved = {
+            protection_tag_for_field(f).lower()
+            for f in config.globally_protected_fields_for_note_type(ah_did, note.mid)
+        }
+        new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
             note.tags = new_tags
             changed.append(note)

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Sequence
 
 import aqt
+from anki.errors import NotFoundError
 from anki.notes import NoteId
 
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
@@ -63,9 +64,14 @@ def reset_local_changes_to_notes(
 
 
 def _strip_personal_protect_tags(nids: Sequence[NoteId]) -> None:
+    # Some nids may refer to locally-deleted notes — the importer recreates them
+    # later in the reset flow, so silently skip them here.
     changed = []
     for nid in nids:
-        note = aqt.mw.col.get_note(nid)
+        try:
+            note = aqt.mw.col.get_note(nid)
+        except NotFoundError:
+            continue
         new_tags = [t for t in note.tags if not is_protect_tag(t)]
         if new_tags != note.tags:
             note.tags = new_tags

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -28,14 +28,14 @@ def reset_local_changes_to_notes(
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
 
-    # Personal-protect tags (AnkiHub_Protect::*) are part of local state — added
-    # by the user or the auto-protect-on-edit hook to keep specific fields from
-    # being overwritten on sync. "Reset local changes" wipes local state, so strip
-    # them first; otherwise the importer's `_prepare_fields` honours them and
-    # refuses to reset the very fields the user edited. Tags matching a currently
-    # globally-protected field are preserved — they encode user intent that should
-    # survive if global protection is later removed (same convention as the
-    # browser "Protect Fields" dialog).
+    # Personal-protect tags (AnkiHub_Protect::*) block the importer's
+    # `_prepare_fields` from resetting their field. Strip them so Reset actually
+    # resets; otherwise the very fields the user edited stay edited (especially
+    # visible since the NRT-748 auto-protect-on-edit hook started adding these
+    # tags automatically). Tags matching a currently globally-protected field
+    # are preserved — those fields are typically the user's personal content
+    # (e.g. Lecture Notes) that should outlive a later removal of global
+    # protection; same convention as the browser "Protect Fields" dialog.
     _strip_personal_protect_tags(nids, ah_did)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -12,7 +12,7 @@ from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
 from .importing import AnkiHubImporter
-from .note_conversion import TAG_FOR_PROTECTING_FIELDS
+from .note_conversion import is_protect_tag
 
 
 def reset_local_changes_to_notes(
@@ -63,11 +63,10 @@ def reset_local_changes_to_notes(
 
 
 def _strip_personal_protect_tags(nids: Sequence[NoteId]) -> None:
-    prefix = f"{TAG_FOR_PROTECTING_FIELDS}::".lower()
     changed = []
     for nid in nids:
         note = aqt.mw.col.get_note(nid)
-        new_tags = [t for t in note.tags if not t.lower().startswith(prefix)]
+        new_tags = [t for t in note.tags if not is_protect_tag(t)]
         if new_tags != note.tags:
             note.tags = new_tags
             changed.append(note)

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -3,7 +3,7 @@
 """
 
 import uuid
-from typing import Sequence
+from typing import Dict, List, Sequence
 
 import aqt
 from anki.errors import NotFoundError
@@ -36,7 +36,7 @@ def reset_local_changes_to_notes(
     # are preserved — those fields are typically the user's personal content
     # (e.g. Lecture Notes) that should outlive a later removal of global
     # protection; same convention as the browser "Protect Fields" dialog.
-    _strip_personal_protect_tags(nids, ah_did)
+    _strip_personal_protect_tags(nids, protected_fields)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)
     note_types = {
@@ -66,19 +66,19 @@ def reset_local_changes_to_notes(
     ankihub_db.reset_mod_values_in_anki_db(list(nids))
 
 
-def _strip_personal_protect_tags(nids: Sequence[NoteId], ah_did: uuid.UUID) -> None:
+def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[int, List[str]]) -> None:
     # Some nids may refer to locally-deleted notes — the importer recreates them
     # later in the reset flow, so silently skip them here.
+    # `protected_fields` is the same freshly-fetched dict passed to the importer,
+    # so preservation and the importer's reset decisions stay in lockstep even if
+    # the cached config is stale.
     changed = []
     for nid in nids:
         try:
             note = aqt.mw.col.get_note(nid)
         except NotFoundError:
             continue
-        preserved = {
-            protection_tag_for_field(f).lower()
-            for f in config.globally_protected_fields_for_note_type(ah_did, note.mid)
-        }
+        preserved = {protection_tag_for_field(f).lower() for f in protected_fields.get(note.mid, [])}
         new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
             note.tags = new_tags

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -5,12 +5,14 @@
 import uuid
 from typing import Sequence
 
+import aqt
 from anki.notes import NoteId
 
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
 from .importing import AnkiHubImporter
+from .note_conversion import TAG_FOR_PROTECTING_FIELDS
 
 
 def reset_local_changes_to_notes(
@@ -24,6 +26,13 @@ def reset_local_changes_to_notes(
     client = AnkiHubClient()
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
+
+    # Personal-protect tags (AnkiHub_Protect[::field]) are part of local state —
+    # added by the user or the auto-protect-on-edit hook to keep specific fields
+    # from being overwritten on sync. "Reset local changes" wipes local state,
+    # so strip them first; otherwise the importer's `_prepare_fields` honours
+    # them and refuses to reset the very fields the user edited.
+    _strip_personal_protect_tags(nids)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)
     note_types = {
@@ -51,3 +60,16 @@ def reset_local_changes_to_notes(
 
     # this way the notes won't be marked as "changed after sync" anymore
     ankihub_db.reset_mod_values_in_anki_db(list(nids))
+
+
+def _strip_personal_protect_tags(nids: Sequence[NoteId]) -> None:
+    prefix = f"{TAG_FOR_PROTECTING_FIELDS}::".lower()
+    changed = []
+    for nid in nids:
+        note = aqt.mw.col.get_note(nid)
+        new_tags = [t for t in note.tags if not t.lower().startswith(prefix)]
+        if new_tags != note.tags:
+            note.tags = new_tags
+            changed.append(note)
+    if changed:
+        aqt.mw.col.update_notes(changed)

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -28,11 +28,11 @@ def reset_local_changes_to_notes(
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
 
-    # Personal-protect tags (AnkiHub_Protect[::field]) are part of local state —
-    # added by the user or the auto-protect-on-edit hook to keep specific fields
-    # from being overwritten on sync. "Reset local changes" wipes local state,
-    # so strip them first; otherwise the importer's `_prepare_fields` honours
-    # them and refuses to reset the very fields the user edited.
+    # Personal-protect tags (AnkiHub_Protect::*) are part of local state — added
+    # by the user or the auto-protect-on-edit hook to keep specific fields from
+    # being overwritten on sync. "Reset local changes" wipes local state, so strip
+    # them first; otherwise the importer's `_prepare_fields` honours them and
+    # refuses to reset the very fields the user edited.
     _strip_personal_protect_tags(nids)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5372,19 +5372,22 @@ def test_reset_local_changes_to_notes(
         basic_note_1 = mw.col.get_note(NoteId(1608240029527))
         basic_note_2 = mw.col.get_note(NoteId(1608240057545))
 
-        # change the content of a note, tag the edited field as personally-protected
-        # (mirrors what the auto-protect-on-edit hook does on real edits), and move
-        # the note to a different deck
-        basic_note_1["Front"] = "changed"
-        basic_note_1.tags = ["AnkiHub_Protect::Front"]
+        # Edit Front + Back, tag both as personally-protected (mirrors the auto-protect
+        # hook's behaviour on real edits), and move the note to a different deck. Back is
+        # also marked as globally protected for this note type — its protect tag should
+        # survive the reset (user-authored intent that should outlast global protection).
+        basic_note_1["Front"] = "changed front"
+        basic_note_1["Back"] = "changed back"
+        basic_note_1.tags = ["AnkiHub_Protect::Front", "AnkiHub_Protect::Back"]
         basic_note_1.flush()
         mw.col.set_deck(basic_note_1.card_ids(), 1)
+        config.set_globally_protected_fields(ah_did, {basic_note_1.mid: ["Back"]})
 
         # delete a note
         mw.col.remove_notes([basic_note_2.id])
 
         # mock the client functions that are called to get the data needed for resetting local changes
-        mocker.patch.object(AnkiHubClient, "get_protected_fields")
+        mocker.patch.object(AnkiHubClient, "get_protected_fields", return_value={basic_note_1.mid: ["Back"]})
         mocker.patch.object(AnkiHubClient, "get_protected_tags")
         mock_client_get_note_type([note_type for note_type in mw.col.models.all()])
 
@@ -5392,13 +5395,15 @@ def test_reset_local_changes_to_notes(
         nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
         reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
 
-        # assert that basic_note_1 was changed back is still in the deck it was moved to
-        # (resetting local changes to notes should not move existing notes between decks as the
-        # user might not want that). The personal-protect tag must also be stripped, otherwise
-        # the importer would have honoured it and skipped resetting Front.
+        # Front: not globally protected → personal-protect tag stripped, field reset.
+        # Back: globally protected → field stays edited (importer respects protected_fields)
+        # and the personal-protect tag survives.
+        # Note is still in the deck it was moved to (Reset shouldn't move cards between decks).
         basic_note_1.load()
         assert basic_note_1["Front"] == "This is the front 1"
-        assert not any(t.lower().startswith("ankihub_protect::") for t in basic_note_1.tags)
+        assert basic_note_1["Back"] == "changed back"
+        assert "AnkiHub_Protect::Front" not in basic_note_1.tags
+        assert "AnkiHub_Protect::Back" in basic_note_1.tags
         assert basic_note_1.cards()
         for card in basic_note_1.cards():
             assert card.did == 1

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5372,8 +5372,11 @@ def test_reset_local_changes_to_notes(
         basic_note_1 = mw.col.get_note(NoteId(1608240029527))
         basic_note_2 = mw.col.get_note(NoteId(1608240057545))
 
-        # change the content of a note and move it to a different deck
+        # change the content of a note, tag the edited field as personally-protected
+        # (mirrors what the auto-protect-on-edit hook does on real edits), and move
+        # the note to a different deck
         basic_note_1["Front"] = "changed"
+        basic_note_1.tags = ["AnkiHub_Protect::Front"]
         basic_note_1.flush()
         mw.col.set_deck(basic_note_1.card_ids(), 1)
 
@@ -5391,9 +5394,11 @@ def test_reset_local_changes_to_notes(
 
         # assert that basic_note_1 was changed back is still in the deck it was moved to
         # (resetting local changes to notes should not move existing notes between decks as the
-        # user might not want that)
+        # user might not want that). The personal-protect tag must also be stripped, otherwise
+        # the importer would have honoured it and skipped resetting Front.
         basic_note_1.load()
         assert basic_note_1["Front"] == "This is the front 1"
+        assert not any(t.lower().startswith("ankihub_protect::") for t in basic_note_1.tags)
         assert basic_note_1.cards()
         for card in basic_note_1.cards():
             assert card.did == 1

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -5381,7 +5381,6 @@ def test_reset_local_changes_to_notes(
         basic_note_1.tags = ["AnkiHub_Protect::Front", "AnkiHub_Protect::Back"]
         basic_note_1.flush()
         mw.col.set_deck(basic_note_1.card_ids(), 1)
-        config.set_globally_protected_fields(ah_did, {basic_note_1.mid: ["Back"]})
 
         # delete a note
         mw.col.remove_notes([basic_note_2.id])


### PR DESCRIPTION
## Related issues
- [NRT-769](https://ankihub.atlassian.net/browse/NRT-769)
- Surfaced by [#1259](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1259) / [NRT-748](https://ankihub.atlassian.net/browse/NRT-748) (auto-protect-on-edit)

## Proposed changes

Pre-existing issue, made far more visible by auto-protect-on-edit:

`AnkiHubImporter._prepare_fields` has always honoured `AnkiHub_Protect::<Field>` tags and refused to reset any field that carries one. Historically this only mattered if a user manually opened the "Protect Fields" dialog and protected something, so "Reset local changes" *seemed* to work for most people. NRT-748 added a hook that silently tags every edited field with `AnkiHub_Protect::<Field>` — now every field a user touches in the editor is implicitly protected, and Reset becomes a no-op for that field.

The bug:

1. Edit `Front` in the editor → (with the auto-protect flag on) `AnkiHub_Protect::Front` is added to the note.
2. Right-click → Reset local changes → `_prepare_fields` calls `get_fields_protected_by_tags(note)` → returns `["Front"]` → **skips resetting Front**.
3. `_prepare_tags` treats `AnkiHub_Protect::*` as an internal tag and preserves it, so the protect tag survives too.

Net: the edited field stays edited, and the "Reset local changes for selected notes" tooltip lies.

### Fix

In `reset_local_changes_to_notes`, strip `AnkiHub_Protect::*` tags from each note before invoking the importer. "Reset local changes" semantically means "wipe local state" — auto-applied protect tags are part of that, and manually-set ones are deliberately overridden by clicking Reset (the user can re-add them).

**Exception:** protect tags matching a *currently* globally-protected field are preserved. Globally-protected fields are typically the user's personal content that's empty on AnkiHub by design (Lecture Notes, Missed Questions, etc.) — the user clicking Reset wants to reset edits to shared fields, not lose their personal annotations. Preserving the tag also means the field stays protected if it later stops being globally protected. Same convention as the browser "Protect Fields" dialog (see `browser.py:390-405`). The "currently globally-protected" check uses the same freshly-fetched `protected_fields` dict that's passed to the importer, so strip preservation and field-reset decisions can't diverge if the cached config is stale.

### Other small things in this PR

- Extracted `is_protect_tag()` into `note_conversion.py` and routed both the new strip and the existing browser-dialog filter through it.
- `_strip_personal_protect_tags` skips locally-deleted nids — `reset_local_changes_to_notes` is contracted to accept them (the importer recreates them), so `aqt.mw.col.get_note()` raising `NotFoundError` is expected.

## How to reproduce

The auto-protect-on-edit hook is gated on the `auto_protect_fields_when_edited` backend feature flag (from [#1259](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1259) / [NRT-748](https://ankihub.atlassian.net/browse/NRT-748)). With the flag **on**, every field edit hits this; with the flag **off**, the bug still exists but only triggers if the user has manually tagged a field via the "Protect Fields" dialog.

1. Enable `auto_protect_fields_when_edited` for your user in the backend (or skip and manually add an `AnkiHub_Protect::Front` tag to a note).
2. Open an AnkiHub note in the editor.
3. Edit a non-globally-protected field; tab out — the auto-protect hook adds `AnkiHub_Protect::<Field>` to the note.
4. In the browser, right-click the note → **Reset local changes**.
5. Without this fix: the field stays edited and the `AnkiHub_Protect::<Field>` tag remains. With this fix: the field is reset and the tag is gone.

Also worth checking:
- A note with `AnkiHub_Protect::<GloballyProtectedField>` → after Reset, that field stays as-is **and** the protect tag survives.
- A locally-deleted nid in the selection → importer recreates it (no `NotFoundError`).

## Screenshots and videos

N/A — no visual change.

## Further comments

`AnkiHub_Protect::All` is also stripped on Reset. Manually-set per-field protect tags on non-globally-protected fields are also wiped — defensible since Reset is explicitly wiping local state, and the user can re-protect after.

[NRT-769]: https://ankihub.atlassian.net/browse/NRT-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-748]: https://ankihub.atlassian.net/browse/NRT-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-748]: https://ankihub.atlassian.net/browse/NRT-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ