### PR TITLE
[NRT-763] Auto-refresh Deck Management dialog when it regains focus

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1037,12 +1037,16 @@ class DeckManagementDialog(QDialog):
         added_ids = new_ids - old_ids
 
         current = self._selected_ah_did()
-        if current is None and len(added_ids) == 1:
-            # Nothing selected and exactly one new subscription (the common "just
-            # subscribed on the web" case): select it so its panel — including
-            # "Sync to install" — is shown. If the user already has a deck selected
-            # we keep it, so a refresh can't retarget an in-progress workflow.
-            select_ah_did: Optional[UUID] = next(iter(added_ids))
+        if current is None and added_ids:
+            # Nothing selected and at least one new subscription (the common "just
+            # subscribed on the web" case): auto-select one so its panel — including
+            # "Sync to install" — is shown. When the user subscribed to several decks
+            # before returning, pick the one that appears last in the server response
+            # (we have no per-deck "subscribed_at" timestamp; this is the closest
+            # proxy for "last added" and matches the order rendered in the list).
+            # If the user already has a deck selected we keep it, so a refresh can't
+            # retarget an in-progress workflow.
+            select_ah_did: Optional[UUID] = next(deck.ah_did for deck in reversed(decks) if deck.ah_did in added_ids)
         else:
             select_ah_did = current if current in new_ids else None
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -102,8 +102,10 @@ class DeckManagementDialog(QDialog):
         # genuine return (deactivate -> reactivate), not the activation Qt emits
         # while the dialog is first shown.
         self._was_deactivated = False
-        # Bumped on every fetch (sync or async); an async result whose generation is
-        # stale (a newer fetch/refresh started meanwhile) is discarded on completion.
+        # Prevents a slow async auto-refresh from clobbering a newer refresh with
+        # stale data (e.g. an unsubscribe rebuilt the list while the fetch was still
+        # in flight). Every fetch — sync or async — bumps this counter, and an async
+        # result is only applied if its generation still matches on completion.
         self._subscriptions_fetch_generation = 0
         # Debounces focus-triggered refreshes; parented to self so it can't fire
         # after the dialog is deleted.

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1,8 +1,9 @@
 """Dialog for managing subscriptions to AnkiHub decks and deck-specific settings."""
 
+import time
 import uuid
 from concurrent.futures import Future
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from uuid import UUID
 
 import aqt
@@ -15,6 +16,7 @@ from aqt.qt import (
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QEvent,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -27,13 +29,14 @@ from aqt.qt import (
     QVBoxLayout,
     QWidget,
     qconnect,
+    sip,
 )
 from aqt.theme import theme_manager
 from aqt.utils import openLink, showInfo, showText, tooltip
 
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
-from ..ankihub_client.models import UserDeckRelation
+from ..ankihub_client.models import Deck, UserDeckRelation
 from ..common_utils import get_media_names_from_note_type
 from ..db import ankihub_db
 from ..gui.operations.deck_creation import create_collaborative_deck
@@ -85,9 +88,22 @@ class DeckManagementDialog(QDialog):
     _window: Optional["DeckManagementDialog"] = None
     silentlyClose = True
 
+    # Minimum seconds between automatic deck-list refreshes triggered by the
+    # dialog regaining focus. Keeps frequent window activations (alt-tab, child
+    # dialogs closing) from each firing a network request.
+    _AUTO_REFRESH_COOLDOWN_SECONDS = 2.0
+
     def __init__(self):
         super(DeckManagementDialog, self).__init__(aqt.mw)
         self.client = AnkiHubClient()
+
+        # Auto-refresh bookkeeping (see _maybe_auto_refresh_decks_list). Seed the
+        # timestamp now so the WindowActivate fired while showing the dialog
+        # doesn't trigger an immediate redundant fetch right after the initial load.
+        self._last_subscriptions_fetch = time.monotonic()
+        self._subscriptions_fetch_in_flight = False
+        self._subscriptions_refetch_pending = False
+
         self._setup_ui()
         self._refresh_decks_list()
 
@@ -877,18 +893,123 @@ class DeckManagementDialog(QDialog):
             )
 
     def _refresh_decks_list(self) -> None:
-        self.decks_list.clear()
+        """Synchronously fetch subscriptions and repopulate the list, preserving selection.
 
+        Used by callers that already run in a context where blocking briefly is acceptable
+        (initial load, unsubscribe, reopen). The focus-triggered auto-refresh uses the
+        non-blocking path in _auto_refresh_decks_list instead.
+        """
         subscribed_decks = self.client.get_deck_subscriptions()
-        for deck in subscribed_decks:
-            if deck.is_user_relation_owner:
-                item = QListWidgetItem(f"{deck.name} (Created by you)")
-            elif deck.is_user_relation_maintainer:
-                item = QListWidgetItem(f"{deck.name} (Maintained by you)")
-            else:
-                item = QListWidgetItem(deck.name)
-            item.setData(Qt.ItemDataRole.UserRole, deck)
-            self.decks_list.addItem(item)
+        self._last_subscriptions_fetch = time.monotonic()
+        self._populate_decks_list(subscribed_decks, select_ah_did=self._selected_ah_did())
+
+    def _populate_decks_list(self, decks: List[Deck], select_ah_did: Optional[UUID]) -> None:
+        """Rebuild the deck list from `decks`, re-selecting `select_ah_did` if present.
+
+        Signals are blocked during the rebuild so the transient empty state doesn't fire
+        itemSelectionChanged -> _refresh_box_bottom_right (which would flash the right panel
+        to "Choose deck…"); the right panel is refreshed once at the end instead.
+        """
+        self.decks_list.blockSignals(True)
+        try:
+            self.decks_list.clear()
+            for deck in decks:
+                if deck.is_user_relation_owner:
+                    item = QListWidgetItem(f"{deck.name} (Created by you)")
+                elif deck.is_user_relation_maintainer:
+                    item = QListWidgetItem(f"{deck.name} (Maintained by you)")
+                else:
+                    item = QListWidgetItem(deck.name)
+                item.setData(Qt.ItemDataRole.UserRole, deck)
+                self.decks_list.addItem(item)
+                if select_ah_did is not None and deck.ah_did == select_ah_did:
+                    item.setSelected(True)
+                    self.decks_list.setCurrentItem(item)
+        finally:
+            self.decks_list.blockSignals(False)
+
+        self._refresh_box_bottom_right()
+
+    @staticmethod
+    def _snapshot_for_decks(decks: List[Deck]) -> List[Tuple[UUID, str, UserDeckRelation]]:
+        """A comparable summary of exactly what the list renders for each deck."""
+        return [(deck.ah_did, deck.name, deck.user_relation) for deck in decks]
+
+    def _current_decks_snapshot(self) -> List[Tuple[UUID, str, UserDeckRelation]]:
+        result = []
+        for i in range(self.decks_list.count()):
+            deck = self.decks_list.item(i).data(Qt.ItemDataRole.UserRole)
+            result.append((deck.ah_did, deck.name, deck.user_relation))
+        return result
+
+    def changeEvent(self, event) -> None:
+        super().changeEvent(event)
+        # Returning from the external browser (or any other app) raises a window
+        # activation event rather than a focus-in/show, so this is where we catch
+        # "the user is looking at the dialog again" and refresh the deck list.
+        if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
+            self._maybe_auto_refresh_decks_list()
+
+    def _maybe_auto_refresh_decks_list(self) -> None:
+        if not config.is_logged_in():
+            return
+        if self._subscriptions_fetch_in_flight:
+            # Remember that something happened during the request so we fetch once
+            # more when it returns (the in-flight response may predate the change).
+            self._subscriptions_refetch_pending = True
+            return
+        if time.monotonic() - self._last_subscriptions_fetch < self._AUTO_REFRESH_COOLDOWN_SECONDS:
+            return
+        self._auto_refresh_decks_list()
+
+    def _auto_refresh_decks_list(self) -> None:
+        self._subscriptions_fetch_in_flight = True
+
+        def on_success(decks: List[Deck]) -> None:
+            self._subscriptions_fetch_in_flight = False
+            self._last_subscriptions_fetch = time.monotonic()
+            if sip.isdeleted(self):
+                return
+            self._apply_fetched_subscriptions(decks)
+            if self._subscriptions_refetch_pending:
+                self._subscriptions_refetch_pending = False
+                self._auto_refresh_decks_list()
+
+        def on_failure(exc: Exception) -> None:
+            # Auto-refresh is best-effort; never surface an error popup on every
+            # focus (e.g. when offline). The cooldown timestamp is still advanced.
+            self._subscriptions_fetch_in_flight = False
+            self._subscriptions_refetch_pending = False
+            self._last_subscriptions_fetch = time.monotonic()
+            LOGGER.warning("Auto-refresh of deck subscriptions failed.", exc_info=exc)
+
+        AddonQueryOp(
+            op=lambda _: self.client.get_deck_subscriptions(),
+            success=on_success,
+            parent=aqt.mw,
+        ).failure(on_failure).run_in_background()
+
+    def _apply_fetched_subscriptions(self, decks: List[Deck]) -> None:
+        current_snapshot = self._current_decks_snapshot()
+        if self._snapshot_for_decks(decks) == current_snapshot:
+            # Nothing changed: skip the rebuild so the list doesn't flicker and the
+            # current selection / right-panel state is left untouched.
+            return
+
+        old_ids = {ah_did for ah_did, _, _ in current_snapshot}
+        new_ids = {deck.ah_did for deck in decks}
+        added_ids = new_ids - old_ids
+
+        if len(added_ids) == 1:
+            # Exactly one new subscription (the common "just subscribed on the web"
+            # case): select it so its panel — including "Sync to install" — is shown.
+            select_ah_did: Optional[UUID] = next(iter(added_ids))
+        else:
+            current = self._selected_ah_did()
+            select_ah_did = current if current in new_ids else None
+
+        self._populate_decks_list(decks, select_ah_did=select_ah_did)
+        LOGGER.info("deck_management_dialog_auto_refreshed", added_decks=len(added_ids))
 
     def _selected_ah_did(self) -> Optional[UUID]:
         selection = self.decks_list.selectedItems()

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -94,6 +94,11 @@ class DeckManagementDialog(QDialog):
     # dialogs closing) from each firing a network request.
     _AUTO_REFRESH_COOLDOWN_SECONDS = 2.0
 
