### PR TITLE
[NRT-777] perf: Run subdeck-tag check off the main thread in Deck Management dialog

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1210,33 +1210,32 @@ class DeckManagementDialog(QDialog):
     def _refresh_subdecks_checkbox(self):
         ah_did = self._selected_ah_did()
 
-        # The stored enabled/checked state doesn't require a DB query, so reflect it
-        # immediately.
+        # Apply the parts that don't require a DB query immediately: the checked state
+        # from config, and the static tooltip.
         deck_config = config.deck_config(ah_did)
         self.subdecks_cb.setChecked(deck_config.subdecks_enabled)
         set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
 
         # Whether the checkbox is interactive depends on whether the deck has subdeck
-        # tags, which requires scanning every note's tags in the AnkiHub DB. For large
-        # decks (tens of thousands of notes with long tag strings) this takes ~100ms,
-        # so run it off the main thread to keep deck selection responsive, then apply
-        # the result once it returns.
+        # tags — a scan over every note's tags in the AnkiHub DB. For large decks this
+        # takes ~100ms, so run it off the main thread and apply the result once it
+        # returns.
         self.subdecks_cb.setEnabled(False)
         self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }")
 
         # Capture the specific checkbox this op is started for. If the panel rebuilds
-        # before the op completes (deck switch, toggle, auto-refresh, ...) self.subdecks_cb
+        # before the op completes (deck switch, toggle, auto-refresh) self.subdecks_cb
         # will point to a new widget and we'll skip applying this now-stale result.
         checkbox = self.subdecks_cb
 
-        # Best-effort check: on failure, log and leave the checkbox in its loading-state
-        # disabled rather than surfacing the add-on's default error dialog for a
-        # transient DB / profile-close error.
         AddonQueryOp(
             op=lambda _: deck_contains_subdeck_tags(ah_did),
             success=lambda has_subdeck_tags: self._apply_subdecks_checkbox_state(ah_did, has_subdeck_tags, checkbox),
             parent=self,
         ).failure(
+            # Best-effort check: on failure, log and leave the checkbox in its loading-
+            # state disabled rather than surfacing the add-on's default error dialog
+            # for a transient DB / profile-close error.
             lambda exc: LOGGER.warning("Subdeck-tag check failed", ah_did=str(ah_did), error=repr(exc))
         ).without_collection().run_in_background()
 

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1224,21 +1224,36 @@ class DeckManagementDialog(QDialog):
         self.subdecks_cb.setEnabled(False)
         self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }")
 
+        # Capture the specific checkbox this op is started for. If the panel rebuilds
+        # before the op completes (deck switch, toggle, auto-refresh, ...) self.subdecks_cb
+        # will point to a new widget and we'll skip applying this now-stale result.
+        checkbox = self.subdecks_cb
+
+        # Best-effort check: on failure, log and leave the checkbox in its loading-state
+        # disabled rather than surfacing the add-on's default error dialog for a
+        # transient DB / profile-close error.
         AddonQueryOp(
             op=lambda _: deck_contains_subdeck_tags(ah_did),
-            success=lambda has_subdeck_tags: self._apply_subdecks_checkbox_state(ah_did, has_subdeck_tags),
+            success=lambda has_subdeck_tags: self._apply_subdecks_checkbox_state(ah_did, has_subdeck_tags, checkbox),
             parent=self,
+        ).failure(
+            lambda exc: LOGGER.warning("Subdeck-tag check failed", ah_did=str(ah_did), error=repr(exc))
         ).without_collection().run_in_background()
 
-    def _apply_subdecks_checkbox_state(self, ah_did: UUID, has_subdeck_tags: bool) -> None:
-        # Ignore stale results: the user may have selected a different deck while the
-        # query was running, in which case self.subdecks_cb now belongs to that deck.
-        if self._selected_ah_did() != ah_did:
+    def _apply_subdecks_checkbox_state(self, ah_did: UUID, has_subdeck_tags: bool, checkbox: QCheckBox) -> None:
+        # Guard against the dialog or the captured checkbox being torn down between op
+        # launch and completion (e.g. profile switch mid-query).
+        if sip.isdeleted(self) or sip.isdeleted(checkbox):
             return
 
-        self.subdecks_cb.setEnabled(has_subdeck_tags)
-        self.subdecks_cb.setStyleSheet("" if has_subdeck_tags else "QCheckBox { color: grey }")
-        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
+        # Ignore stale results: a different deck may have been selected (self.subdecks_cb
+        # is then a different widget) or this checkbox may have been rebuilt for the same
+        # deck. Either way, the now-current op will set the right state.
+        if self._selected_ah_did() != ah_did or self.subdecks_cb is not checkbox:
+            return
+
+        checkbox.setEnabled(has_subdeck_tags)
+        checkbox.setStyleSheet("" if has_subdeck_tags else "QCheckBox { color: grey }")
 
     @classmethod
     def display_subscribe_window(cls):

