### PR TITLE
[NRT-773] Deck Management dialog QA fixes

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -2,6 +2,7 @@
 
 import uuid
 from concurrent.futures import Future
+from html import escape
 from typing import List, Optional
 from uuid import UUID
 
@@ -185,6 +186,10 @@ class DeckManagementDialog(QDialog):
         self.decks_list_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
 
         self.decks_list = QListWidget()
+        # Elide long deck names with a trailing "…" instead of showing a horizontal
+        # scrollbar; the full name is available via each item's tooltip.
+        self.decks_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.decks_list.setTextElideMode(Qt.TextElideMode.ElideRight)
         qconnect(self.decks_list.itemSelectionChanged, self._refresh_box_bottom_right)
 
         box = QVBoxLayout()
@@ -883,6 +888,10 @@ class DeckManagementDialog(QDialog):
                 item = QListWidgetItem(f"{deck.name} (Maintained by you)")
             else:
                 item = QListWidgetItem(deck.name)
+            # Full name on hover, since long names are elided in the list. Wrap it in
+            # HTML so Qt renders the tooltip as a word-wrapped block instead of one long
+            # thin line; escape the name so any "<"/"&" in it isn't treated as markup.
+            item.setToolTip(f"<div>{escape(item.text())}</div>")
             item.setData(Qt.ItemDataRole.UserRole, deck)
             self.decks_list.addItem(item)
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -543,10 +543,13 @@ class DeckManagementDialog(QDialog):
             ),
         )
 
-        # Add checkbox and icon label to the result layout
+        # Add checkbox and icon label to the result layout. The trailing stretch keeps
+        # the icon next to the (multi-line) checkbox instead of being pushed to the far
+        # right of the wide panel, matching the other checkbox/icon rows.
         box = QHBoxLayout()
         box.addWidget(self.ankihub_deleted_notes_behavior_cb)
         box.addWidget(self.ankihub_deleted_notes_behavior_icon_label)
+        box.addStretch()
 
         return box
 
@@ -665,7 +668,6 @@ class DeckManagementDialog(QDialog):
         qconnect(self.update_templates_btn.clicked, self._on_update_templates_btn_clicked)
         self._update_templates_btn_state()
         box.addWidget(self.note_types_label)
-        box.addSpacing(8)
         # Group the buttons in their own layout with tight spacing so they sit close
         # together, independent of the parent layout's larger default item spacing.
         buttons_layout = QVBoxLayout()

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -281,9 +281,9 @@ class DeckManagementDialog(QDialog):
         # Initialize and setup the unsubscribe button
         self.unsubscribe_btn = QPushButton("Unsubscribe")
         if theme_manager.night_mode:
-            self.unsubscribe_btn.setStyleSheet("color: #e29792")
+            self.unsubscribe_btn.setStyleSheet("color: #f5a19f")
         else:
-            self.unsubscribe_btn.setStyleSheet("color: #e2857f")
+            self.unsubscribe_btn.setStyleSheet("color: #f38987")
         qconnect(self.unsubscribe_btn.clicked, self._on_unsubscribe)
 
         # Add widgets to the action buttons layout

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -228,7 +228,9 @@ class DeckManagementDialog(QDialog):
         # Destination for new cards
         self.box_new_cards_destination = self._setup_box_new_cards_destination(selected_ah_did)
         self.box_bottom_right.addLayout(self.box_new_cards_destination)
-        self.box_bottom_right.addStretch()
+        # Keep sections stacked at the top with the same spacing as the others; a single
+        # trailing stretch (below) absorbs slack so content doesn't float/jump between decks.
+        self.box_bottom_right.addSpacing(16)
 
         # Note Types
         self.box_note_types = self._setup_box_note_types(selected_ah_did)
@@ -459,11 +461,8 @@ class DeckManagementDialog(QDialog):
 
         # Initialize and set up the subdecks documentation link label
         self.subdecks_docs_link_label = QLabel(
-            """
-            <a href="https://community.ankihub.net/t/creating-a-deck/103683#subdecks-and-subdeck-tags-2">
-                Learn about subdecks
-            </a>
-            """
+            '<a href="https://community.ankihub.net/t/creating-a-deck/103683#subdecks-and-subdeck-tags-2">'
+            "Learn about subdecks</a>"
         )
         self.subdecks_docs_link_label.setOpenExternalLinks(True)
         self.subdecks_docs_link_label.setContentsMargins(20, 0, 0, 0)
@@ -553,11 +552,8 @@ class DeckManagementDialog(QDialog):
 
         # Help link
         self.auto_protect_fields_docs_link_label = QLabel(
-            """
-            <a href="https://community.ankihub.net/t/protecting-fields-and-tags/165604">
-                Learn about protecting fields
-            </a>
-            """
+            '<a href="https://community.ankihub.net/t/protecting-fields-and-tags/165604">'
+            "Learn about protecting fields</a>"
         )
         self.auto_protect_fields_docs_link_label.setOpenExternalLinks(True)
         self.auto_protect_fields_docs_link_label.setContentsMargins(20, 0, 0, 0)