+    # Activations within this window of the last fetch (notably the WindowActivate
+    # emitted while the dialog is being shown) are ignored — the list is already
+    # current, so there's nothing to refresh and no point scheduling a deferred one.
+    _AUTO_REFRESH_ACTIVATION_GRACE_SECONDS = 0.5
+
     def __init__(self):
         super(DeckManagementDialog, self).__init__(aqt.mw)
         self.client = AnkiHubClient()
@@ -973,11 +978,16 @@ class DeckManagementDialog(QDialog):
             # more when it returns (the in-flight response may predate the change).
             self._subscriptions_refetch_pending = True
             return
-        remaining = self._AUTO_REFRESH_COOLDOWN_SECONDS - (time.monotonic() - self._last_subscriptions_fetch)
+        elapsed = time.monotonic() - self._last_subscriptions_fetch
+        if elapsed < self._AUTO_REFRESH_ACTIVATION_GRACE_SECONDS:
+            # Just fetched (e.g. the activation emitted while showing the dialog):
+            # the list is current, so don't fetch or schedule a redundant refresh.
+            return
+        remaining = self._AUTO_REFRESH_COOLDOWN_SECONDS - elapsed
         if remaining > 0:
-            # Within the cooldown: defer instead of dropping the event, otherwise an
-            # activation that lands right after the initial load (user subscribes and
-            # returns quickly) would be lost and the new deck wouldn't show up.
+            # Past the grace window but still within the cooldown: defer instead of
+            # dropping the event, otherwise an activation from a quick browser round
+            # trip would be lost and a newly subscribed deck wouldn't show up.
             self._schedule_auto_refresh(remaining)
             return
         self._auto_refresh_decks_list()
@@ -989,7 +999,9 @@ class DeckManagementDialog(QDialog):
 
         def on_timeout() -> None:
             self._subscriptions_refresh_scheduled = False
-            if sip.isdeleted(self):
+            # The singleton keeps the dialog alive after close, so it may be hidden
+            # (not deleted) by the time this fires — don't refresh a closed dialog.
+            if sip.isdeleted(self) or not self.isVisible():
                 return
             self._maybe_auto_refresh_decks_list()
 
@@ -1003,7 +1015,9 @@ class DeckManagementDialog(QDialog):
         def on_success(decks: List[Deck]) -> None:
             self._subscriptions_fetch_in_flight = False
             self._last_subscriptions_fetch = time.monotonic()
-            if sip.isdeleted(self):
+            # Dialog closed (kept alive by the singleton, so not necessarily deleted)
+            # or hidden: nothing to update.
+            if sip.isdeleted(self) or not self.isVisible():
                 return
             # Discard a result that a newer fetch/refresh has superseded (e.g. an
             # unsubscribe ran a synchronous refresh while this request was in flight),
@@ -1024,7 +1038,7 @@ class DeckManagementDialog(QDialog):
             self._subscriptions_fetch_in_flight = False
             self._last_subscriptions_fetch = time.monotonic()
             LOGGER.warning("Auto-refresh of deck subscriptions failed.", exc_info=exc)
-            if sip.isdeleted(self):
+            if sip.isdeleted(self) or not self.isVisible():
                 return
             # A change observed mid-request still deserves another attempt.
             if self._subscriptions_refetch_pending:

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -95,9 +95,8 @@ class DeckManagementDialog(QDialog):
     # Coalesce bursts of window activations (alt-tab, child dialogs closing) into a
     # single refresh fired once focus settles.
     _REFRESH_DEBOUNCE_MS = 400
-    # Skip a refresh if we fetched within this window — suppresses the activation
-    # emitted while the dialog is being shown (it lands right after the initial
-    # synchronous load) and throttles repeated quick returns.
+    # Throttle: at most one auto-refresh fetch per this interval. Requests that
+    # arrive sooner are deferred to the end of the interval, not dropped.
     _REFRESH_MIN_INTERVAL_SECONDS = 1.0
 
     def __init__(self):
@@ -109,6 +108,10 @@ class DeckManagementDialog(QDialog):
         # doesn't trigger a redundant fetch right after the initial load.
         self._last_subscriptions_fetch = time.monotonic()
         self._subscriptions_fetch_in_flight = False
+        # True once the dialog has lost activation, so we only auto-refresh on a
+        # genuine return (deactivate -> reactivate), not the activation Qt emits
+        # while the dialog is first shown.
+        self._was_deactivated = False
         # Bumped on every fetch (sync or async); an async result whose generation is
         # stale (a newer fetch/refresh started meanwhile) is discarded on completion.
         self._subscriptions_fetch_generation = 0