--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -1210,13 +1210,35 @@ class DeckManagementDialog(QDialog):
     def _refresh_subdecks_checkbox(self):
         ah_did = self._selected_ah_did()
 
-        has_subdeck_tags = deck_contains_subdeck_tags(ah_did)
-        self.subdecks_cb.setEnabled(has_subdeck_tags)
-        self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }" if not has_subdeck_tags else "")
-        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
-
+        # The stored enabled/checked state doesn't require a DB query, so reflect it
+        # immediately.
         deck_config = config.deck_config(ah_did)
         self.subdecks_cb.setChecked(deck_config.subdecks_enabled)
+        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
+
+        # Whether the checkbox is interactive depends on whether the deck has subdeck
+        # tags, which requires scanning every note's tags in the AnkiHub DB. For large
+        # decks (tens of thousands of notes with long tag strings) this takes ~100ms,
+        # so run it off the main thread to keep deck selection responsive, then apply
+        # the result once it returns.
+        self.subdecks_cb.setEnabled(False)
+        self.subdecks_cb.setStyleSheet("QCheckBox { color: grey }")
+
+        AddonQueryOp(
+            op=lambda _: deck_contains_subdeck_tags(ah_did),
+            success=lambda has_subdeck_tags: self._apply_subdecks_checkbox_state(ah_did, has_subdeck_tags),
+            parent=self,
+        ).without_collection().run_in_background()
+
+    def _apply_subdecks_checkbox_state(self, ah_did: UUID, has_subdeck_tags: bool) -> None:
+        # Ignore stale results: the user may have selected a different deck while the
+        # query was running, in which case self.subdecks_cb now belongs to that deck.
+        if self._selected_ah_did() != ah_did:
+            return
+
+        self.subdecks_cb.setEnabled(has_subdeck_tags)
+        self.subdecks_cb.setStyleSheet("" if has_subdeck_tags else "QCheckBox { color: grey }")
+        set_styled_tooltip(self.subdecks_cb, self.subdecks_tooltip_message)
 
     @classmethod
     def display_subscribe_window(cls):


### PR DESCRIPTION
## Related issues
- [NRT-777](https://ankihub.atlassian.net/browse/NRT-777)

> Stacked on `worktree-NRT-763-deck-dialog-autorefresh` and targets it as the base — the diff shows only this change. Retarget once NRT-763 lands.

## Proposed changes
Selecting a deck in **AnkiHub → 📚 Deck management** froze the dialog for several hundred milliseconds (often over a second in practice) on each click, worst on the first. Profiled live: `_refresh_box_bottom_right` rebuilds the right-hand panel synchronously on the main thread, and the dominant cost is `_refresh_subdecks_checkbox` → **`deck_contains_subdeck_tags(ah_did)`** — a leading-wildcard `ILIKE '%SUBDECK_TAG::%::%'` scan over every note's `tags` column in the AnkiHub DB. For an AnKing-style deck (~28k notes, avg ~1.3 KB tag strings, no matching subdeck tag so the `.exists()` query can't short-circuit) that's ~38 MB of text scanned per selection, ~90 ms on the main thread.

Move the scan into a background `AddonQueryOp().without_collection()` and apply the resulting enabled-state on the main thread when it returns. The stored *checked*-state and tooltip are still applied immediately; only the interactive-or-not bit arrives async. To keep that callback robust:

- Capture the specific `QCheckBox` instance the op was started for; in the success callback, skip if `sip.isdeleted(self)` / `sip.isdeleted(checkbox)` (dialog torn down mid-query, e.g. profile switch) or `self.subdecks_cb is not checkbox` (panel rebuilt the checkbox while the query was in flight).
- Add a `.failure()` handler that logs and leaves the checkbox in its disabled loading state, instead of raising into the central error handler for a transient DB / profile-close error.

**Measured (live, on the affected deck):** blocking refresh dropped from ~110 ms → ~23 ms, with the ~90 ms tag-scan now off the main thread.

Out of scope / known latent: the owner-only Note Types section is O(number of note types) (~1.6 ms/type), so it could lag for owners of decks with many note types — not hit in practice here.

## How to reproduce
1. Install the **AnKing deck**. Its ~28k notes carry long `!AK_UpdateTags::...` tag strings but no `AnkiHub_Subdeck` tags — exactly the combination that hits the slow path (full per-deck scan with no short-circuit, multiplied by long tag strings per row).
2. Open **AnkiHub → 📚 Deck management**.
3. Click the deck.
4. **Before:** the right-hand panel hangs for several hundred milliseconds, often well over a second; worst on the first click.
   **After:** the panel appears immediately; the "Enable Subdecks" checkbox is briefly greyed/disabled and becomes interactive a moment later once the background check completes.

## Screenshots and videos
N/A (perf fix; see measured numbers above).

## Further comments
All 19 `TestDeckManagementDialog` tests pass; mypy and pre-commit hooks (ruff check + format) are clean. Verified live on the affected machine with timing instrumentation (then removed).


[NRT-777]: https://ankihub.atlassian.net/browse/NRT-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