@@ -607,11 +603,8 @@ class DeckManagementDialog(QDialog):
 
         # Initialize and set up the documentation link label
         self.new_cards_destination_docs_link_label = QLabel(
-            """
-            <a href="https://community.ankihub.net/t/how-are-anki-decks-related-to-ankihub-decks/4811">
-                More about destinations for new cards
-            </a>
-            """
+            '<a href="https://community.ankihub.net/t/how-are-anki-decks-related-to-ankihub-decks/4811">'
+            "More about destinations for new cards</a>"
         )
         self.new_cards_destination_docs_link_label.setOpenExternalLinks(True)
 
@@ -643,11 +636,14 @@ class DeckManagementDialog(QDialog):
         self._update_templates_btn_state()
         box.addWidget(self.note_types_label)
         box.addSpacing(8)
-        box.addWidget(self.add_note_type_btn)
-        box.addSpacing(4)
-        box.addWidget(self.add_field_btn)
-        box.addSpacing(4)
-        box.addWidget(self.update_templates_btn)
+        # Group the buttons in their own layout with tight spacing so they sit close
+        # together, independent of the parent layout's larger default item spacing.
+        buttons_layout = QVBoxLayout()
+        buttons_layout.setSpacing(4)
+        buttons_layout.addWidget(self.add_note_type_btn)
+        buttons_layout.addWidget(self.add_field_btn)
+        buttons_layout.addWidget(self.update_templates_btn)
+        box.addLayout(buttons_layout)
 
         return box
 


### PR DESCRIPTION
## Related issues
- Tracked by [NRT-773].
- Follow-up to the Deck Management dialog redesign shipped in NRT-748 (the merged [#1259](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1259)).

## Proposed changes
UI adjustments to the **Deck Management** dialog (`ankihub/gui/decks_dialog.py`), from QA + design feedback:

1. **Sections no longer "jump" when switching decks.** `_refresh_box_bottom_right` had two `addStretch()` calls (one between "Destination for New Cards" and "Note Types", one trailing). Two stretches split the leftover vertical space, so on decks with fewer sections the whole panel floated to a different vertical position. Replaced the middle stretch with `addSpacing(16)`, leaving a single trailing stretch → every section stacks from the top consistently across all decks.

2. **"Note Types" gets the same section spacing as "Destination for New Cards"** — a direct consequence of the change above (the 16px gap above it now matches the other section headers).

3. **"Learn about…" doc links hug their related control.** The three link `QLabel`s were built from triple-quoted multi-line HTML; `QLabel` renders the leading/trailing newlines as phantom blank lines (~2 extra line-heights above/below each link). Collapsed all three to single-line HTML, removing the excess space QA flagged.

4. **Note-type buttons sit closer together.** The three buttons used `addSpacing(4)`, but the parent `QVBoxLayout`'s default item spacing also applied on both sides of each spacer (~24px total gap on macOS). Moved them into their own layout with an explicit `setSpacing(4)`.

5. **Long deck names no longer scroll the deck list sideways.** The left deck list now elides long names with a trailing "…" (horizontal scrollbar off + `ElideRight`) and exposes the full name via a word-wrapped HTML tooltip on hover. The right-side deck title keeps wrapping onto a second line as before, which reads fine.

6. **Unsubscribe button color matches Figma.** The light-mode text color was a duller, more desaturated pink than the spec (read as "blurry/inactive"); bumped it to the Figma coral `#f38987`, with a matching softened `#f5a19f` for dark mode.

7. **Tooltip icon alignment on "Remove notes without review history…".** That checkbox/icon row was the only one missing a trailing `addStretch()`, so with its multi-line label the tooltip icon got pushed to the far right of the wide panel. Added the stretch to match the other rows. _(from PR review)_

8. **Tightened the "Note Types" header→buttons gap.** Removed an explicit `addSpacing(8)` between the label and the first button so it matches the other section headers (this is the label-to-button gap, separate from the button-to-button tightening in #4). _(from PR review)_

No behavioral changes — purely layout/markup/styling. (Also merged latest `main`, which added auto-refresh-on-focus to this dialog; the long-name tooltip is applied in the new `_populate_decks_list` so it covers the auto-refresh path too.)

## How to reproduce
1. Open **AnkiHub → Deck Management**.
2. Select a subscribed deck you own (so "Note Types" + the auto-protect option render; the latter requires the `auto_protect_fields_when_edited` feature flag).
3. Observe: doc links sit directly under their controls, "Note Types" has consistent spacing above and below its header, the publish buttons are tightly grouped, the "Remove notes…" tooltip icon sits next to its checkbox, and the Unsubscribe button is the brighter coral.
4. Switch between decks — sections stay anchored at the same vertical positions (no jump).
5. Subscribe to a deck with a very long name — the list elides it with "…" (full name in the tooltip) instead of scrolling sideways.

## Screenshots and videos
Long deck name: elided in the list with a word-wrapped tooltip, and wrapped in the right-side title.

<img width="480" alt="Deck Management: long deck name elided in the list with a wrapped tooltip, and wrapped in the right-side title" src="https://github.com/user-attachments/assets/e8ca9788-0e94-488a-b3b3-936c831e09b8" />

## Further comments
Stacked conceptually on the merged NRT-748 redesign; branched off `main`.

[NRT-748]: https://ankihub.atlassian.net/browse/NRT-748
[NRT-773]: https://ankihub.atlassian.net/browse/NRT-773