@@ -913,6 +916,9 @@ class DeckManagementDialog(QDialog):
         (initial load, unsubscribe, reopen). The focus-triggered auto-refresh uses the
         non-blocking path in _auto_refresh_decks_list instead.
         """
+        # This full refresh supersedes any pending/auto refresh.
+        self._refresh_debounce_timer.stop()
+        self._was_deactivated = False
         self._subscriptions_fetch_generation += 1
         subscribed_decks = self.client.get_deck_subscriptions()
         self._last_subscriptions_fetch = time.monotonic()
@@ -961,10 +967,17 @@ class DeckManagementDialog(QDialog):
         super().changeEvent(event)
         # Returning from the external browser (or any other app) raises a window
         # activation event rather than a focus-in/show, so this is where we catch
-        # "the user is looking at the dialog again". Debounce so a burst of
-        # activations (alt-tab, child dialogs closing) coalesces into one refresh.
-        if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
-            self._refresh_debounce_timer.start(self._REFRESH_DEBOUNCE_MS)
+        # "the user is looking at the dialog again".
+        if event.type() == QEvent.Type.ActivationChange:
+            if self.isActiveWindow():
+                # Only refresh on a genuine return (we lost activation and regained
+                # it), not the activation emitted while the dialog is first shown.
+                # Debounce so a burst of activations coalesces into one refresh.
+                if self._was_deactivated:
+                    self._was_deactivated = False
+                    self._refresh_debounce_timer.start(self._REFRESH_DEBOUNCE_MS)
+            else:
+                self._was_deactivated = True
 
     def _on_refresh_debounce_timeout(self) -> None:
         # The singleton keeps the dialog alive after close, so it may be hidden
@@ -974,17 +987,21 @@ class DeckManagementDialog(QDialog):
         # Don't rebuild the list out from under an open child dialog (unsubscribe
         # confirmation, note-type/destination pickers) or popup (combo dropdown);
         # those workflows are deck-scoped. The dialog itself is application-modal, so
-        # exclude it from the check — otherwise auto-refresh would never run.
+        # exclude it from the check — otherwise auto-refresh would never run. Closing
+        # the child reactivates us, which re-triggers this, so nothing is lost.
         active_modal = QApplication.activeModalWidget()
         if (active_modal is not None and active_modal is not self) or QApplication.activePopupWidget() is not None:
             return
-        # A fetch is already running; its result will refresh the list. A genuine
-        # later return re-triggers this via another activation.
+        # A fetch is already running: defer until it finishes rather than dropping
+        # this return, so a change it didn't capture is still picked up.
         if self._subscriptions_fetch_in_flight:
+            self._refresh_debounce_timer.start(self._REFRESH_DEBOUNCE_MS)
             return
-        # Skip if we just fetched — notably the activation emitted while showing the
-        # dialog, which lands right after the initial synchronous load.
-        if time.monotonic() - self._last_subscriptions_fetch < self._REFRESH_MIN_INTERVAL_SECONDS:
+        # Throttle: at most one fetch per min interval. Defer to the end of the
+        # interval rather than dropping the request.
+        remaining = self._REFRESH_MIN_INTERVAL_SECONDS - (time.monotonic() - self._last_subscriptions_fetch)
+        if remaining > 0:
+            self._refresh_debounce_timer.start(int(remaining * 1000) + 50)
             return
         self._auto_refresh_decks_list()
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -92,27 +92,31 @@ class DeckManagementDialog(QDialog):
     # Minimum seconds between automatic deck-list refreshes triggered by the
     # dialog regaining focus. Keeps frequent window activations (alt-tab, child
     # dialogs closing) from each firing a network request.
-    _AUTO_REFRESH_COOLDOWN_SECONDS = 2.0
-
-    # Activations within this window of the last fetch (notably the WindowActivate
-    # emitted while the dialog is being shown) are ignored — the list is already
-    # current, so there's nothing to refresh and no point scheduling a deferred one.
-    _AUTO_REFRESH_ACTIVATION_GRACE_SECONDS = 0.5
+    # Coalesce bursts of window activations (alt-tab, child dialogs closing) into a
+    # single refresh fired once focus settles.
+    _REFRESH_DEBOUNCE_MS = 400
+    # Skip a refresh if we fetched within this window — suppresses the activation
+    # emitted while the dialog is being shown (it lands right after the initial
+    # synchronous load) and throttles repeated quick returns.
+    _REFRESH_MIN_INTERVAL_SECONDS = 1.0
 
     def __init__(self):
         super(DeckManagementDialog, self).__init__(aqt.mw)
         self.client = AnkiHubClient()
 
-        # Auto-refresh bookkeeping (see _maybe_auto_refresh_decks_list). Seed the
+        # Auto-refresh bookkeeping (see _on_refresh_debounce_timeout). Seed the
         # timestamp now so the WindowActivate fired while showing the dialog
-        # doesn't trigger an immediate redundant fetch right after the initial load.
+        # doesn't trigger a redundant fetch right after the initial load.
         self._last_subscriptions_fetch = time.monotonic()
         self._subscriptions_fetch_in_flight = False
-        self._subscriptions_refetch_pending = False
-        self._subscriptions_refresh_scheduled = False
         # Bumped on every fetch (sync or async); an async result whose generation is
         # stale (a newer fetch/refresh started meanwhile) is discarded on completion.
         self._subscriptions_fetch_generation = 0
+        # Debounces focus-triggered refreshes; parented to self so it can't fire
+        # after the dialog is deleted.
+        self._refresh_debounce_timer = QTimer(self)
+        self._refresh_debounce_timer.setSingleShot(True)
+        qconnect(self._refresh_debounce_timer.timeout, self._on_refresh_debounce_timeout)
 
         self._setup_ui()
         self._refresh_decks_list()
@@ -943,69 +947,46 @@ class DeckManagementDialog(QDialog):
         self._refresh_box_bottom_right()
 
     @staticmethod
-    def _snapshot_for_decks(decks: List[Deck]) -> List[Tuple[UUID, str, UserDeckRelation]]:
-        """A comparable summary of exactly what the list renders for each deck."""
-        return [(deck.ah_did, deck.name, deck.user_relation) for deck in decks]
+    def _deck_snapshot(deck: Deck) -> Tuple[UUID, str, UserDeckRelation]:
+        """A comparable summary of exactly what the list renders for a deck."""
+        return (deck.ah_did, deck.name, deck.user_relation)
 
     def _current_decks_snapshot(self) -> List[Tuple[UUID, str, UserDeckRelation]]:
-        result = []
-        for i in range(self.decks_list.count()):
-            deck = self.decks_list.item(i).data(Qt.ItemDataRole.UserRole)
-            result.append((deck.ah_did, deck.name, deck.user_relation))
-        return result
+        return [
+            self._deck_snapshot(self.decks_list.item(i).data(Qt.ItemDataRole.UserRole))
+            for i in range(self.decks_list.count())
+        ]
 
     def changeEvent(self, event) -> None:
         super().changeEvent(event)
         # Returning from the external browser (or any other app) raises a window
         # activation event rather than a focus-in/show, so this is where we catch
-        # "the user is looking at the dialog again" and refresh the deck list.
+        # "the user is looking at the dialog again". Debounce so a burst of
+        # activations (alt-tab, child dialogs closing) coalesces into one refresh.
         if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
-            self._maybe_auto_refresh_decks_list()
+            self._refresh_debounce_timer.start(self._REFRESH_DEBOUNCE_MS)
 
-    def _maybe_auto_refresh_decks_list(self) -> None:
-        if not config.is_logged_in():
+    def _on_refresh_debounce_timeout(self) -> None:
+        # The singleton keeps the dialog alive after close, so it may be hidden
+        # (not deleted) by the time this fires — don't refresh a closed dialog.
+        if sip.isdeleted(self) or not self.isVisible() or not config.is_logged_in():
             return
         # Don't rebuild the list out from under an open child dialog (unsubscribe
         # confirmation, note-type/destination pickers) or popup (combo dropdown);
-        # those workflows are deck-scoped and a refresh could change the selection or
-        # tear down widgets mid-action. The dialog itself is application-modal, so
+        # those workflows are deck-scoped. The dialog itself is application-modal, so
         # exclude it from the check — otherwise auto-refresh would never run.
         active_modal = QApplication.activeModalWidget()
         if (active_modal is not None and active_modal is not self) or QApplication.activePopupWidget() is not None:
             return
+        # A fetch is already running; its result will refresh the list. A genuine
+        # later return re-triggers this via another activation.
         if self._subscriptions_fetch_in_flight:
-            # Remember that something happened during the request so we fetch once
-            # more when it returns (the in-flight response may predate the change).
-            self._subscriptions_refetch_pending = True
             return
-        elapsed = time.monotonic() - self._last_subscriptions_fetch
-        if elapsed < self._AUTO_REFRESH_ACTIVATION_GRACE_SECONDS:
-            # Just fetched (e.g. the activation emitted while showing the dialog):
-            # the list is current, so don't fetch or schedule a redundant refresh.
-            return
-        remaining = self._AUTO_REFRESH_COOLDOWN_SECONDS - elapsed
-        if remaining > 0:
-            # Past the grace window but still within the cooldown: defer instead of
-            # dropping the event, otherwise an activation from a quick browser round
-            # trip would be lost and a newly subscribed deck wouldn't show up.
-            self._schedule_auto_refresh(remaining)
+        # Skip if we just fetched — notably the activation emitted while showing the
+        # dialog, which lands right after the initial synchronous load.
+        if time.monotonic() - self._last_subscriptions_fetch < self._REFRESH_MIN_INTERVAL_SECONDS:
             return
         self._auto_refresh_decks_list()
-
-    def _schedule_auto_refresh(self, delay_seconds: float) -> None:
-        if self._subscriptions_refresh_scheduled:
-            return
-        self._subscriptions_refresh_scheduled = True
-
-        def on_timeout() -> None:
-            self._subscriptions_refresh_scheduled = False
-            # The singleton keeps the dialog alive after close, so it may be hidden
-            # (not deleted) by the time this fires — don't refresh a closed dialog.
-            if sip.isdeleted(self) or not self.isVisible():
-                return
-            self._maybe_auto_refresh_decks_list()
-
-        QTimer.singleShot(int(delay_seconds * 1000) + 50, on_timeout)
 
     def _auto_refresh_decks_list(self) -> None:
         self._subscriptions_fetch_in_flight = True
@@ -1028,22 +1009,13 @@ class DeckManagementDialog(QDialog):
                 except Exception as exc:
                     # Best-effort: a render failure must not surface an error popup.
                     LOGGER.warning("Applying auto-refreshed deck subscriptions failed.", exc_info=exc)
-            if self._subscriptions_refetch_pending:
-                self._subscriptions_refetch_pending = False
-                self._maybe_auto_refresh_decks_list()
 
         def on_failure(exc: Exception) -> None:
             # Auto-refresh is best-effort; never surface an error popup on every
-            # focus (e.g. when offline). The cooldown timestamp is still advanced.
+            # focus (e.g. when offline).
             self._subscriptions_fetch_in_flight = False
             self._last_subscriptions_fetch = time.monotonic()
             LOGGER.warning("Auto-refresh of deck subscriptions failed.", exc_info=exc)
-            if sip.isdeleted(self) or not self.isVisible():
-                return
-            # A change observed mid-request still deserves another attempt.
-            if self._subscriptions_refetch_pending:
-                self._subscriptions_refetch_pending = False
-                self._maybe_auto_refresh_decks_list()
 
         AddonQueryOp(
             op=lambda _: self.client.get_deck_subscriptions(),
@@ -1055,7 +1027,7 @@ class DeckManagementDialog(QDialog):
         current_snapshot = self._current_decks_snapshot()
         # Order-insensitive: a reordered-but-identical list isn't a real change, so
         # comparing as sets avoids a needless rebuild (and visible reshuffle).
-        if set(self._snapshot_for_decks(decks)) == set(current_snapshot):
+        if {self._deck_snapshot(deck) for deck in decks} == set(current_snapshot):
             # Nothing changed: skip the rebuild so the list doesn't flicker and the
             # current selection / right-panel state is left untouched.
             return

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1210,13 +1210,49 @@ class DeckManagementDialog(QDialog):
     def _refresh_subdecks_checkbox(self):
         ah_did = self._selected_ah_did()
 
-        has_subdeck_tags = deck_contains_subdeck_tags(ah_did)
-        self.subdecks_cb.setEnabled(has_subdeck_tags)
-        self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }" if not has_subdeck_tags else "")
-        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
-
+        # Apply the parts that don't require a DB query immediately: the checked state
+        # from config, and the static tooltip.
         deck_config = config.deck_config(ah_did)
         self.subdecks_cb.setChecked(deck_config.subdecks_enabled)
+        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
+
+        # Whether the checkbox is interactive depends on whether the deck has subdeck
+        # tags — a scan over every note's tags in the AnkiHub DB. For large decks this
+        # takes ~100ms, so run it off the main thread and apply the result once it
+        # returns.
+        self.subdecks_cb.setEnabled(False)
+        self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }")
+
+        # Capture the specific checkbox this op is started for. If the panel rebuilds
+        # before the op completes (deck switch, toggle, auto-refresh) self.subdecks_cb
+        # will point to a new widget and we'll skip applying this now-stale result.
+        checkbox = self.subdecks_cb
+
+        AddonQueryOp(
+            op=lambda _: deck_contains_subdeck_tags(ah_did),
+            success=lambda has_subdeck_tags: self._apply_subdecks_checkbox_state(ah_did, has_subdeck_tags, checkbox),
+            parent=self,
+        ).failure(
+            # Best-effort check: on failure, log and leave the checkbox in its loading-
+            # state disabled rather than surfacing the add-on's default error dialog
+            # for a transient DB / profile-close error.
+            lambda exc: LOGGER.warning("Subdeck-tag check failed", ah_did=str(ah_did), error=repr(exc))
+        ).without_collection().run_in_background()
+
+    def _apply_subdecks_checkbox_state(self, ah_did: UUID, has_subdeck_tags: bool, checkbox: QCheckBox) -> None:
+        # Guard against the dialog or the captured checkbox being torn down between op
+        # launch and completion (e.g. profile switch mid-query).
+        if sip.isdeleted(self) or sip.isdeleted(checkbox):
+            return
+
+        # Ignore stale results: a different deck may have been selected (self.subdecks_cb
+        # is then a different widget) or this checkbox may have been rebuilt for the same
+        # deck. Either way, the now-current op will set the right state.
+        if self._selected_ah_did() != ah_did or self.subdecks_cb is not checkbox:
+            return
+
+        checkbox.setEnabled(has_subdeck_tags)
+        checkbox.setStyleSheet("" if has_subdeck_tags else "QCheckBox { color: grey }")
 
     @classmethod
     def display_subscribe_window(cls):

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1,6 +1,5 @@
 """Dialog for managing subscriptions to AnkiHub decks and deck-specific settings."""
 
-import time
 import uuid
 from concurrent.futures import Future
 from typing import List, Optional, Tuple
@@ -89,24 +88,15 @@ class DeckManagementDialog(QDialog):
     _window: Optional["DeckManagementDialog"] = None
     silentlyClose = True
 
-    # Minimum seconds between automatic deck-list refreshes triggered by the
-    # dialog regaining focus. Keeps frequent window activations (alt-tab, child
-    # dialogs closing) from each firing a network request.
     # Coalesce bursts of window activations (alt-tab, child dialogs closing) into a
     # single refresh fired once focus settles.
     _REFRESH_DEBOUNCE_MS = 400
-    # Throttle: at most one auto-refresh fetch per this interval. Requests that
-    # arrive sooner are deferred to the end of the interval, not dropped.
-    _REFRESH_MIN_INTERVAL_SECONDS = 1.0
 
     def __init__(self):
         super(DeckManagementDialog, self).__init__(aqt.mw)
         self.client = AnkiHubClient()
 
-        # Auto-refresh bookkeeping (see _on_refresh_debounce_timeout). Seed the
-        # timestamp now so the WindowActivate fired while showing the dialog
-        # doesn't trigger a redundant fetch right after the initial load.
-        self._last_subscriptions_fetch = time.monotonic()
+        # Auto-refresh bookkeeping (see _on_refresh_debounce_timeout).
         self._subscriptions_fetch_in_flight = False
         # True once the dialog has lost activation, so we only auto-refresh on a
         # genuine return (deactivate -> reactivate), not the activation Qt emits
@@ -921,7 +911,6 @@ class DeckManagementDialog(QDialog):
         self._was_deactivated = False
         self._subscriptions_fetch_generation += 1
         subscribed_decks = self.client.get_deck_subscriptions()
-        self._last_subscriptions_fetch = time.monotonic()
         self._populate_decks_list(subscribed_decks, select_ah_did=self._selected_ah_did())
 
     def _populate_decks_list(self, decks: List[Deck], select_ah_did: Optional[UUID]) -> None:
@@ -992,16 +981,10 @@ class DeckManagementDialog(QDialog):
         active_modal = QApplication.activeModalWidget()
         if (active_modal is not None and active_modal is not self) or QApplication.activePopupWidget() is not None:
             return
-        # A fetch is already running: defer until it finishes rather than dropping
+        # A fetch is already running: retry once it finishes rather than dropping
         # this return, so a change it didn't capture is still picked up.
         if self._subscriptions_fetch_in_flight:
             self._refresh_debounce_timer.start(self._REFRESH_DEBOUNCE_MS)
-            return
-        # Throttle: at most one fetch per min interval. Defer to the end of the
-        # interval rather than dropping the request.
-        remaining = self._REFRESH_MIN_INTERVAL_SECONDS - (time.monotonic() - self._last_subscriptions_fetch)
-        if remaining > 0:
-            self._refresh_debounce_timer.start(int(remaining * 1000) + 50)
             return
         self._auto_refresh_decks_list()
 
@@ -1012,7 +995,6 @@ class DeckManagementDialog(QDialog):
 
         def on_success(decks: List[Deck]) -> None:
             self._subscriptions_fetch_in_flight = False
-            self._last_subscriptions_fetch = time.monotonic()
             # Dialog closed (kept alive by the singleton, so not necessarily deleted)
             # or hidden: nothing to update.
             if sip.isdeleted(self) or not self.isVisible():
@@ -1031,7 +1013,6 @@ class DeckManagementDialog(QDialog):
             # Auto-refresh is best-effort; never surface an error popup on every
             # focus (e.g. when offline).
             self._subscriptions_fetch_in_flight = False
-            self._last_subscriptions_fetch = time.monotonic()
             LOGGER.warning("Auto-refresh of deck subscriptions failed.", exc_info=exc)
 
         AddonQueryOp(

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -26,6 +26,7 @@ from aqt.qt import (
     QScrollArea,
     QSizePolicy,
     Qt,
+    QTimer,
     QVBoxLayout,
     QWidget,
     qconnect,
@@ -103,6 +104,10 @@ class DeckManagementDialog(QDialog):
         self._last_subscriptions_fetch = time.monotonic()
         self._subscriptions_fetch_in_flight = False
         self._subscriptions_refetch_pending = False
+        self._subscriptions_refresh_scheduled = False
+        # Bumped on every fetch (sync or async); an async result whose generation is
+        # stale (a newer fetch/refresh started meanwhile) is discarded on completion.
+        self._subscriptions_fetch_generation = 0
 
         self._setup_ui()
         self._refresh_decks_list()
@@ -899,6 +904,7 @@ class DeckManagementDialog(QDialog):
         (initial load, unsubscribe, reopen). The focus-triggered auto-refresh uses the
         non-blocking path in _auto_refresh_decks_list instead.
         """
+        self._subscriptions_fetch_generation += 1
         subscribed_decks = self.client.get_deck_subscriptions()
         self._last_subscriptions_fetch = time.monotonic()
         self._populate_decks_list(subscribed_decks, select_ah_did=self._selected_ah_did())
@@ -925,6 +931,7 @@ class DeckManagementDialog(QDialog):
                 if select_ah_did is not None and deck.ah_did == select_ah_did:
                     item.setSelected(True)
                     self.decks_list.setCurrentItem(item)
+                    self.decks_list.scrollToItem(item)
         finally:
             self.decks_list.blockSignals(False)
 
@@ -953,35 +960,76 @@ class DeckManagementDialog(QDialog):
     def _maybe_auto_refresh_decks_list(self) -> None:
         if not config.is_logged_in():
             return
+        # Don't rebuild the list out from under an open child dialog (unsubscribe
+        # confirmation, note-type/destination pickers) or popup (combo dropdown);
+        # those workflows are deck-scoped and a refresh could change the selection or
+        # tear down widgets mid-action. The dialog itself is application-modal, so
+        # exclude it from the check — otherwise auto-refresh would never run.
+        active_modal = QApplication.activeModalWidget()
+        if (active_modal is not None and active_modal is not self) or QApplication.activePopupWidget() is not None:
+            return
         if self._subscriptions_fetch_in_flight:
             # Remember that something happened during the request so we fetch once
             # more when it returns (the in-flight response may predate the change).
             self._subscriptions_refetch_pending = True
             return
-        if time.monotonic() - self._last_subscriptions_fetch < self._AUTO_REFRESH_COOLDOWN_SECONDS:
+        remaining = self._AUTO_REFRESH_COOLDOWN_SECONDS - (time.monotonic() - self._last_subscriptions_fetch)
+        if remaining > 0:
+            # Within the cooldown: defer instead of dropping the event, otherwise an
+            # activation that lands right after the initial load (user subscribes and
+            # returns quickly) would be lost and the new deck wouldn't show up.
+            self._schedule_auto_refresh(remaining)
             return
         self._auto_refresh_decks_list()
 
+    def _schedule_auto_refresh(self, delay_seconds: float) -> None:
+        if self._subscriptions_refresh_scheduled:
+            return
+        self._subscriptions_refresh_scheduled = True
+
+        def on_timeout() -> None:
+            self._subscriptions_refresh_scheduled = False
+            if sip.isdeleted(self):
+                return
+            self._maybe_auto_refresh_decks_list()
+
+        QTimer.singleShot(int(delay_seconds * 1000) + 50, on_timeout)
+
     def _auto_refresh_decks_list(self) -> None:
         self._subscriptions_fetch_in_flight = True
+        self._subscriptions_fetch_generation += 1
+        generation = self._subscriptions_fetch_generation
 
         def on_success(decks: List[Deck]) -> None:
             self._subscriptions_fetch_in_flight = False
             self._last_subscriptions_fetch = time.monotonic()
             if sip.isdeleted(self):
                 return
-            self._apply_fetched_subscriptions(decks)
+            # Discard a result that a newer fetch/refresh has superseded (e.g. an
+            # unsubscribe ran a synchronous refresh while this request was in flight),
+            # otherwise the stale list would clobber the up-to-date one.
+            if generation == self._subscriptions_fetch_generation:
+                try:
+                    self._apply_fetched_subscriptions(decks)
+                except Exception as exc:
+                    # Best-effort: a render failure must not surface an error popup.
+                    LOGGER.warning("Applying auto-refreshed deck subscriptions failed.", exc_info=exc)
             if self._subscriptions_refetch_pending:
                 self._subscriptions_refetch_pending = False
-                self._auto_refresh_decks_list()
+                self._maybe_auto_refresh_decks_list()
 
         def on_failure(exc: Exception) -> None:
             # Auto-refresh is best-effort; never surface an error popup on every
             # focus (e.g. when offline). The cooldown timestamp is still advanced.
             self._subscriptions_fetch_in_flight = False
-            self._subscriptions_refetch_pending = False
             self._last_subscriptions_fetch = time.monotonic()
             LOGGER.warning("Auto-refresh of deck subscriptions failed.", exc_info=exc)
+            if sip.isdeleted(self):
+                return
+            # A change observed mid-request still deserves another attempt.
+            if self._subscriptions_refetch_pending:
+                self._subscriptions_refetch_pending = False
+                self._maybe_auto_refresh_decks_list()
 
         AddonQueryOp(
             op=lambda _: self.client.get_deck_subscriptions(),
@@ -991,7 +1039,9 @@ class DeckManagementDialog(QDialog):
 
     def _apply_fetched_subscriptions(self, decks: List[Deck]) -> None:
         current_snapshot = self._current_decks_snapshot()
-        if self._snapshot_for_decks(decks) == current_snapshot:
+        # Order-insensitive: a reordered-but-identical list isn't a real change, so
+        # comparing as sets avoids a needless rebuild (and visible reshuffle).
+        if set(self._snapshot_for_decks(decks)) == set(current_snapshot):
             # Nothing changed: skip the rebuild so the list doesn't flicker and the
             # current selection / right-panel state is left untouched.
             return
@@ -1000,12 +1050,14 @@ class DeckManagementDialog(QDialog):
         new_ids = {deck.ah_did for deck in decks}
         added_ids = new_ids - old_ids
 
-        if len(added_ids) == 1:
-            # Exactly one new subscription (the common "just subscribed on the web"
-            # case): select it so its panel — including "Sync to install" — is shown.
+        current = self._selected_ah_did()
+        if current is None and len(added_ids) == 1:
+            # Nothing selected and exactly one new subscription (the common "just
+            # subscribed on the web" case): select it so its panel — including
+            # "Sync to install" — is shown. If the user already has a deck selected
+            # we keep it, so a refresh can't retarget an in-progress workflow.
             select_ah_did: Optional[UUID] = next(iter(added_ids))
         else:
-            current = self._selected_ah_did()
             select_ah_did = current if current in new_ids else None
 
         self._populate_decks_list(decks, select_ah_did=select_ah_did)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -46,7 +46,7 @@ from aqt.gui_hooks import (
     overview_will_render_bottom,
 )
 from aqt.importing import AnkiPackageImporter
-from aqt.qt import QAction, Qt, QUrl, QWidget
+from aqt.qt import QAction, QEvent, Qt, QUrl, QWidget
 from aqt.theme import theme_manager
 from aqt.webview import AnkiWebView
 from pytest import fixture
@@ -4618,7 +4618,7 @@ class TestDeckManagementDialog:
             populate_spy.assert_not_called()
             assert dialog._selected_ah_did() == ah_did
 
-    def test_auto_refresh_throttles_and_skips_in_flight(
+    def test_auto_refresh_defers_rather_than_drops_then_fetches(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
@@ -4641,23 +4641,59 @@ class TestDeckManagementDialog:
             mocker.patch("ankihub.gui.decks_dialog.QApplication.activePopupWidget", return_value=None)
 
             auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
+            defer_mock = mocker.patch.object(dialog._refresh_debounce_timer, "start")
 
-            # Just fetched (within the min interval, e.g. the activation emitted while
-            # showing the dialog) -> no fetch.
+            # Within the min interval -> defer (re-arm the timer), don't drop or fetch.
             dialog._last_subscriptions_fetch = monotonic()
             dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_not_called()
+            defer_mock.assert_called_once()
 
-            # Past the min interval but a fetch is already in flight -> no fetch.
+            # Past the min interval but a fetch is in flight -> defer, don't fetch.
+            defer_mock.reset_mock()
             dialog._last_subscriptions_fetch = monotonic() - (dialog._REFRESH_MIN_INTERVAL_SECONDS + 1.0)
             dialog._subscriptions_fetch_in_flight = True
             dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_not_called()
+            defer_mock.assert_called_once()
 
             # Past the min interval and nothing in flight -> fetch.
             dialog._subscriptions_fetch_in_flight = False
             dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_called_once()
+
+    def test_auto_refresh_only_triggers_on_genuine_return(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            ah_did = install_ah_deck()
+            anki_did = config.deck_config(ah_did).anki_id
+            deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did)
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+
+            start_mock = mocker.patch.object(dialog._refresh_debounce_timer, "start")
+            activation_event = QEvent(QEvent.Type.ActivationChange)
+
+            # Activation without a prior deactivation (e.g. while first showing the
+            # dialog) must not schedule a refresh.
+            mocker.patch.object(dialog, "isActiveWindow", return_value=True)
+            dialog.changeEvent(activation_event)
+            start_mock.assert_not_called()
+
+            # Losing then regaining activation is a genuine return -> schedule one.
+            mocker.patch.object(dialog, "isActiveWindow", return_value=False)
+            dialog.changeEvent(activation_event)
+            mocker.patch.object(dialog, "isActiveWindow", return_value=True)
+            dialog.changeEvent(activation_event)
+            start_mock.assert_called_once()
 
     def test_toggle_subdecks(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4546,13 +4546,46 @@ class TestDeckManagementDialog:
             dialog.display_subscribe_window()
             assert dialog.decks_list.count() == 1
 
-            # A new deck appears, as if the user subscribed to it on the web.
+            # A new deck appears, as if the user subscribed to it on the web. Nothing
+            # is selected yet, so the single new deck is auto-selected.
             new_deck = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck")
             dialog._apply_fetched_subscriptions([existing_deck, new_deck])
 
             assert dialog.decks_list.count() == 2
             # The single newly-added deck is auto-selected so its panel is surfaced.
             assert dialog._selected_ah_did() == new_deck.ah_did
+
+    def test_auto_refresh_keeps_existing_selection_when_deck_added(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            existing_deck_name = "Existing Deck"
+            ah_did = install_ah_deck(ah_deck_name=existing_deck_name)
+            anki_did = config.deck_config(ah_did).anki_id
+            existing_deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did, name=existing_deck_name)
+
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[existing_deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+            # The user has a deck selected (e.g. is configuring it).
+            dialog.decks_list.setCurrentRow(0)
+            qtbot.wait(200)
+            assert dialog._selected_ah_did() == ah_did
+
+            # A new deck appears while the user has a selection -> the selection must
+            # not be stolen (a refresh could otherwise retarget an in-progress workflow).
+            new_deck = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck")
+            dialog._apply_fetched_subscriptions([existing_deck, new_deck])
+
+            assert dialog.decks_list.count() == 2
+            assert dialog._selected_ah_did() == ah_did
 
     def test_auto_refresh_is_noop_when_subscriptions_unchanged(
         self,
@@ -4585,7 +4618,7 @@ class TestDeckManagementDialog:
             populate_spy.assert_not_called()
             assert dialog._selected_ah_did() == ah_did
 
-    def test_auto_refresh_skips_fetch_during_cooldown(
+    def test_auto_refresh_defers_during_cooldown_then_fetches(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
@@ -4602,13 +4635,21 @@ class TestDeckManagementDialog:
             dialog = DeckManagementDialog()
             dialog.display_subscribe_window()
 
-            auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
+            # Isolate the cooldown branching from the "child dialog open" guard (the
+            # test harness leaves sibling modal dialogs around).
+            mocker.patch("ankihub.gui.decks_dialog.QApplication.activeModalWidget", return_value=None)
+            mocker.patch("ankihub.gui.decks_dialog.QApplication.activePopupWidget", return_value=None)
 
-            # Within the cooldown window after the initial load -> no fetch.
+            auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
+            schedule_mock = mocker.patch.object(dialog, "_schedule_auto_refresh")
+
+            # Within the cooldown window after the initial load -> defer (don't drop)
+            # the activation rather than fetch immediately.
             dialog._maybe_auto_refresh_decks_list()
             auto_refresh_mock.assert_not_called()
+            schedule_mock.assert_called_once()
 
-            # Past the cooldown -> a fetch is triggered.
+            # Past the cooldown -> fetch immediately.
             dialog._last_subscriptions_fetch = 0.0
             dialog._maybe_auto_refresh_decks_list()
             auto_refresh_mock.assert_called_once()

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9,7 +9,7 @@ import uuid
 from concurrent.futures import Future
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from time import monotonic, sleep, time
+from time import sleep, time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Set, Tuple, Union, cast
 from unittest.mock import Mock
 from zipfile import ZipFile
@@ -4618,7 +4618,7 @@ class TestDeckManagementDialog:
             populate_spy.assert_not_called()
             assert dialog._selected_ah_did() == ah_did
 
-    def test_auto_refresh_defers_rather_than_drops_then_fetches(
+    def test_auto_refresh_defers_while_fetch_in_flight(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
@@ -4635,29 +4635,21 @@ class TestDeckManagementDialog:
             dialog = DeckManagementDialog()
             dialog.display_subscribe_window()
 
-            # Isolate the throttle/in-flight branching from the "child dialog open"
-            # guard (the test harness leaves sibling modal dialogs around).
+            # Isolate the in-flight branching from the "child dialog open" guard (the
+            # test harness leaves sibling modal dialogs around).
             mocker.patch("ankihub.gui.decks_dialog.QApplication.activeModalWidget", return_value=None)
             mocker.patch("ankihub.gui.decks_dialog.QApplication.activePopupWidget", return_value=None)
 
             auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
             defer_mock = mocker.patch.object(dialog._refresh_debounce_timer, "start")
 
-            # Within the min interval -> defer (re-arm the timer), don't drop or fetch.
-            dialog._last_subscriptions_fetch = monotonic()
-            dialog._on_refresh_debounce_timeout()
-            auto_refresh_mock.assert_not_called()
-            defer_mock.assert_called_once()
-
-            # Past the min interval but a fetch is in flight -> defer, don't fetch.
-            defer_mock.reset_mock()
-            dialog._last_subscriptions_fetch = monotonic() - (dialog._REFRESH_MIN_INTERVAL_SECONDS + 1.0)
+            # A fetch is already in flight -> defer (re-arm the timer), don't drop or fetch.
             dialog._subscriptions_fetch_in_flight = True
             dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_not_called()
             defer_mock.assert_called_once()
 
-            # Past the min interval and nothing in flight -> fetch.
+            # Nothing in flight -> fetch.
             dialog._subscriptions_fetch_in_flight = False
             dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_called_once()

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4579,14 +4579,17 @@ class TestDeckManagementDialog:
             dialog.display_subscribe_window()
             assert dialog.decks_list.count() == 1
 
-            # Two new decks appear at once, with nothing selected.
-            new_deck_a = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck A")
-            new_deck_b = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck B")
-            dialog._apply_fetched_subscriptions([existing_deck, new_deck_a, new_deck_b])
+            # Two new decks appear at once, with nothing selected. Give the deck that
+            # comes LAST in the response the LOWER ah_did, so a passing assertion can
+            # only be explained by "last in response" — not by first-in-response or by
+            # any id/set ordering.
+            new_deck_first = DeckFactory.create(ah_did=uuid.UUID(int=2), name="Newly Subscribed Deck A")
+            new_deck_last = DeckFactory.create(ah_did=uuid.UUID(int=1), name="Newly Subscribed Deck B")
+            dialog._apply_fetched_subscriptions([existing_deck, new_deck_first, new_deck_last])
 
             assert dialog.decks_list.count() == 3
-            # The last newly-added deck in the response is auto-selected.
-            assert dialog._selected_ah_did() == new_deck_b.ah_did
+            # The deck appearing last in the response is auto-selected.
+            assert dialog._selected_ah_did() == new_deck_last.ah_did
 
     def test_auto_refresh_keeps_existing_selection_when_deck_added(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4618,7 +4618,7 @@ class TestDeckManagementDialog:
             populate_spy.assert_not_called()
             assert dialog._selected_ah_did() == ah_did
 
-    def test_auto_refresh_defers_during_cooldown_then_fetches(
+    def test_auto_refresh_throttles_and_skips_in_flight(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
@@ -4635,31 +4635,28 @@ class TestDeckManagementDialog:
             dialog = DeckManagementDialog()
             dialog.display_subscribe_window()
 
-            # Isolate the cooldown branching from the "child dialog open" guard (the
-            # test harness leaves sibling modal dialogs around).
+            # Isolate the throttle/in-flight branching from the "child dialog open"
+            # guard (the test harness leaves sibling modal dialogs around).
             mocker.patch("ankihub.gui.decks_dialog.QApplication.activeModalWidget", return_value=None)
             mocker.patch("ankihub.gui.decks_dialog.QApplication.activePopupWidget", return_value=None)
 
             auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
-            schedule_mock = mocker.patch.object(dialog, "_schedule_auto_refresh")
 
-            # Just fetched (within the grace window, e.g. the activation emitted while
-            # showing the dialog) -> ignore: neither fetch nor schedule.
+            # Just fetched (within the min interval, e.g. the activation emitted while
+            # showing the dialog) -> no fetch.
             dialog._last_subscriptions_fetch = monotonic()
-            dialog._maybe_auto_refresh_decks_list()
+            dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_not_called()
-            schedule_mock.assert_not_called()
 
-            # Past the grace window but within the cooldown -> defer (don't drop) the
-            # activation rather than fetch immediately.
-            dialog._last_subscriptions_fetch = monotonic() - 1.0
-            dialog._maybe_auto_refresh_decks_list()
+            # Past the min interval but a fetch is already in flight -> no fetch.
+            dialog._last_subscriptions_fetch = monotonic() - (dialog._REFRESH_MIN_INTERVAL_SECONDS + 1.0)
+            dialog._subscriptions_fetch_in_flight = True
+            dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_not_called()
-            schedule_mock.assert_called_once()
 
-            # Past the cooldown -> fetch immediately.
-            dialog._last_subscriptions_fetch = monotonic() - (dialog._AUTO_REFRESH_COOLDOWN_SECONDS + 1.0)
-            dialog._maybe_auto_refresh_decks_list()
+            # Past the min interval and nothing in flight -> fetch.
+            dialog._subscriptions_fetch_in_flight = False
+            dialog._on_refresh_debounce_timeout()
             auto_refresh_mock.assert_called_once()
 
     def test_toggle_subdecks(

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -46,7 +46,7 @@ from aqt.gui_hooks import (
     overview_will_render_bottom,
 )
 from aqt.importing import AnkiPackageImporter
-from aqt.qt import QAction, QEvent, Qt, QUrl, QWidget
+from aqt.qt import QAction, QDialog, QEvent, Qt, QUrl, QWidget
 from aqt.theme import theme_manager
 from aqt.webview import AnkiWebView
 from pytest import fixture
@@ -4686,6 +4686,125 @@ class TestDeckManagementDialog:
             mocker.patch.object(dialog, "isActiveWindow", return_value=True)
             dialog.changeEvent(activation_event)
             start_mock.assert_called_once()
+
+    def test_auto_refresh_discards_stale_async_result_after_sync_refresh(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        """If a sync refresh runs while an async auto-refresh is in flight, the
+        stale async result must be dropped on completion (generation guard) so it
+        can't clobber the newer list.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            deck_name = "Existing Deck"
+            ah_did = install_ah_deck(ah_deck_name=deck_name)
+            anki_did = config.deck_config(ah_did).anki_id
+            existing_deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did, name=deck_name)
+
+            get_subs_mock = mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[existing_deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+            assert dialog.decks_list.count() == 1
+
+            # Capture the async on_success without firing it, so we control when (and
+            # against which generation) the stale result lands.
+            captured: dict = {}
+
+            class FakeQueryOp:
+                def __init__(self, *, op, success, parent):
+                    captured["success"] = success
+
+                def failure(self, failure):
+                    return self
+
+                def run_in_background(self):
+                    pass  # never actually runs the op
+
+            mocker.patch("ankihub.gui.decks_dialog.AddonQueryOp", FakeQueryOp)
+
+            # Start the async auto-refresh: its on_success closure captures the
+            # current generation. The op never runs (FakeQueryOp), so the in-flight
+            # result is effectively pending.
+            dialog._auto_refresh_decks_list()
+            assert "success" in captured
+
+            # A sync refresh (e.g. an unsubscribe) lands while the async is in flight,
+            # rebuilds the list to a new state, and bumps the fetch generation.
+            get_subs_mock.return_value = []
+            dialog._refresh_decks_list()
+            assert dialog.decks_list.count() == 0
+
+            # Now fire the in-flight async's on_success with the stale list (still
+            # containing the deck). The captured generation no longer matches, so the
+            # result must be discarded — apply must not run, list must stay empty.
+            apply_spy = mocker.spy(dialog, "_apply_fetched_subscriptions")
+            captured["success"]([existing_deck])
+
+            apply_spy.assert_not_called()
+            assert dialog.decks_list.count() == 0
+
+    def test_auto_refresh_modal_and_popup_guard(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        """The debounce timeout must skip when a child modal/popup is open, but the
+        dialog itself being application-modal must NOT block its own refresh — the
+        `is not self` carve-out is what keeps auto-refresh working at all.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            ah_did = install_ah_deck()
+            anki_did = config.deck_config(ah_did).anki_id
+            deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did)
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+
+            active_modal_mock = mocker.patch(
+                "ankihub.gui.decks_dialog.QApplication.activeModalWidget", return_value=None
+            )
+            active_popup_mock = mocker.patch(
+                "ankihub.gui.decks_dialog.QApplication.activePopupWidget", return_value=None
+            )
+            auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
+            timer_start_mock = mocker.patch.object(dialog._refresh_debounce_timer, "start")
+
+            # (a) A child modal dialog is open -> skip; closing it would re-trigger via
+            # ActivationChange, so nothing is lost (no fetch, no re-arm here).
+            active_modal_mock.return_value = QDialog(dialog)
+            active_popup_mock.return_value = None
+            auto_refresh_mock.reset_mock()
+            timer_start_mock.reset_mock()
+            dialog._on_refresh_debounce_timeout()
+            auto_refresh_mock.assert_not_called()
+            timer_start_mock.assert_not_called()
+
+            # (b) The dialog itself is the active modal (it's application-modal) -> the
+            # `is not self` carve-out lets the refresh proceed.
+            active_modal_mock.return_value = dialog
+            active_popup_mock.return_value = None
+            auto_refresh_mock.reset_mock()
+            dialog._subscriptions_fetch_in_flight = False
+            dialog._on_refresh_debounce_timeout()
+            auto_refresh_mock.assert_called_once()
+
+            # (c) A popup (e.g. combo dropdown) is open -> skip (no fetch, no re-arm).
+            active_modal_mock.return_value = None
+            active_popup_mock.return_value = QWidget()
+            auto_refresh_mock.reset_mock()
+            timer_start_mock.reset_mock()
+            dialog._on_refresh_debounce_timeout()
+            auto_refresh_mock.assert_not_called()
+            timer_start_mock.assert_not_called()
 
     def test_toggle_subdecks(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4555,6 +4555,39 @@ class TestDeckManagementDialog:
             # The single newly-added deck is auto-selected so its panel is surfaced.
             assert dialog._selected_ah_did() == new_deck.ah_did
 
+    def test_auto_refresh_selects_last_added_when_multiple_decks_added(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        """When the user subscribes to several decks on the web before returning,
+        auto-select the one that appears last in the server response — the closest
+        proxy we have for 'last added' since Deck carries no subscription timestamp.
+        """
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            existing_deck_name = "Existing Deck"
+            ah_did = install_ah_deck(ah_deck_name=existing_deck_name)
+            anki_did = config.deck_config(ah_did).anki_id
+            existing_deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did, name=existing_deck_name)
+
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[existing_deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+            assert dialog.decks_list.count() == 1
+
+            # Two new decks appear at once, with nothing selected.
+            new_deck_a = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck A")
+            new_deck_b = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck B")
+            dialog._apply_fetched_subscriptions([existing_deck, new_deck_a, new_deck_b])
+
+            assert dialog.decks_list.count() == 3
+            # The last newly-added deck in the response is auto-selected.
+            assert dialog._selected_ah_did() == new_deck_b.ah_did
+
     def test_auto_refresh_keeps_existing_selection_when_deck_added(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4526,6 +4526,93 @@ class TestDeckManagementDialog:
             deck_name = config.deck_config(ah_did).name
             assert deck_name in dialog.deck_name_label.text()
 
+    def test_auto_refresh_selects_newly_added_deck(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            existing_deck_name = "Existing Deck"
+            ah_did = install_ah_deck(ah_deck_name=existing_deck_name)
+            anki_did = config.deck_config(ah_did).anki_id
+            existing_deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did, name=existing_deck_name)
+
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[existing_deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+            assert dialog.decks_list.count() == 1
+
+            # A new deck appears, as if the user subscribed to it on the web.
+            new_deck = DeckFactory.create(ah_did=uuid.uuid4(), name="Newly Subscribed Deck")
+            dialog._apply_fetched_subscriptions([existing_deck, new_deck])
+
+            assert dialog.decks_list.count() == 2
+            # The single newly-added deck is auto-selected so its panel is surfaced.
+            assert dialog._selected_ah_did() == new_deck.ah_did
+
+    def test_auto_refresh_is_noop_when_subscriptions_unchanged(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            deck_name = "Test Deck"
+            ah_did = install_ah_deck(ah_deck_name=deck_name)
+            anki_did = config.deck_config(ah_did).anki_id
+            deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did, name=deck_name)
+
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+            dialog.decks_list.setCurrentRow(0)
+            qtbot.wait(200)
+
+            populate_spy = mocker.spy(dialog, "_populate_decks_list")
+
+            # The same set of subscriptions must not trigger a rebuild (no flicker,
+            # selection preserved).
+            dialog._apply_fetched_subscriptions([deck])
+
+            populate_spy.assert_not_called()
+            assert dialog._selected_ah_did() == ah_did
+
+    def test_auto_refresh_skips_fetch_during_cooldown(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            self._mock_dependencies(mocker)
+
+            ah_did = install_ah_deck()
+            anki_did = config.deck_config(ah_did).anki_id
+            deck = DeckFactory.create(ah_did=ah_did, anki_did=anki_did)
+            mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[deck])
+
+            dialog = DeckManagementDialog()
+            dialog.display_subscribe_window()
+
+            auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
+
+            # Within the cooldown window after the initial load -> no fetch.
+            dialog._maybe_auto_refresh_decks_list()
+            auto_refresh_mock.assert_not_called()
+
+            # Past the cooldown -> a fetch is triggered.
+            dialog._last_subscriptions_fetch = 0.0
+            dialog._maybe_auto_refresh_decks_list()
+            auto_refresh_mock.assert_called_once()
+
     def test_toggle_subdecks(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9,7 +9,7 @@ import uuid
 from concurrent.futures import Future
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from time import sleep, time
+from time import monotonic, sleep, time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Set, Tuple, Union, cast
 from unittest.mock import Mock
 from zipfile import ZipFile
@@ -4643,14 +4643,22 @@ class TestDeckManagementDialog:
             auto_refresh_mock = mocker.patch.object(dialog, "_auto_refresh_decks_list")
             schedule_mock = mocker.patch.object(dialog, "_schedule_auto_refresh")
 
-            # Within the cooldown window after the initial load -> defer (don't drop)
-            # the activation rather than fetch immediately.
+            # Just fetched (within the grace window, e.g. the activation emitted while
+            # showing the dialog) -> ignore: neither fetch nor schedule.
+            dialog._last_subscriptions_fetch = monotonic()
+            dialog._maybe_auto_refresh_decks_list()
+            auto_refresh_mock.assert_not_called()
+            schedule_mock.assert_not_called()
+
+            # Past the grace window but within the cooldown -> defer (don't drop) the
+            # activation rather than fetch immediately.
+            dialog._last_subscriptions_fetch = monotonic() - 1.0
             dialog._maybe_auto_refresh_decks_list()
             auto_refresh_mock.assert_not_called()
             schedule_mock.assert_called_once()
 
             # Past the cooldown -> fetch immediately.
-            dialog._last_subscriptions_fetch = 0.0
+            dialog._last_subscriptions_fetch = monotonic() - (dialog._AUTO_REFRESH_COOLDOWN_SECONDS + 1.0)
             dialog._maybe_auto_refresh_decks_list()
             auto_refresh_mock.assert_called_once()
 


### PR DESCRIPTION
## Related issues
- Closes [NRT-763](https://ankihub.atlassian.net/browse/NRT-763)

## Proposed changes
The **Deck Management** dialog only refreshed its subscription list on open, unsubscribe, and reopen. So when a user clicked **🔗 Browse Decks**, subscribed to a deck on the web, and switched back to the still-open dialog, the new deck didn't appear until they closed and reopened the dialog.

This makes the dialog auto-refresh when it regains focus. Returning from the external browser raises a window-activation event (not a focus-in/show), so the trigger is `changeEvent()` + `QEvent.Type.ActivationChange`. It only acts on a **genuine return** — the window was deactivated and then reactivated — which naturally excludes the activation Qt emits while the dialog is first shown (no timing heuristic needed).

The refresh is built to be cheap and non-disruptive:

- **Async fetch** via `AddonQueryOp` (no progress spinner) — `get_deck_subscriptions()` is a blocking HTTP call, so it never runs on the UI thread.
- **Diff before render:** an order-insensitive `(ah_did, name, user_relation)` snapshot is compared against the current list; the list is only rebuilt when it actually changed. Unchanged returns are no-ops → no flicker, current selection preserved.
- **Selection on change:** if nothing is currently selected and one or more decks were added (the common "just subscribed on the web" case), one is auto-selected and scrolled into view, surfacing its panel — including the "⚠️ not installed → 🔃 Sync to install" nudge. When several decks were added at once, the one appearing last in the server response is picked (there is no per-deck "subscribed at" timestamp, so this is the closest proxy for "last added"). If the user already has a deck selected, that selection is kept, so a refresh can't retarget an in-progress, deck-scoped workflow (publish / change-destination).
- **Debounce + defer:** a 400 ms debounce coalesces bursts of activations into one refresh. If a fetch is already in flight, the return is deferred (the timer re-arms) rather than dropped, so a change the in-flight request didn't capture is still picked up.
- **Safety:** the auto path is skipped while a child modal/popup is open (closing it reactivates the dialog, re-triggering); async results are versioned so a stale in-flight fetch can't clobber a newer (e.g. post-unsubscribe) refresh; callbacks are guarded with `sip.isdeleted(self)` / `isVisible()` (the dialog is retained by a singleton, so it can be closed-but-not-deleted); and the rebuild blocks signals to avoid the `itemSelectionChanged → _refresh_box_bottom_right` cascade flashing the right panel.
- **Errors:** failures on the auto path are logged silently — no error popup on every focus when offline.

All changes are contained to `ankihub/gui/decks_dialog.py`.

## How to reproduce
1. AnkiHub menu → **Deck Management**.
2. Click **🔗 Browse Decks** — the deck catalog opens in the browser.
3. Subscribe to a deck on the web.
4. Switch back to the still-open Deck Management dialog.
5. **Before:** the new deck is missing until you close and reopen the dialog. **After:** the deck appears (and, if nothing was selected, is selected) shortly after the dialog regains focus.

## Screenshots and videos
_No UI screenshots — behavioural change._ Verified manually on Linux (subscribe-on-web → return → deck appears on focus; no flicker on unchanged returns) in addition to the automated tests below.

## Further comments
A manual "Refresh" button was considered as a simpler fallback; auto-refresh-on-focus was chosen so it Just Works, with the diff/defer/guards above keeping it safe. Added tests (`test_auto_refresh_*`) covering: auto-select of a single new deck, auto-select of the last-in-response deck when several are added at once, keeping an existing selection when a deck is added, no-op on unchanged subscriptions, deferral while a fetch is in flight, the stale-async-result generation guard, the child-modal/popup guard, and that a refresh only triggers on a genuine return (not the initial show).


[NRT-763]: https://ankihub.atlassian.net/browse/NRT-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

