### PR TITLE
[NRT-751] Disable the editor Suggest button when there's nothing to suggest

### DIFF
--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -50,7 +50,8 @@ def _setup_additional_editor_buttons():
     gui_hooks.webview_did_receive_js_message.append(_on_js_message)
     gui_hooks.editor_did_load_note.append(_refresh_buttons)
     gui_hooks.editor_did_init.append(_track_editor)
-    gui_hooks.editor_did_fire_typing_timer.append(_on_editor_typing_timer)
+    gui_hooks.editor_did_fire_typing_timer.append(_refresh_buttons_for_edited_note)
+    gui_hooks.editor_did_update_tags.append(_refresh_buttons_for_edited_note)
     gui_hooks.add_cards_did_change_note_type.append(_on_add_cards_did_change_notetype)
 
     Editor.ankihub_command = AnkiHubCommands.CHANGE.value  # type: ignore
@@ -439,8 +440,9 @@ def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
 
 editor: Editor
 
-# Live editors tracked so the typing-timer hook (which only receives a Note) can
-# locate the owning editor and refresh its button state as the user types.
+# Live editors tracked so the field-typing and tag-update hooks (which only
+# receive a Note) can locate the owning editor and refresh its button state as
+# the user edits.
 _tracked_editors: List[Editor] = []
 
 
@@ -448,7 +450,12 @@ def _track_editor(editor: Editor) -> None:
     _tracked_editors.append(editor)
 
 
-def _on_editor_typing_timer(note: Note) -> None:
+def _refresh_buttons_for_edited_note(note: Note) -> None:
+    """Refresh the owning editor's buttons after a field or tag edit.
+
+    Hook handler for editor_did_fire_typing_timer and editor_did_update_tags,
+    both of which pass only the edited Note.
+    """
     # Match by object identity, not note.id: unsaved Add-Cards notes all share
     # id 0, so an id comparison would refresh every open Add-Cards editor.
     for tracked in list(_tracked_editors):

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -152,7 +152,7 @@ def _on_suggestion_button_press(editor: Editor) -> None:
     # Cover the rest of the keyboard-shortcut path: it fires even when the
     # button is visually disabled, including for empty new notes that must
     # not fall through to add_current_note below.
-    ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id) if note.id != 0 else None
+    ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
     if ah_note is not None and cast(AnkiHubNote, ah_note).was_deleted():
         tooltip(NOTE_DELETED_TOOLTIP)
         return

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -3,7 +3,7 @@
 import functools
 from typing import Any, List, Tuple, cast
 
-from anki.models import NoteType, NotetypeId
+from anki.models import NotetypeId
 from anki.notes import Note
 from aqt import gui_hooks
 from aqt.addcards import AddCards
@@ -51,7 +51,6 @@ def _setup_additional_editor_buttons():
     gui_hooks.editor_did_init.append(_track_editor)
     gui_hooks.editor_did_fire_typing_timer.append(_refresh_buttons_for_edited_note)
     gui_hooks.editor_did_update_tags.append(_refresh_buttons_for_edited_note)
-    gui_hooks.add_cards_did_change_note_type.append(_on_add_cards_did_change_notetype)
 
     Editor.ankihub_command = AnkiHubCommands.CHANGE.value  # type: ignore
 
@@ -225,26 +224,6 @@ def _default_suggestion_button_tooltip() -> str:
     return f"Send your request to AnkiHub ({_suggestion_button_hotkey()})"
 
 
-def _should_block_for_no_changes(note: Note) -> bool:
-    """True when the 'No changes to suggest' gate should block suggesting `note`.
-
-    Behind AUTO_PROTECT_FEATURE_FLAG. Reuses the dialog's suggestibility check so
-    the editor button and the dialog's pre-open gate agree on what counts as a
-    suggestible change (field edit outside the globally-protected denylist, or a
-    tag change).
-    """
-    if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
-        return False
-    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
-    globally_protected = (
-        {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
-        if ah_did
-        else {}
-    )
-    diffs = compute_note_diffs([note])
-    return not any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected)
-
-
 def _suggestion_button_hotkey():
     return config.public_config["hotkey"]
 
@@ -359,6 +338,26 @@ def _refresh_editor_fields_for_anki_below_v50_js(hide_last_field: bool) -> str:
             """
 
 
+def _should_block_for_no_changes(note: Note) -> bool:
+    """True when the 'No changes to suggest' gate should block suggesting `note`.
+
+    Behind AUTO_PROTECT_FEATURE_FLAG. Reuses the dialog's suggestibility check so
+    the editor button and the dialog's pre-open gate agree on what counts as a
+    suggestible change (field edit outside the globally-protected denylist, or a
+    tag change).
+    """
+    if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
+        return False
+    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
+    globally_protected = (
+        {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
+        if ah_did
+        else {}
+    )
+    diffs = compute_note_diffs([note])
+    return not any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected)
+
+
 def _refresh_buttons(editor: Editor) -> None:
     """Enables/Disables buttons depending on the note type and if the note is synced with AnkiHub.
     Also changes the label of the suggestion button based on whether the note is already on AnkiHub.
@@ -437,9 +436,8 @@ def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
     editor.web.eval(set_tooltip_script.format(text))
 
 
-# Live editors tracked so hooks that don't hand us the Editor — the field-typing
-# and tag-update hooks (Note only) and the note-type-change hook (note types
-# only) — can still find the editor(s) to refresh.
+# Live editors tracked so the field-typing and tag-update hooks (which pass only
+# a Note, not the Editor) can find the owning editor to refresh.
 _tracked_editors: List[Editor] = []
 
 
@@ -447,31 +445,22 @@ def _track_editor(editor: Editor) -> None:
     _tracked_editors.append(editor)
 
 
-def _live_tracked_editors() -> List[Editor]:
-    """Tracked editors whose widget is still alive, pruning the rest in place."""
-    live = [e for e in _tracked_editors if not sip.isdeleted(e.widget)]
-    _tracked_editors[:] = live
-    return live
-
-
 def _refresh_buttons_for_edited_note(note: Note) -> None:
     """Refresh the owning editor's buttons after a field or tag edit.
 
     Hook handler for editor_did_fire_typing_timer and editor_did_update_tags,
-    both of which pass only the edited Note.
+    both of which pass only the edited Note. Note-type changes don't need a
+    handler here: they go through editor.loadNote, which fires
+    editor_did_load_note -> _refresh_buttons on the affected editor.
     """
     # Match by object identity, not note.id: unsaved Add-Cards notes all share
     # id 0, so an id comparison would refresh every open Add-Cards editor.
-    for tracked in _live_tracked_editors():
+    for tracked in list(_tracked_editors):
+        if sip.isdeleted(tracked.widget):
+            _tracked_editors.remove(tracked)
+            continue
         if tracked.note is note:
             _refresh_buttons(tracked)
-
-
-def _on_add_cards_did_change_notetype(old: NoteType, new: NoteType) -> None:
-    # The hook gives us the note types, not the editor, so refresh every live
-    # editor. _refresh_buttons is idempotent UI-only work.
-    for tracked in _live_tracked_editors():
-        _refresh_buttons(tracked)
 
 
 def _setup_editor_did_load_js_message(editor: Editor) -> None:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -36,6 +36,10 @@ SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"
 VIEW_NOTE_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note"
 VIEW_NOTE_HISTORY_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note-history"
 
+# Live editors tracked so the field-typing and tag-update hooks (which pass only
+# a Note, not the Editor) can find the owning editor to refresh.
+_tracked_editors: List[Editor] = []
+
 
 def setup() -> None:
     _setup_additional_editor_buttons()
@@ -434,11 +438,6 @@ def _set_suggestion_button_label(editor: Editor, label: str) -> None:
 def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
     set_tooltip_script = f"document.getElementById('{SUGGESTION_BTN_ID}').title='{{}}';"
     editor.web.eval(set_tooltip_script.format(text))
-
-
-# Live editors tracked so the field-typing and tag-update hooks (which pass only
-# a Note, not the Editor) can find the owning editor to refresh.
-_tracked_editors: List[Editor] = []
 
 
 def _track_editor(editor: Editor) -> None:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -139,7 +139,7 @@ def _on_suggestion_button_press(editor: Editor) -> None:
             if cast(AnkiHubNote, ah_note).was_deleted():
                 tooltip(NOTE_DELETED_TOOLTIP)
                 return
-            if _no_changes_gate_active(note):
+            if _should_block_for_no_changes(note):
                 tooltip(NO_CHANGES_TO_SUGGEST_TOOLTIP)
                 return
 
@@ -225,7 +225,7 @@ def _default_suggestion_button_tooltip() -> str:
     return f"Send your request to AnkiHub ({_suggestion_button_hotkey()})"
 
 
-def _no_changes_gate_active(note: Note) -> bool:
+def _should_block_for_no_changes(note: Note) -> bool:
     """True when the 'No changes to suggest' gate should block suggesting `note`.
 
     Behind AUTO_PROTECT_FEATURE_FLAG. Reuses the dialog's suggestibility check so
@@ -390,7 +390,7 @@ def _refresh_buttons(editor: Editor) -> None:
             _set_suggestion_button_tooltip(editor, NOTE_DELETED_TOOLTIP)
         else:
             _enable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
-            if _no_changes_gate_active(note):
+            if _should_block_for_no_changes(note):
                 _disable_buttons(editor, [SUGGESTION_BTN_ID])
                 _set_suggestion_button_tooltip(editor, NO_CHANGES_TO_SUGGEST_TOOLTIP)
             else:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -33,7 +33,7 @@ from ..settings import (
     url_view_note,
     url_view_note_history,
 )
-from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
+from .suggestion_dialog import globally_protected_fields_by_mid, open_suggestion_dialog_for_single_suggestion
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 NO_CHANGES_TO_SUGGEST_TOOLTIP = "No changes to suggest"
@@ -378,11 +378,7 @@ def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
     # otherwise the globally-protected map is empty and a globally-protected
     # first field wouldn't gate the button (the dialog resolves it the same way).
     ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id) or ankihub_db.ankihub_did_for_note_type(NotetypeId(note.mid))
-    globally_protected = (
-        {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
-        if ah_did
-        else {}
-    )
+    globally_protected = globally_protected_fields_by_mid(ah_did) if ah_did else {}
     diffs = compute_note_diffs([note])
     if any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected):
         return None

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -44,7 +44,6 @@ def setup() -> None:
 
 
 def _setup_additional_editor_buttons():
-    gui_hooks.add_cards_did_init.append(_on_add_cards_init)
     gui_hooks.editor_did_init_buttons.append(_setup_editor_buttons)
     gui_hooks.editor_did_init.append(_setup_editor_did_load_js_message)
     gui_hooks.webview_did_receive_js_message.append(_on_js_message)
@@ -438,16 +437,21 @@ def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
     editor.web.eval(set_tooltip_script.format(text))
 
 
-editor: Editor
-
-# Live editors tracked so the field-typing and tag-update hooks (which only
-# receive a Note) can locate the owning editor and refresh its button state as
-# the user edits.
+# Live editors tracked so hooks that don't hand us the Editor — the field-typing
+# and tag-update hooks (Note only) and the note-type-change hook (note types
+# only) — can still find the editor(s) to refresh.
 _tracked_editors: List[Editor] = []
 
 
 def _track_editor(editor: Editor) -> None:
     _tracked_editors.append(editor)
+
+
+def _live_tracked_editors() -> List[Editor]:
+    """Tracked editors whose widget is still alive, pruning the rest in place."""
+    live = [e for e in _tracked_editors if not sip.isdeleted(e.widget)]
+    _tracked_editors[:] = live
+    return live
 
 
 def _refresh_buttons_for_edited_note(note: Note) -> None:
@@ -458,22 +462,16 @@ def _refresh_buttons_for_edited_note(note: Note) -> None:
     """
     # Match by object identity, not note.id: unsaved Add-Cards notes all share
     # id 0, so an id comparison would refresh every open Add-Cards editor.
-    for tracked in list(_tracked_editors):
-        if sip.isdeleted(tracked.widget):
-            _tracked_editors.remove(tracked)
-            continue
+    for tracked in _live_tracked_editors():
         if tracked.note is note:
             _refresh_buttons(tracked)
 
 
-def _on_add_cards_init(add_cards: AddCards) -> None:
-    global editor
-    editor = add_cards.editor
-
-
 def _on_add_cards_did_change_notetype(old: NoteType, new: NoteType) -> None:
-    global editor
-    _refresh_buttons(editor)
+    # The hook gives us the note types, not the editor, so refresh every live
+    # editor. _refresh_buttons is idempotent UI-only work.
+    for tracked in _live_tracked_editors():
+        _refresh_buttons(tracked)
 
 
 def _setup_editor_did_load_js_message(editor: Editor) -> None:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -31,6 +31,7 @@ from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 NO_CHANGES_TO_SUGGEST_TOOLTIP = "No changes to suggest"
+NOTE_DELETED_TOOLTIP = "This note has been deleted from AnkiHub. No new suggestions can be made."
 SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"
 VIEW_NOTE_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note"
 VIEW_NOTE_HISTORY_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note-history"
@@ -134,9 +135,13 @@ def _on_suggestion_button_press(editor: Editor) -> None:
     note = editor.note
     if note is not None and note.id != 0:
         ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
-        if ah_note is not None and not cast(AnkiHubNote, ah_note).was_deleted() and _no_changes_gate_active(note):
-            tooltip(NO_CHANGES_TO_SUGGEST_TOOLTIP)
-            return
+        if ah_note is not None:
+            if cast(AnkiHubNote, ah_note).was_deleted():
+                tooltip(NOTE_DELETED_TOOLTIP)
+                return
+            if _no_changes_gate_active(note):
+                tooltip(NO_CHANGES_TO_SUGGEST_TOOLTIP)
+                return
 
     # The command is expected to have been set at this point already, either by
     # fetching the default or by selecting a command from the dropdown menu.
@@ -382,10 +387,7 @@ def _refresh_buttons(editor: Editor) -> None:
         if ah_note.was_deleted():
             _enable_buttons(editor, [VIEW_NOTE_HISTORY_BTN_ID])
             _disable_buttons(editor, [SUGGESTION_BTN_ID, VIEW_NOTE_BTN_ID])
-            _set_suggestion_button_tooltip(
-                editor,
-                "This note has been deleted from AnkiHub. No new suggestions can be made.",
-            )
+            _set_suggestion_button_tooltip(editor, NOTE_DELETED_TOOLTIP)
         else:
             _enable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
             if _no_changes_gate_active(note):
@@ -447,11 +449,13 @@ def _track_editor(editor: Editor) -> None:
 
 
 def _on_editor_typing_timer(note: Note) -> None:
+    # Match by object identity, not note.id: unsaved Add-Cards notes all share
+    # id 0, so an id comparison would refresh every open Add-Cards editor.
     for tracked in list(_tracked_editors):
         if sip.isdeleted(tracked.widget):
             _tracked_editors.remove(tracked)
             continue
-        if tracked.note is not None and tracked.note.id == note.id:
+        if tracked.note is note:
             _refresh_buttons(tracked)
 
 

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -139,18 +139,23 @@ def _on_suggestion_button_press(editor: Editor) -> None:
         AnkiHubLogin.display_login()
         return
 
-    # Covers the keyboard-shortcut path, which fires even when the button is
-    # visually disabled — including empty new notes, which must not fall through
-    # to add_current_note below.
+    # The visual gate disables every button when the note isn't an AnkiHub
+    # note type; the keyboard shortcut still fires, but there's nothing to do
+    # (and the dialog opener below would otherwise hit an assert).
     note = editor.note
-    if note is not None and ankihub_db.is_ankihub_note_type(note.mid):
-        ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id) if note.id != 0 else None
-        if ah_note is not None and cast(AnkiHubNote, ah_note).was_deleted():
-            tooltip(NOTE_DELETED_TOOLTIP)
-            return
-        if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
-            tooltip(gate_tooltip)
-            return
+    if note is None or not ankihub_db.is_ankihub_note_type(note.mid):
+        return
+
+    # Cover the rest of the keyboard-shortcut path: it fires even when the
+    # button is visually disabled, including for empty new notes that must
+    # not fall through to add_current_note below.
+    ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id) if note.id != 0 else None
+    if ah_note is not None and cast(AnkiHubNote, ah_note).was_deleted():
+        tooltip(NOTE_DELETED_TOOLTIP)
+        return
+    if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
+        tooltip(gate_tooltip)
+        return
 
     # The command is expected to have been set at this point already, either by
     # fetching the default or by selecting a command from the dropdown menu.

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -135,15 +135,17 @@ def _on_suggestion_button_press(editor: Editor) -> None:
     the hotkey is pressed.
     """
 
-    if not config.is_logged_in():
-        AnkiHubLogin.display_login()
-        return
-
     # The visual gate disables every button when the note isn't an AnkiHub
     # note type; the keyboard shortcut still fires, but there's nothing to do
-    # (and the dialog opener below would otherwise hit an assert).
+    # (and the dialog opener below would otherwise hit an assert). No-op
+    # before the login check so a logged-out user pressing the hotkey on a
+    # non-AnkiHub note doesn't get a misleading login prompt.
     note = editor.note
     if note is None or not ankihub_db.is_ankihub_note_type(note.mid):
+        return
+
+    if not config.is_logged_in():
+        AnkiHubLogin.display_login()
         return
 
     # Cover the rest of the keyboard-shortcut path: it fires even when the
@@ -361,6 +363,12 @@ def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
     dialog's suggestibility check so the editor button and the dialog's
     pre-open gate agree. An empty first field is reported distinctly from
     "no changes" — for a new note that's the only reason it can be gated.
+
+    Per NRT-508/751: change_type is treated as non-DELETE here, by design.
+    An unchanged existing AnkiHub note therefore gets the "no changes"
+    tooltip rather than enabling the button on the chance the user might
+    DELETE — DELETE-from-editor for unchanged notes is intentionally not
+    supported; the browser's "Suggest to delete" is the path for that.
     """
     if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
         return None

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -187,7 +187,7 @@ def _setup_editor_buttons(buttons: List[str], editor: Editor) -> None:
         func=lambda editor: editor.call_after_note_saved(
             functools.partial(_on_suggestion_button_press, editor), keepFocus=True
         ),
-        tip=f"Send your request to AnkiHub ({_suggestion_button_hotkey()})",
+        tip=_default_suggestion_button_tooltip(),
         label=f'<span id="{SUGGESTION_BTN_ID}-label" style="vertical-align: top;"></span>',
         id=SUGGESTION_BTN_ID,
         keys=_suggestion_button_hotkey(),
@@ -238,8 +238,9 @@ def _setup_editor_buttons(buttons: List[str], editor: Editor) -> None:
         )
 
 
-def _default_suggestion_button_tooltip() -> str:
-    return f"Send your request to AnkiHub ({_suggestion_button_hotkey()})"
+def _default_suggestion_button_tooltip(is_new_note: bool = False) -> str:
+    verb = "Suggest the note" if is_new_note else "Suggest a change"
+    return f"{verb} to AnkiHub ({_suggestion_button_hotkey()})"
 
 
 def _suggestion_button_hotkey():
@@ -386,7 +387,7 @@ def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
     return NO_CHANGES_TO_SUGGEST_TOOLTIP
 
 
-def _apply_suggestion_button_gate(editor: Editor, note: Note) -> None:
+def _apply_suggestion_button_gate(editor: Editor, note: Note, is_new_note: bool) -> None:
     """Enable or disable the suggestion button based on whether `note` has
     anything to suggest. Shared by the change-note and new-note branches;
     delegates the gating decision (and the feature-flag check) to
@@ -396,7 +397,7 @@ def _apply_suggestion_button_gate(editor: Editor, note: Note) -> None:
         _set_suggestion_button_tooltip(editor, gate_tooltip)
     else:
         _enable_buttons(editor, [SUGGESTION_BTN_ID])
-        _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip())
+        _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip(is_new_note))
 
 
 def _refresh_buttons(editor: Editor) -> None:
@@ -430,12 +431,12 @@ def _refresh_buttons(editor: Editor) -> None:
             _set_suggestion_button_tooltip(editor, NOTE_DELETED_TOOLTIP)
         else:
             _enable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
-            _apply_suggestion_button_gate(editor, note)
+            _apply_suggestion_button_gate(editor, note, is_new_note=False)
     else:
         command = AnkiHubCommands.NEW.value
 
         _disable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
-        _apply_suggestion_button_gate(editor, note)
+        _apply_suggestion_button_gate(editor, note, is_new_note=True)
 
     _set_suggestion_button_label(editor, command)
     editor.ankihub_command = command  # type: ignore

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -22,6 +22,7 @@ from ..main.suggestions import (
     _has_empty_first_field,
     any_suggestible_from_diffs,
     compute_note_diffs,
+    globally_protected_fields_by_mid,
 )
 from ..main.utils import is_tag_in_list, update_notes_with_named_undo
 from ..settings import (
@@ -33,7 +34,7 @@ from ..settings import (
     url_view_note,
     url_view_note_history,
 )
-from .suggestion_dialog import globally_protected_fields_by_mid, open_suggestion_dialog_for_single_suggestion
+from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 NO_CHANGES_TO_SUGGEST_TOOLTIP = "No changes to suggest"

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -16,7 +16,7 @@ from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
 from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
-from ..main.suggestions import AUTO_PROTECT_FEATURE_FLAG
+from ..main.suggestions import AUTO_PROTECT_FEATURE_FLAG, any_suggestible_from_diffs, compute_note_diffs
 from ..main.utils import is_tag_in_list, update_notes_with_named_undo
 from ..settings import (
     ANKI_INT_VERSION,
@@ -30,6 +30,7 @@ from ..settings import (
 from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
+NO_CHANGES_TO_SUGGEST_TOOLTIP = "No changes to suggest"
 SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"
 VIEW_NOTE_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note"
 VIEW_NOTE_HISTORY_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note-history"
@@ -47,6 +48,8 @@ def _setup_additional_editor_buttons():
     gui_hooks.editor_did_init.append(_setup_editor_did_load_js_message)
     gui_hooks.webview_did_receive_js_message.append(_on_js_message)
     gui_hooks.editor_did_load_note.append(_refresh_buttons)
+    gui_hooks.editor_did_init.append(_track_editor)
+    gui_hooks.editor_did_fire_typing_timer.append(_on_editor_typing_timer)
     gui_hooks.add_cards_did_change_note_type.append(_on_add_cards_did_change_notetype)
 
     Editor.ankihub_command = AnkiHubCommands.CHANGE.value  # type: ignore
@@ -124,6 +127,16 @@ def _on_suggestion_button_press(editor: Editor) -> None:
     if not config.is_logged_in():
         AnkiHubLogin.display_login()
         return
+
+    # Covers the keyboard-shortcut path, which fires even when the button is
+    # visually disabled. New notes (no AH-DB row) are never gated here — they
+    # always carry content to suggest.
+    note = editor.note
+    if note is not None and note.id != 0:
+        ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
+        if ah_note is not None and not cast(AnkiHubNote, ah_note).was_deleted() and _no_changes_gate_active(note):
+            tooltip(NO_CHANGES_TO_SUGGEST_TOOLTIP)
+            return
 
     # The command is expected to have been set at this point already, either by
     # fetching the default or by selecting a command from the dropdown menu.
@@ -205,6 +218,26 @@ def _setup_editor_buttons(buttons: List[str], editor: Editor) -> None:
 
 def _default_suggestion_button_tooltip() -> str:
     return f"Send your request to AnkiHub ({_suggestion_button_hotkey()})"
+
+
+def _no_changes_gate_active(note: Note) -> bool:
+    """True when the 'No changes to suggest' gate should block suggesting `note`.
+
+    Behind AUTO_PROTECT_FEATURE_FLAG. Reuses the dialog's suggestibility check so
+    the editor button and the dialog's pre-open gate agree on what counts as a
+    suggestible change (field edit outside the globally-protected denylist, or a
+    tag change).
+    """
+    if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
+        return False
+    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
+    globally_protected = (
+        {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
+        if ah_did
+        else {}
+    )
+    diffs = compute_note_diffs([note])
+    return not any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected)
 
 
 def _suggestion_button_hotkey():
@@ -354,11 +387,13 @@ def _refresh_buttons(editor: Editor) -> None:
                 "This note has been deleted from AnkiHub. No new suggestions can be made.",
             )
         else:
-            _enable_buttons(editor, all_button_ids)
-            _set_suggestion_button_tooltip(
-                editor,
-                _default_suggestion_button_tooltip(),
-            )
+            _enable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
+            if _no_changes_gate_active(note):
+                _disable_buttons(editor, [SUGGESTION_BTN_ID])
+                _set_suggestion_button_tooltip(editor, NO_CHANGES_TO_SUGGEST_TOOLTIP)
+            else:
+                _enable_buttons(editor, [SUGGESTION_BTN_ID])
+                _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip())
     else:
         command = AnkiHubCommands.NEW.value
 
@@ -401,6 +436,23 @@ def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
 
 
 editor: Editor
+
+# Live editors tracked so the typing-timer hook (which only receives a Note) can
+# locate the owning editor and refresh its button state as the user types.
+_tracked_editors: List[Editor] = []
+
+
+def _track_editor(editor: Editor) -> None:
+    _tracked_editors.append(editor)
+
+
+def _on_editor_typing_timer(note: Note) -> None:
+    for tracked in list(_tracked_editors):
+        if sip.isdeleted(tracked.widget):
+            _tracked_editors.remove(tracked)
+            continue
+        if tracked.note is not None and tracked.note.id == note.id:
+            _refresh_buttons(tracked)
 
 
 def _on_add_cards_init(add_cards: AddCards) -> None:

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -140,18 +140,17 @@ def _on_suggestion_button_press(editor: Editor) -> None:
         return
 
     # Covers the keyboard-shortcut path, which fires even when the button is
-    # visually disabled. New notes (no AH-DB row) are never gated here — they
-    # always carry content to suggest.
+    # visually disabled — including empty new notes, which must not fall through
+    # to add_current_note below.
     note = editor.note
-    if note is not None and note.id != 0:
-        ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id)
-        if ah_note is not None:
-            if cast(AnkiHubNote, ah_note).was_deleted():
-                tooltip(NOTE_DELETED_TOOLTIP)
-                return
-            if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
-                tooltip(gate_tooltip)
-                return
+    if note is not None and ankihub_db.is_ankihub_note_type(note.mid):
+        ah_note = AnkiHubNote.get_or_none(anki_note_id=note.id) if note.id != 0 else None
+        if ah_note is not None and cast(AnkiHubNote, ah_note).was_deleted():
+            tooltip(NOTE_DELETED_TOOLTIP)
+            return
+        if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
+            tooltip(gate_tooltip)
+            return
 
     # The command is expected to have been set at this point already, either by
     # fetching the default or by selecting a command from the dropdown menu.
@@ -362,7 +361,10 @@ def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
         return None
     if _has_empty_first_field(note):
         return EMPTY_FIRST_FIELD_TOOLTIP
-    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
+    # New notes have no AH-DB row, so fall back to the deck of their note type —
+    # otherwise the globally-protected map is empty and a globally-protected
+    # first field wouldn't gate the button (the dialog resolves it the same way).
+    ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id) or ankihub_db.ankihub_did_for_note_type(NotetypeId(note.mid))
     globally_protected = (
         {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
         if ah_did
@@ -376,8 +378,9 @@ def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
 
 def _apply_suggestion_button_gate(editor: Editor, note: Note) -> None:
     """Enable or disable the suggestion button based on whether `note` has
-    anything to suggest. Shared by the change-note and new-note branches; a
-    no-op (button stays enabled) when the feature flag is off."""
+    anything to suggest. Shared by the change-note and new-note branches;
+    delegates the gating decision (and the feature-flag check) to
+    `_suggestion_gate_tooltip`."""
     if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
         _disable_buttons(editor, [SUGGESTION_BTN_ID])
         _set_suggestion_button_tooltip(editor, gate_tooltip)
@@ -456,6 +459,9 @@ def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
 
 
 def _track_editor(editor: Editor) -> None:
+    # Sweep editors whose widget is gone so the list can't accumulate across a
+    # session (the edit hooks also prune, but only for editors that fire them).
+    _tracked_editors[:] = [e for e in _tracked_editors if not sip.isdeleted(e.widget)]
     _tracked_editors.append(editor)
 
 

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -362,6 +362,18 @@ def _should_block_for_no_changes(note: Note) -> bool:
     return not any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected)
 
 
+def _apply_suggestion_button_gate(editor: Editor, note: Note) -> None:
+    """Enable or disable the suggestion button based on whether `note` has
+    anything to suggest. Shared by the change-note and new-note branches; a
+    no-op (button stays enabled) when the feature flag is off."""
+    if _should_block_for_no_changes(note):
+        _disable_buttons(editor, [SUGGESTION_BTN_ID])
+        _set_suggestion_button_tooltip(editor, NO_CHANGES_TO_SUGGEST_TOOLTIP)
+    else:
+        _enable_buttons(editor, [SUGGESTION_BTN_ID])
+        _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip())
+
+
 def _refresh_buttons(editor: Editor) -> None:
     """Enables/Disables buttons depending on the note type and if the note is synced with AnkiHub.
     Also changes the label of the suggestion button based on whether the note is already on AnkiHub.
@@ -393,21 +405,12 @@ def _refresh_buttons(editor: Editor) -> None:
             _set_suggestion_button_tooltip(editor, NOTE_DELETED_TOOLTIP)
         else:
             _enable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
-            if _should_block_for_no_changes(note):
-                _disable_buttons(editor, [SUGGESTION_BTN_ID])
-                _set_suggestion_button_tooltip(editor, NO_CHANGES_TO_SUGGEST_TOOLTIP)
-            else:
-                _enable_buttons(editor, [SUGGESTION_BTN_ID])
-                _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip())
+            _apply_suggestion_button_gate(editor, note)
     else:
         command = AnkiHubCommands.NEW.value
 
-        _enable_buttons(editor, [SUGGESTION_BTN_ID])
         _disable_buttons(editor, [VIEW_NOTE_BTN_ID, VIEW_NOTE_HISTORY_BTN_ID])
-        _set_suggestion_button_tooltip(
-            editor,
-            _default_suggestion_button_tooltip(),
-        )
+        _apply_suggestion_button_gate(editor, note)
 
     _set_suggestion_button_label(editor, command)
     editor.ankihub_command = command  # type: ignore

--- a/ankihub/gui/editor.py
+++ b/ankihub/gui/editor.py
@@ -1,7 +1,8 @@
 """Modifies the Anki editor (aqt.editor) to add AnkiHub buttons and functionality."""
 
 import functools
-from typing import Any, List, Tuple, cast
+import json
+from typing import Any, List, Optional, Tuple, cast
 
 from anki.models import NotetypeId
 from anki.notes import Note
@@ -16,7 +17,12 @@ from ..db import ankihub_db
 from ..db.models import AnkiHubNote
 from ..gui.menu import AnkiHubLogin
 from ..main.note_conversion import TAG_FOR_PROTECTING_ALL_FIELDS, protection_tag_for_field
-from ..main.suggestions import AUTO_PROTECT_FEATURE_FLAG, any_suggestible_from_diffs, compute_note_diffs
+from ..main.suggestions import (
+    AUTO_PROTECT_FEATURE_FLAG,
+    _has_empty_first_field,
+    any_suggestible_from_diffs,
+    compute_note_diffs,
+)
 from ..main.utils import is_tag_in_list, update_notes_with_named_undo
 from ..settings import (
     ANKI_INT_VERSION,
@@ -31,6 +37,7 @@ from .suggestion_dialog import open_suggestion_dialog_for_single_suggestion
 
 ANKIHUB_BTN_ID_PREFIX = "ankihub-btn"
 NO_CHANGES_TO_SUGGEST_TOOLTIP = "No changes to suggest"
+EMPTY_FIRST_FIELD_TOOLTIP = "The first field can't be empty"
 NOTE_DELETED_TOOLTIP = "This note has been deleted from AnkiHub. No new suggestions can be made."
 SUGGESTION_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-suggestion"
 VIEW_NOTE_BTN_ID = f"{ANKIHUB_BTN_ID_PREFIX}-view-note"
@@ -142,8 +149,8 @@ def _on_suggestion_button_press(editor: Editor) -> None:
             if cast(AnkiHubNote, ah_note).was_deleted():
                 tooltip(NOTE_DELETED_TOOLTIP)
                 return
-            if _should_block_for_no_changes(note):
-                tooltip(NO_CHANGES_TO_SUGGEST_TOOLTIP)
+            if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
+                tooltip(gate_tooltip)
                 return
 
     # The command is expected to have been set at this point already, either by
@@ -342,16 +349,19 @@ def _refresh_editor_fields_for_anki_below_v50_js(hide_last_field: bool) -> str:
             """
 
 
-def _should_block_for_no_changes(note: Note) -> bool:
-    """True when the 'No changes to suggest' gate should block suggesting `note`.
+def _suggestion_gate_tooltip(note: Note) -> Optional[str]:
+    """The tooltip explaining why the Suggest button is gated for `note`, or
+    None when the note is suggestible (button stays enabled).
 
-    Behind AUTO_PROTECT_FEATURE_FLAG. Reuses the dialog's suggestibility check so
-    the editor button and the dialog's pre-open gate agree on what counts as a
-    suggestible change (field edit outside the globally-protected denylist, or a
-    tag change).
+    Behind AUTO_PROTECT_FEATURE_FLAG (returns None when off). Reuses the
+    dialog's suggestibility check so the editor button and the dialog's
+    pre-open gate agree. An empty first field is reported distinctly from
+    "no changes" — for a new note that's the only reason it can be gated.
     """
     if not config.get_feature_flags().get(AUTO_PROTECT_FEATURE_FLAG, False):
-        return False
+        return None
+    if _has_empty_first_field(note):
+        return EMPTY_FIRST_FIELD_TOOLTIP
     ah_did = ankihub_db.ankihub_did_for_anki_nid(note.id)
     globally_protected = (
         {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
@@ -359,16 +369,18 @@ def _should_block_for_no_changes(note: Note) -> bool:
         else {}
     )
     diffs = compute_note_diffs([note])
-    return not any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected)
+    if any_suggestible_from_diffs([note], diffs, change_type=None, globally_protected_by_mid=globally_protected):
+        return None
+    return NO_CHANGES_TO_SUGGEST_TOOLTIP
 
 
 def _apply_suggestion_button_gate(editor: Editor, note: Note) -> None:
     """Enable or disable the suggestion button based on whether `note` has
     anything to suggest. Shared by the change-note and new-note branches; a
     no-op (button stays enabled) when the feature flag is off."""
-    if _should_block_for_no_changes(note):
+    if (gate_tooltip := _suggestion_gate_tooltip(note)) is not None:
         _disable_buttons(editor, [SUGGESTION_BTN_ID])
-        _set_suggestion_button_tooltip(editor, NO_CHANGES_TO_SUGGEST_TOOLTIP)
+        _set_suggestion_button_tooltip(editor, gate_tooltip)
     else:
         _enable_buttons(editor, [SUGGESTION_BTN_ID])
         _set_suggestion_button_tooltip(editor, _default_suggestion_button_tooltip())
@@ -434,13 +446,13 @@ def _set_enabled_states_of_buttons(editor: Editor, button_ids: list[str], enable
 
 
 def _set_suggestion_button_label(editor: Editor, label: str) -> None:
-    set_label_script = f"document.getElementById('{SUGGESTION_BTN_ID}-label').textContent='{{}}';"
-    editor.web.eval(set_label_script.format(label))
+    # json.dumps so values with quotes/apostrophes can't break the JS string.
+    editor.web.eval(f"document.getElementById('{SUGGESTION_BTN_ID}-label').textContent={json.dumps(label)};")
 
 
 def _set_suggestion_button_tooltip(editor: Editor, text: str) -> None:
-    set_tooltip_script = f"document.getElementById('{SUGGESTION_BTN_ID}').title='{{}}';"
-    editor.web.eval(set_tooltip_script.format(text))
+    # json.dumps so values with quotes/apostrophes can't break the JS string.
+    editor.web.eval(f"document.getElementById('{SUGGESTION_BTN_ID}').title={json.dumps(text)};")
 
 
 def _track_editor(editor: Editor) -> None:

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -129,7 +129,7 @@ def open_suggestion_dialog_for_single_suggestion(
         note_diffs=diffs,
         ah_did=ah_did,
         preselected_change_type=preselected_change_type,
-        globally_protected_fields_by_mid=_globally_protected_fields_by_mid(ah_did),
+        globally_protected_fields_by_mid=globally_protected_fields_by_mid(ah_did),
         parent=parent,
     )
 
@@ -256,7 +256,7 @@ def open_suggestion_dialog_for_bulk_suggestion(
         return
 
     notes = [aqt.mw.col.get_note(nid) for nid in anki_nids]
-    globally_protected = _globally_protected_fields_by_mid(ah_did)
+    globally_protected = globally_protected_fields_by_mid(ah_did)
 
     diffs = compute_note_diffs(notes)
 
@@ -345,7 +345,7 @@ def _determine_ah_did_for_nids_to_be_suggested(anki_nids: Collection[NoteId], pa
     return ah_did
 
 
-def _globally_protected_fields_by_mid(ah_did: uuid.UUID) -> Dict[NotetypeId, Set[str]]:
+def globally_protected_fields_by_mid(ah_did: uuid.UUID) -> Dict[NotetypeId, Set[str]]:
     """Coerce the cached globally-protected fields into the shape the widget expects."""
     return {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
 

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -55,6 +55,7 @@ from ..main.suggestions import (
     any_suggestible_from_diffs,
     compute_note_diffs,
     get_anki_nid_to_ah_dids_dict,
+    globally_protected_fields_by_mid,
     suggest_new_note,
     suggest_note_update,
     suggest_notes_in_bulk,
@@ -343,11 +344,6 @@ def _determine_ah_did_for_nids_to_be_suggested(anki_nids: Collection[NoteId], pa
 
     ah_did = list(ah_dids)[0]
     return ah_did
-
-
-def globally_protected_fields_by_mid(ah_did: uuid.UUID) -> Dict[NotetypeId, Set[str]]:
-    """Coerce the cached globally-protected fields into the shape the widget expects."""
-    return {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
 
 
 def _comment_with_source(suggestion_meta: SuggestionMetadata) -> str:

--- a/ankihub/main/suggestions.py
+++ b/ankihub/main/suggestions.py
@@ -207,6 +207,13 @@ def compute_note_diffs(notes: Sequence[Note]) -> Dict[NoteId, NoteDiff]:
     return result
 
 
+def globally_protected_fields_by_mid(ah_did: uuid.UUID) -> Dict[NotetypeId, Set[str]]:
+    """Coerce the cached globally-protected fields into the typed shape that
+    `_is_suggestible_from_diff`, `any_suggestible_from_diffs`, and the dialog
+    widget consume."""
+    return {NotetypeId(mid): set(names) for mid, names in config.globally_protected_fields(ah_did).items()}
+
+
 def _is_suggestible_from_diff(
     note: Note,
     diff: NoteDiff,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -44,6 +44,7 @@ from aqt.gui_hooks import (
     browser_will_show_context_menu,
     deck_options_did_load,
     editor_did_fire_typing_timer,
+    editor_did_update_tags,
     overview_will_render_bottom,
 )
 from aqt.importing import AnkiPackageImporter
@@ -883,6 +884,39 @@ class TestEditor:
             # without reloading the note.
             add_cards_dialog.editor.note["Front"] = "edited value"
             editor_did_fire_typing_timer(add_cards_dialog.editor.note)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_button_refreshes_live_on_tag_update(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # No changes yet: disabled.
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            # Add a tag and fire the tag-update hook; the button should enable live.
+            # Field typing timers don't fire for tag edits, so this hook is what
+            # keeps the button in sync with tag changes.
+            add_cards_dialog.editor.note.tags.append("a-new-tag")
+            editor_did_update_tags(add_cards_dialog.editor.note)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -154,6 +154,7 @@ from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_f
 from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import (
+    EMPTY_FIRST_FIELD_TOOLTIP,
     NO_CHANGES_TO_SUGGEST_TOOLTIP,
     NOTE_DELETED_TOOLTIP,
     SUGGESTION_BTN_ID,
@@ -891,6 +892,11 @@ class TestEditor:
             self.assert_suggestion_button_enabled_status(
                 qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_content
             )
+            if not has_content:
+                # Empty first field is reported distinctly from "no changes".
+                self.assert_suggestion_button_tooltip(
+                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=EMPTY_FIRST_FIELD_TOOLTIP
+                )
 
             add_cards_dialog.editor.cleanup()
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -39,7 +39,6 @@ from aqt.browser.sidebar.item import SidebarItem
 from aqt.browser.sidebar.tree import SidebarTreeView
 from aqt.deckoptions import DeckOptionsDialog
 from aqt.gui_hooks import (
-    add_cards_did_change_note_type,
     browser_did_search,
     browser_will_show,
     browser_will_show_context_menu,
@@ -918,39 +917,6 @@ class TestEditor:
             # keeps the button in sync with tag changes.
             add_cards_dialog.editor.note.tags.append("a-new-tag")
             editor_did_update_tags(add_cards_dialog.editor.note)
-
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_notetype_change_refreshes_button_via_registry(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
-
-            # No changes yet: disabled.
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
-
-            # The note-type-change hook passes no editor; the button must still
-            # refresh via the live-editor registry (replacing the old global).
-            add_cards_dialog.editor.note["Front"] = "edited value"
-            note_type = add_cards_dialog.editor.note.note_type()
-            add_cards_did_change_note_type(note_type, note_type)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -154,6 +154,7 @@ from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
 from ankihub.gui.editor import (
     NO_CHANGES_TO_SUGGEST_TOOLTIP,
+    NOTE_DELETED_TOOLTIP,
     SUGGESTION_BTN_ID,
     _on_field_unfocus_auto_protect,
     _on_suggestion_button_press,
@@ -885,6 +886,41 @@ class TestEditor:
             _on_suggestion_button_press(add_cards_dialog.editor)
 
             tooltip_mock.assert_called_once_with(NO_CHANGES_TO_SUGGEST_TOOLTIP)
+            assert not open_dialog_mock.called
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_action_gate_blocks_deleted_note(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "is_logged_in", return_value=True)
+
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+            AnkiHubNote.update(last_update_type=SuggestionType.DELETE.value[0]).where(
+                AnkiHubNote.ankihub_note_id == ah_note.ah_nid
+            ).execute()
+
+            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
+            tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # Keyboard shortcut fires even when the button is disabled; a note
+            # deleted on AnkiHub must not reach the dialog.
+            _on_suggestion_button_press(add_cards_dialog.editor)
+
+            tooltip_mock.assert_called_once_with(NOTE_DELETED_TOOLTIP)
             assert not open_dialog_mock.called
 
             add_cards_dialog.editor.cleanup()

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -825,6 +825,37 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
+    def test_suggestion_button_enabled_for_locally_protected_field_edit(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            # A personal AnkiHub_Protect tag stops sync from overwriting the local
+            # edit; it must NOT exclude the field from the gate (only globally
+            # protected fields do). The user can still suggest the edit.
+            anki_note["Front"] = "edited value"
+            anki_note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
     def test_suggestion_button_refreshes_live_on_typing_timer(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -857,6 +857,43 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
+    @pytest.mark.parametrize("has_content", [True, False])
+    def test_new_note_suggestion_button_gated_on_content(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        qtbot: QtBot,
+        has_content: bool,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note_type = import_ah_note_type(ah_did=ah_did)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            # A brand-new note (AnkiHub note type, not yet on AnkiHub) with an
+            # empty first field has nothing to suggest, so the button is gated
+            # too — not just existing-note edits.
+            anki_note = aqt.mw.col.new_note(ah_note_type)
+            if has_content:
+                anki_note["Front"] = "content"
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            self.assert_suggestion_button_text(
+                qtbot=qtbot, addcards=add_cards_dialog, expected_text=AnkiHubCommands.NEW.value
+            )
+            self.assert_suggestion_button_enabled_status(
+                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_content
+            )
+
+            add_cards_dialog.editor.cleanup()
+
     def test_suggestion_button_refreshes_live_on_typing_timer(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1097,6 +1097,34 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
+    def test_suggestion_action_gate_no_op_for_non_ankihub_note(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        add_anki_note: AddAnkiNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "is_logged_in", return_value=True)
+
+            anki_note = add_anki_note()  # non-AnkiHub note type
+
+            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # The button is visually disabled for non-AnkiHub notes; the hotkey
+            # still fires, but it must be a no-op (used to hit an assert in the
+            # dialog opener).
+            _on_suggestion_button_press(add_cards_dialog.editor)
+
+            assert not open_dialog_mock.called
+
+            add_cards_dialog.editor.cleanup()
+
     def test_with_note_deleted_on_ankihub(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -1097,31 +1097,35 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
+    @pytest.mark.parametrize("logged_in", [True, False])
     def test_suggestion_action_gate_no_op_for_non_ankihub_note(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
         add_anki_note: AddAnkiNote,
         qtbot: QtBot,
+        logged_in: bool,
     ):
         editor.setup()
         with anki_session_with_addon_data.profile_loaded():
-            mocker.patch.object(config, "is_logged_in", return_value=True)
+            mocker.patch.object(config, "is_logged_in", return_value=logged_in)
 
             anki_note = add_anki_note()  # non-AnkiHub note type
 
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
+            login_mock = mocker.patch.object(AnkiHubLogin, "display_login")
 
             add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
             add_cards_dialog.editor.set_note(anki_note)
             self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
 
             # The button is visually disabled for non-AnkiHub notes; the hotkey
-            # still fires, but it must be a no-op (used to hit an assert in the
-            # dialog opener).
+            # still fires, but it must be a no-op — even when logged out, since
+            # there's no AnkiHub action to authenticate for.
             _on_suggestion_button_press(add_cards_dialog.editor)
 
             assert not open_dialog_mock.called
+            assert not login_mock.called
 
             add_cards_dialog.editor.cleanup()
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -787,23 +787,20 @@ class TestEditor:
         [
             # Flag-on covers the full gate matrix; flag-off is the regression
             # row confirming the gate is a true no-op when the feature is off.
-            pytest.param(_no_mutation, True, False, NO_CHANGES_TO_SUGGEST_TOOLTIP, id="no_change_disabled"),
-            pytest.param(_set_front, True, True, None, id="field_edit_enabled"),
-            pytest.param(
-                _globally_protect_front_and_set,
-                True,
-                False,
-                NO_CHANGES_TO_SUGGEST_TOOLTIP,
-                id="globally_protected_only_edit_disabled",
-            ),
-            pytest.param(
-                _locally_protect_front_and_set,
-                True,
-                True,
-                None,
-                id="locally_protected_edit_enabled",
-            ),
-            pytest.param(_no_mutation, False, True, None, id="flag_off_no_change_enabled"),
+            # fmt: off
+            (_no_mutation, True, False, NO_CHANGES_TO_SUGGEST_TOOLTIP),
+            (_set_front, True, True, None),
+            (_globally_protect_front_and_set, True, False, NO_CHANGES_TO_SUGGEST_TOOLTIP),
+            (_locally_protect_front_and_set, True, True, None),
+            (_no_mutation, False, True, None),
+            # fmt: on
+        ],
+        ids=[
+            "no_change_disabled",
+            "field_edit_enabled",
+            "globally_protected_only_edit_disabled",
+            "locally_protected_edit_enabled",
+            "flag_off_no_change_enabled",
         ],
     )
     def test_visual_gate_on_existing_ah_note(
@@ -841,14 +838,16 @@ class TestEditor:
     @pytest.mark.parametrize(
         "mutate,expected_enabled,expected_tooltip",
         [
-            pytest.param(_no_mutation, False, EMPTY_FIRST_FIELD_TOOLTIP, id="empty_first_field_disabled"),
-            pytest.param(_set_front, True, None, id="first_field_filled_enabled"),
-            pytest.param(
-                _globally_protect_front_and_set,
-                False,
-                NO_CHANGES_TO_SUGGEST_TOOLTIP,
-                id="globally_protected_first_field_disabled",
-            ),
+            # fmt: off
+            (_no_mutation, False, EMPTY_FIRST_FIELD_TOOLTIP),
+            (_set_front, True, None),
+            (_globally_protect_front_and_set, False, NO_CHANGES_TO_SUGGEST_TOOLTIP),
+            # fmt: on
+        ],
+        ids=[
+            "empty_first_field_disabled",
+            "first_field_filled_enabled",
+            "globally_protected_first_field_disabled",
         ],
     )
     def test_visual_gate_on_new_ah_note(
@@ -981,21 +980,16 @@ class TestEditor:
     @pytest.mark.parametrize(
         "setup,expected_tooltip",
         [
-            pytest.param(
-                _action_setup_unchanged_existing_note,
-                NO_CHANGES_TO_SUGGEST_TOOLTIP,
-                id="no_changes_existing_note",
-            ),
-            pytest.param(
-                _action_setup_deleted_existing_note,
-                NOTE_DELETED_TOOLTIP,
-                id="deleted_existing_note",
-            ),
-            pytest.param(
-                _action_setup_empty_new_note,
-                EMPTY_FIRST_FIELD_TOOLTIP,
-                id="empty_first_field_new_note",
-            ),
+            # fmt: off
+            (_action_setup_unchanged_existing_note, NO_CHANGES_TO_SUGGEST_TOOLTIP),
+            (_action_setup_deleted_existing_note, NOTE_DELETED_TOOLTIP),
+            (_action_setup_empty_new_note, EMPTY_FIRST_FIELD_TOOLTIP),
+            # fmt: on
+        ],
+        ids=[
+            "no_changes_existing_note",
+            "deleted_existing_note",
+            "empty_first_field_new_note",
         ],
     )
     def test_action_gate_blocks(

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -539,6 +539,53 @@ class TestEntryPoint:
         on_profile_did_open_mock.assert_called_once()
 
 
+# Mutators that prepare a note before TestEditor's visual-gate tests open AddCards.
+# Each row of the parametrized tests names one of these (via `pytest.param(... id=...)`)
+# so failures point at a specific scenario rather than a tuple index.
+
+
+def _no_mutation(ah_did: uuid.UUID, note: Note) -> None:
+    pass
+
+
+def _set_front(ah_did: uuid.UUID, note: Note) -> None:
+    note["Front"] = "edited value"
+
+
+def _globally_protect_front_and_set(ah_did: uuid.UUID, note: Note) -> None:
+    config.set_globally_protected_fields(ah_did, {note.mid: ["Front"]})
+    note["Front"] = "edited value"
+
+
+def _locally_protect_front_and_set(ah_did: uuid.UUID, note: Note) -> None:
+    note["Front"] = "edited value"
+    note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
+
+
+# Setup callables for the parametrized action-gate-blocks test below. Each takes
+# the three fixtures the test passes through and returns the prepared note.
+
+
+def _action_setup_unchanged_existing_note(install_ah_deck, import_ah_note, import_ah_note_type) -> Note:
+    ah_did = install_ah_deck()
+    return aqt.mw.col.get_note(NoteId(import_ah_note(ah_did=ah_did).anki_nid))
+
+
+def _action_setup_deleted_existing_note(install_ah_deck, import_ah_note, import_ah_note_type) -> Note:
+    ah_did = install_ah_deck()
+    ah_note = import_ah_note(ah_did=ah_did)
+    AnkiHubNote.update(last_update_type=SuggestionType.DELETE.value[0]).where(
+        AnkiHubNote.ankihub_note_id == ah_note.ah_nid
+    ).execute()
+    return aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+
+def _action_setup_empty_new_note(install_ah_deck, import_ah_note, import_ah_note_type) -> Note:
+    ah_did = install_ah_deck()
+    ah_note_type = import_ah_note_type(ah_did=ah_did)
+    return aqt.mw.col.new_note(ah_note_type)
+
+
 # The JS in the webviews is flaky if not run in sequential mode
 @pytest.mark.sequential
 class TestEditor:
@@ -735,140 +782,94 @@ class TestEditor:
             # Clear editor to prevent dialog that asks for confirmation to discard changes when closing the editor
             add_cards_dialog.editor.cleanup()
 
-    @pytest.mark.parametrize("has_change", [True, False])
-    def test_suggestion_button_gated_on_edit_state(
+    @pytest.mark.parametrize(
+        "mutate,flag_on,expected_enabled,expected_tooltip",
+        [
+            # Flag-on covers the full gate matrix; flag-off is the regression
+            # row confirming the gate is a true no-op when the feature is off.
+            pytest.param(_no_mutation, True, False, NO_CHANGES_TO_SUGGEST_TOOLTIP, id="no_change_disabled"),
+            pytest.param(_set_front, True, True, None, id="field_edit_enabled"),
+            pytest.param(
+                _globally_protect_front_and_set,
+                True,
+                False,
+                NO_CHANGES_TO_SUGGEST_TOOLTIP,
+                id="globally_protected_only_edit_disabled",
+            ),
+            pytest.param(
+                _locally_protect_front_and_set,
+                True,
+                True,
+                None,
+                id="locally_protected_edit_enabled",
+            ),
+            pytest.param(_no_mutation, False, True, None, id="flag_off_no_change_enabled"),
+        ],
+    )
+    def test_visual_gate_on_existing_ah_note(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
         qtbot: QtBot,
-        has_change: bool,
+        mutate: Callable[[uuid.UUID, Note], None],
+        flag_on: bool,
+        expected_enabled: bool,
+        expected_tooltip: Optional[str],
     ):
         editor.setup()
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+            anki_note = aqt.mw.col.get_note(NoteId(import_ah_note(ah_did=ah_did).anki_nid))
 
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            if has_change:
-                anki_note["Front"] = "edited value"
+            config.set_feature_flags({"auto_protect_fields_when_edited": flag_on})
+            mutate(ah_did, anki_note)
 
             add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_enabled_status(
-                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_change
+                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=expected_enabled
             )
-            if not has_change:
+            if expected_tooltip is not None:
                 self.assert_suggestion_button_tooltip(
-                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=NO_CHANGES_TO_SUGGEST_TOOLTIP
+                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=expected_tooltip
                 )
 
             add_cards_dialog.editor.cleanup()
 
-    def test_suggestion_button_not_gated_when_flag_off(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": False})
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            # Flag off: button stays enabled even with no changes (legacy behavior).
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_suggestion_button_gate_ignores_globally_protected_edit(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-            config.set_globally_protected_fields(ah_did, {anki_note.mid: ["Front"]})
-
-            # The only edit is to a globally-protected field, which would be stripped
-            # at submit — so the button stays disabled.
-            anki_note["Front"] = "edited value"
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_suggestion_button_enabled_for_locally_protected_field_edit(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            # A personal AnkiHub_Protect tag stops sync from overwriting the local
-            # edit; it must NOT exclude the field from the gate (only globally
-            # protected fields do). The user can still suggest the edit.
-            anki_note["Front"] = "edited value"
-            anki_note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
-
-            add_cards_dialog.editor.cleanup()
-
-    @pytest.mark.parametrize("has_content", [True, False])
-    def test_new_note_suggestion_button_gated_on_content(
+    @pytest.mark.parametrize(
+        "mutate,expected_enabled,expected_tooltip",
+        [
+            pytest.param(_no_mutation, False, EMPTY_FIRST_FIELD_TOOLTIP, id="empty_first_field_disabled"),
+            pytest.param(_set_front, True, None, id="first_field_filled_enabled"),
+            pytest.param(
+                _globally_protect_front_and_set,
+                False,
+                NO_CHANGES_TO_SUGGEST_TOOLTIP,
+                id="globally_protected_first_field_disabled",
+            ),
+        ],
+    )
+    def test_visual_gate_on_new_ah_note(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
         install_ah_deck: InstallAHDeck,
         import_ah_note_type: ImportAHNoteType,
         qtbot: QtBot,
-        has_content: bool,
+        mutate: Callable[[uuid.UUID, Note], None],
+        expected_enabled: bool,
+        expected_tooltip: Optional[str],
     ):
         editor.setup()
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
             ah_note_type = import_ah_note_type(ah_did=ah_did)
+            anki_note = aqt.mw.col.new_note(ah_note_type)
 
             config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            # A brand-new note (AnkiHub note type, not yet on AnkiHub) with an
-            # empty first field has nothing to suggest, so the button is gated
-            # too — not just existing-note edits.
-            anki_note = aqt.mw.col.new_note(ah_note_type)
-            if has_content:
-                anki_note["Front"] = "content"
+            mutate(ah_did, anki_note)
 
             add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
@@ -876,73 +877,12 @@ class TestEditor:
                 qtbot=qtbot, addcards=add_cards_dialog, expected_text=AnkiHubCommands.NEW.value
             )
             self.assert_suggestion_button_enabled_status(
-                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_content
+                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=expected_enabled
             )
-            if not has_content:
-                # Empty first field is reported distinctly from "no changes".
+            if expected_tooltip is not None:
                 self.assert_suggestion_button_tooltip(
-                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=EMPTY_FIRST_FIELD_TOOLTIP
+                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=expected_tooltip
                 )
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_new_note_button_disabled_when_first_field_globally_protected(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note_type: ImportAHNoteType,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            ah_did = install_ah_deck()
-            ah_note_type = import_ah_note_type(ah_did=ah_did)
-
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            # A new note's deck is resolved from its note type (it has no AH-DB
-            # row). With the first field globally protected, the server can never
-            # accept the new note, so the button is disabled even with content —
-            # matching the dialog's gate.
-            anki_note = aqt.mw.col.new_note(ah_note_type)
-            anki_note["Front"] = "content"
-            config.set_globally_protected_fields(ah_did, {anki_note.mid: ["Front"]})
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_new_note_action_gate_blocks_empty_first_field(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note_type: ImportAHNoteType,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            mocker.patch.object(config, "is_logged_in", return_value=True)
-            config.set_feature_flags({"auto_protect_fields_when_edited": True})
-
-            ah_did = install_ah_deck()
-            ah_note_type = import_ah_note_type(ah_did=ah_did)
-            anki_note = aqt.mw.col.new_note(ah_note_type)  # empty first field
-
-            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
-            tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            # The hotkey fires even when the button is disabled; an empty new note
-            # must be gated here, not fall through to add_current_note.
-            _on_suggestion_button_press(add_cards_dialog.editor)
-
-            tooltip_mock.assert_called_once_with(EMPTY_FIRST_FIELD_TOOLTIP)
-            assert not open_dialog_mock.called
 
             add_cards_dialog.editor.cleanup()
 
@@ -1038,66 +978,55 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
-    def test_suggestion_action_gate_blocks_when_no_changes(
+    @pytest.mark.parametrize(
+        "setup,expected_tooltip",
+        [
+            pytest.param(
+                _action_setup_unchanged_existing_note,
+                NO_CHANGES_TO_SUGGEST_TOOLTIP,
+                id="no_changes_existing_note",
+            ),
+            pytest.param(
+                _action_setup_deleted_existing_note,
+                NOTE_DELETED_TOOLTIP,
+                id="deleted_existing_note",
+            ),
+            pytest.param(
+                _action_setup_empty_new_note,
+                EMPTY_FIRST_FIELD_TOOLTIP,
+                id="empty_first_field_new_note",
+            ),
+        ],
+    )
+    def test_action_gate_blocks(
         self,
         anki_session_with_addon_data: AnkiSession,
         mocker: MockerFixture,
         install_ah_deck: InstallAHDeck,
         import_ah_note: ImportAHNote,
+        import_ah_note_type: ImportAHNoteType,
         qtbot: QtBot,
+        setup: Callable[..., Note],
+        expected_tooltip: str,
     ):
         editor.setup()
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "is_logged_in", return_value=True)
             config.set_feature_flags({"auto_protect_fields_when_edited": True})
 
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+            anki_note = setup(install_ah_deck, import_ah_note, import_ah_note_type)
 
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
             tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
 
             add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
-            # Invoke the action directly to cover the keyboard-shortcut path, which
-            # fires even when the button is visually disabled.
+            # The hotkey fires even when the button is visually disabled; the
+            # action gate must short-circuit with the right tooltip and never
+            # fall through to the dialog (or, for new notes, to add_current_note).
             _on_suggestion_button_press(add_cards_dialog.editor)
 
-            tooltip_mock.assert_called_once_with(NO_CHANGES_TO_SUGGEST_TOOLTIP)
-            assert not open_dialog_mock.called
-
-            add_cards_dialog.editor.cleanup()
-
-    def test_suggestion_action_gate_blocks_deleted_note(
-        self,
-        anki_session_with_addon_data: AnkiSession,
-        mocker: MockerFixture,
-        install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
-        qtbot: QtBot,
-    ):
-        editor.setup()
-        with anki_session_with_addon_data.profile_loaded():
-            mocker.patch.object(config, "is_logged_in", return_value=True)
-
-            ah_did = install_ah_deck()
-            ah_note = import_ah_note(ah_did=ah_did)
-            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
-            AnkiHubNote.update(last_update_type=SuggestionType.DELETE.value[0]).where(
-                AnkiHubNote.ankihub_note_id == ah_note.ah_nid
-            ).execute()
-
-            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
-            tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
-
-            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
-
-            # Keyboard shortcut fires even when the button is disabled; a note
-            # deleted on AnkiHub must not reach the dialog.
-            _on_suggestion_button_press(add_cards_dialog.editor)
-
-            tooltip_mock.assert_called_once_with(NOTE_DELETED_TOOLTIP)
+            tooltip_mock.assert_called_once_with(expected_tooltip)
             assert not open_dialog_mock.called
 
             add_cards_dialog.editor.cleanup()

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -900,6 +900,70 @@ class TestEditor:
 
             add_cards_dialog.editor.cleanup()
 
+    def test_new_note_button_disabled_when_first_field_globally_protected(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note_type = import_ah_note_type(ah_did=ah_did)
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            # A new note's deck is resolved from its note type (it has no AH-DB
+            # row). With the first field globally protected, the server can never
+            # accept the new note, so the button is disabled even with content —
+            # matching the dialog's gate.
+            anki_note = aqt.mw.col.new_note(ah_note_type)
+            anki_note["Front"] = "content"
+            config.set_globally_protected_fields(ah_did, {anki_note.mid: ["Front"]})
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_new_note_action_gate_blocks_empty_first_field(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "is_logged_in", return_value=True)
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            ah_did = install_ah_deck()
+            ah_note_type = import_ah_note_type(ah_did=ah_did)
+            anki_note = aqt.mw.col.new_note(ah_note_type)  # empty first field
+
+            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
+            tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # The hotkey fires even when the button is disabled; an empty new note
+            # must be gated here, not fall through to add_current_note.
+            _on_suggestion_button_press(add_cards_dialog.editor)
+
+            tooltip_mock.assert_called_once_with(EMPTY_FIRST_FIELD_TOOLTIP)
+            assert not open_dialog_mock.called
+
+            add_cards_dialog.editor.cleanup()
+
     def test_suggestion_button_refreshes_live_on_typing_timer(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -39,6 +39,7 @@ from aqt.browser.sidebar.item import SidebarItem
 from aqt.browser.sidebar.tree import SidebarTreeView
 from aqt.deckoptions import DeckOptionsDialog
 from aqt.gui_hooks import (
+    add_cards_did_change_note_type,
     browser_did_search,
     browser_will_show,
     browser_will_show_context_menu,
@@ -917,6 +918,39 @@ class TestEditor:
             # keeps the button in sync with tag changes.
             add_cards_dialog.editor.note.tags.append("a-new-tag")
             editor_did_update_tags(add_cards_dialog.editor.note)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_notetype_change_refreshes_button_via_registry(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # No changes yet: disabled.
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            # The note-type-change hook passes no editor; the button must still
+            # refresh via the live-editor registry (replacing the old global).
+            add_cards_dialog.editor.note["Front"] = "edited value"
+            note_type = add_cards_dialog.editor.note.note_type()
+            add_cards_did_change_note_type(note_type, note_type)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -756,10 +756,7 @@ class TestEditor:
             if has_change:
                 anki_note["Front"] = "edited value"
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_enabled_status(
                 qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_change
@@ -787,10 +784,7 @@ class TestEditor:
 
             config.set_feature_flags({"auto_protect_fields_when_edited": False})
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # Flag off: button stays enabled even with no changes (legacy behavior).
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
@@ -818,10 +812,7 @@ class TestEditor:
             # at submit — so the button stays disabled.
             anki_note["Front"] = "edited value"
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
 
@@ -849,10 +840,7 @@ class TestEditor:
             anki_note["Front"] = "edited value"
             anki_note.tags.append(f"{TAG_FOR_PROTECTING_FIELDS}::Front")
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
 
@@ -882,9 +870,7 @@ class TestEditor:
             if has_content:
                 anki_note["Front"] = "content"
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_text(
                 qtbot=qtbot, addcards=add_cards_dialog, expected_text=AnkiHubCommands.NEW.value
@@ -923,9 +909,7 @@ class TestEditor:
             anki_note["Front"] = "content"
             config.set_globally_protected_fields(ah_did, {anki_note.mid: ["Front"]})
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
 
@@ -951,9 +935,7 @@ class TestEditor:
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
             tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # The hotkey fires even when the button is disabled; an empty new note
             # must be gated here, not fall through to add_current_note.
@@ -980,9 +962,7 @@ class TestEditor:
 
             config.set_feature_flags({"auto_protect_fields_when_edited": True})
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # No changes yet: disabled.
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
@@ -990,6 +970,37 @@ class TestEditor:
             # Edit a field and fire the typing timer; the button should enable live,
             # without reloading the note.
             add_cards_dialog.editor.note["Front"] = "edited value"
+            editor_did_fire_typing_timer(add_cards_dialog.editor.note)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_new_note_button_refreshes_live_as_first_field_is_filled(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note_type: ImportAHNoteType,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note_type = import_ah_note_type(ah_did=ah_did)
+            anki_note = aqt.mw.col.new_note(ah_note_type)  # empty first field
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
+
+            # Empty new note: disabled.
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            # Fill the first field and fire the typing timer; the live-refresh
+            # path must enable the button even for an unsaved (id 0) note —
+            # identity-matching `tracked.note is note` makes this work.
+            add_cards_dialog.editor.note["Front"] = "content"
             editor_did_fire_typing_timer(add_cards_dialog.editor.note)
 
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
@@ -1012,9 +1023,7 @@ class TestEditor:
 
             config.set_feature_flags({"auto_protect_fields_when_edited": True})
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # No changes yet: disabled.
             self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
@@ -1049,9 +1058,7 @@ class TestEditor:
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
             tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # Invoke the action directly to cover the keyboard-shortcut path, which
             # fires even when the button is visually disabled.
@@ -1084,9 +1091,7 @@ class TestEditor:
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
             tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # Keyboard shortcut fires even when the button is disabled; a note
             # deleted on AnkiHub must not reach the dialog.
@@ -1115,9 +1120,7 @@ class TestEditor:
             open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
             login_mock = mocker.patch.object(AnkiHubLogin, "display_login")
 
-            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
-            add_cards_dialog.editor.set_note(anki_note)
-            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+            add_cards_dialog = self._open_addcards(anki_note, qtbot, mocker)
 
             # The button is visually disabled for non-AnkiHub notes; the hotkey
             # still fires, but it must be a no-op — even when logged out, since
@@ -1178,6 +1181,13 @@ class TestEditor:
 
             # Clear editor to prevent dialog that asks for confirmation to discard changes when closing the editor
             add_cards_dialog.editor.cleanup()
+
+    def _open_addcards(self, anki_note: Note, qtbot: QtBot, mocker: MockerFixture) -> AddCards:
+        """Open AddCards with `anki_note`, then wait for the first button refresh."""
+        add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+        add_cards_dialog.editor.set_note(anki_note)
+        self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+        return add_cards_dialog
 
     def wait_suggestion_button_ready(self, qtbot: QtBot, mocker: MockerFixture) -> None:
         refresh_buttons_spy = mocker.spy(editor, "_refresh_buttons")

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -43,6 +43,7 @@ from aqt.gui_hooks import (
     browser_will_show,
     browser_will_show_context_menu,
     deck_options_did_load,
+    editor_did_fire_typing_timer,
     overview_will_render_bottom,
 )
 from aqt.importing import AnkiPackageImporter
@@ -151,7 +152,12 @@ from ankihub.gui.config_dialog import get_config_dialog_manager, setup_config_di
 from ankihub.gui.deck_options import _backup_fsrs_parameters, _can_revert_from_fsrs_parameters
 from ankihub.gui.deck_updater import _AnkiHubDeckUpdater, ah_deck_updater
 from ankihub.gui.decks_dialog import DeckManagementDialog
-from ankihub.gui.editor import SUGGESTION_BTN_ID, _on_field_unfocus_auto_protect
+from ankihub.gui.editor import (
+    NO_CHANGES_TO_SUGGEST_TOOLTIP,
+    SUGGESTION_BTN_ID,
+    _on_field_unfocus_auto_protect,
+    _on_suggestion_button_press,
+)
 from ankihub.gui.errors import upload_logs_and_data_in_background
 from ankihub.gui.exceptions import DeckDownloadAndInstallError, RemoteDeckNotFoundError
 from ankihub.gui.flashcard_selector_dialog import FlashCardSelectorDialog
@@ -726,6 +732,163 @@ class TestEditor:
             # Clear editor to prevent dialog that asks for confirmation to discard changes when closing the editor
             add_cards_dialog.editor.cleanup()
 
+    @pytest.mark.parametrize("has_change", [True, False])
+    def test_suggestion_button_gated_on_edit_state(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+        has_change: bool,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            if has_change:
+                anki_note["Front"] = "edited value"
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            self.assert_suggestion_button_enabled_status(
+                qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=has_change
+            )
+            if not has_change:
+                self.assert_suggestion_button_tooltip(
+                    qtbot=qtbot, addcards=add_cards_dialog, expected_tooltip=NO_CHANGES_TO_SUGGEST_TOOLTIP
+                )
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_button_not_gated_when_flag_off(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": False})
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # Flag off: button stays enabled even with no changes (legacy behavior).
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_button_gate_ignores_globally_protected_edit(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+            config.set_globally_protected_fields(ah_did, {anki_note.mid: ["Front"]})
+
+            # The only edit is to a globally-protected field, which would be stripped
+            # at submit — so the button stays disabled.
+            anki_note["Front"] = "edited value"
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_button_refreshes_live_on_typing_timer(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # No changes yet: disabled.
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=False)
+
+            # Edit a field and fire the typing timer; the button should enable live,
+            # without reloading the note.
+            add_cards_dialog.editor.note["Front"] = "edited value"
+            editor_did_fire_typing_timer(add_cards_dialog.editor.note)
+
+            self.assert_suggestion_button_enabled_status(qtbot=qtbot, addcards=add_cards_dialog, expected_enabled=True)
+
+            add_cards_dialog.editor.cleanup()
+
+    def test_suggestion_action_gate_blocks_when_no_changes(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        qtbot: QtBot,
+    ):
+        editor.setup()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "is_logged_in", return_value=True)
+            config.set_feature_flags({"auto_protect_fields_when_edited": True})
+
+            ah_did = install_ah_deck()
+            ah_note = import_ah_note(ah_did=ah_did)
+            anki_note = aqt.mw.col.get_note(NoteId(ah_note.anki_nid))
+
+            open_dialog_mock = mocker.patch("ankihub.gui.editor.open_suggestion_dialog_for_single_suggestion")
+            tooltip_mock = mocker.patch("ankihub.gui.editor.tooltip")
+
+            add_cards_dialog: AddCards = dialogs.open("AddCards", aqt.mw)
+            add_cards_dialog.editor.set_note(anki_note)
+            self.wait_suggestion_button_ready(qtbot=qtbot, mocker=mocker)
+
+            # Invoke the action directly to cover the keyboard-shortcut path, which
+            # fires even when the button is visually disabled.
+            _on_suggestion_button_press(add_cards_dialog.editor)
+
+            tooltip_mock.assert_called_once_with(NO_CHANGES_TO_SUGGEST_TOOLTIP)
+            assert not open_dialog_mock.called
+
+            add_cards_dialog.editor.cleanup()
+
     def test_with_note_deleted_on_ankihub(
         self,
         anki_session_with_addon_data: AnkiSession,
@@ -795,6 +958,14 @@ class TestEditor:
                 callback,
             )
         callback.assert_called_with(not expected_enabled)
+
+    def assert_suggestion_button_tooltip(self, qtbot: QtBot, addcards: AddCards, expected_tooltip: str) -> None:
+        with qtbot.wait_callback() as callback:
+            addcards.editor.web.evalWithCallback(
+                f"document.getElementById('{SUGGESTION_BTN_ID}').title",
+                callback,
+            )
+        callback.assert_called_with(expected_tooltip)
 
     def click_suggestion_button(self, addcards: AddCards) -> None:
         addcards.editor.web.eval(f"document.getElementById('{SUGGESTION_BTN_ID}').click()")


### PR DESCRIPTION
## Related issues

- [NRT-751](https://ankihub.atlassian.net/browse/NRT-751) — sub-task of [NRT-508](https://ankihub.atlassian.net/browse/NRT-508) ("Automatically protect a field when users update it"), deferred from [NRT-749](https://ankihub.atlassian.net/browse/NRT-749).
- Based on #1288 (`NRT-749`), whose diff-based suggestion API (`compute_note_diffs` / `any_suggestible_from_diffs`) this reuses. **Merge #1288 first; this PR targets `NRT-749`.**

## Proposed changes

When a user is in the editor for an AnkiHub note that has nothing to suggest (no field diff vs the AnkiHub-stored note, no tag change), the toolbar's "Suggest a change" button is now disabled with the tooltip **"No changes to suggest"**. Previously the button was always enabled and submitting opened a dialog that couldn't produce a suggestion. Implements the NRT-508 spec line: *"If the user didn't edit any field the 'Suggest a change' button should be disable[d]."*

Gating lives in `ankihub/gui/editor.py`, behind the `auto_protect_fields_when_edited` feature flag (matching NRT-749's dark-merge strategy):

- **Visual gate** — in `_refresh_buttons`, both the change-note (not-deleted) and new-note branches disable `SUGGESTION_BTN_ID` and set a tooltip explaining why when the note has nothing to suggest: *"No changes to suggest"*, or *"The first field can't be empty"* (the latter is a new note's only possible gate reason). View / View-history buttons are managed per branch as before.
- **Action gate** — in `_on_suggestion_button_press`, an early-return covers the keyboard-shortcut path (the shortcut fires even when the button is visually disabled): a no-op for non-AnkiHub note types (closing a pre-existing `AssertionError` from the dialog opener), the gate tooltip when nothing's suggestible (including empty/globally-protected-first-field **new** notes, so they don't fall through to `add_current_note`), and the deleted-note tooltip for notes deleted on AnkiHub.
- **Live refresh** — registered on `editor_did_fire_typing_timer` (field edits) and `editor_did_update_tags` (tag edits) so the button tracks edits within the current note instead of only updating on note reload.

"Suggestible" is computed via `any_suggestible_from_diffs` — the same check the bulk-suggest dialog uses — so the button and the dialog agree: a field edit outside the **globally-protected** denylist, or a tag change (and, for a new note, a non-empty first field). Locally/personally-protected fields (`AnkiHub_Protect::Field`) still count: the protect tag only stops sync from overwriting the local edit; the user can still suggest it. Only globally-protected (deck-owner-managed) fields are excluded.

The gate predicate returns the tooltip reason (or `None` when suggestible) rather than a bare bool, so each block reason shows the right message. For a new note (no AnkiHub-DB row) the deck is resolved from its note type, so a globally-protected first field gates the button just as it would block the dialog. The button's enabled-state tooltip was also rephrased from *"Send your request to AnkiHub"* to *"Suggest a change to AnkiHub"* (or *"Suggest the note to AnkiHub"* for new notes) — "request" was the odd word out vs the feature's "Suggest" vocabulary. The button label/tooltip JS setters now encode their value with `json.dumps` — a latent bug surfaced by the apostrophe in the new tooltip (values were interpolated into single-quoted JS literals with no escaping).

### Editor-registry, and the removed note-type handler

The live-refresh hooks pass only a `Note`, not the `Editor`, so this PR adds a `_tracked_editors` registry (populated on `editor_did_init`, pruned lazily, matched by object identity) used by the field-typing and tag-update handlers.

While here, the pre-existing `editor` module global and its `add_cards_did_change_note_type` handler were removed: a note-type change in AddCards goes through `editor.loadNote`, which already fires `editor_did_load_note -> _refresh_buttons` on the affected editor (verified in aqt at 2.1.50 and 25.x). The explicit handler was redundant and actually fired *earlier* — synchronously after `loadNote()` returns, before the webview callback — racing the DOM.

### Note: delete-from-editor for unchanged notes

The gate treats `change_type` as non-DELETE: an unchanged existing AnkiHub note shows *"No changes to suggest"* and the button is disabled, even though the dialog's change-type dropdown *would* let the user pick `DELETE` (`suggest_note_update` exempts DELETE from its empty/no-changes checks). This matches the NRT-508/751 spec wording — *"if the user didn't edit any field the button should be disabled"* — and removes one minor pre-existing path: deleting unchanged notes via the editor's Suggest button. The browser's **"Suggest to delete"** menu remains the supported path for that flow.

## How to reproduce

With the `auto_protect_fields_when_edited` flag on:

1. Open an AnkiHub note in the editor with no local edits → Suggest button is disabled, tooltip "No changes to suggest".
2. Edit a field → button enables live, without reloading the note. Revert it → disables again.
3. Edit only a globally-protected field → stays disabled. A locally-protected field edit keeps it enabled.
4. Add or remove a tag → button updates live.
5. Add a new note of an AnkiHub note type with an empty first field → button is disabled; type into the first field → it enables.
6. With no changes, trigger the suggest hotkey → tooltip fires, dialog does not open. Same for a note deleted on AnkiHub.

With the flag off, the button behaves as before (always enabled for valid notes).

## Tests

New tests in `TestEditor` (`tests/addon/test_integration.py`), consolidated into three parametrized tests + four standalone ones: the existing-note visual gate (no-change disabled, field edit enabled, globally-protected-only edit excluded, locally-protected edit still enabled, flag-off no-op), the new-note visual gate (empty / filled / globally-protected-first-field), the action-gate blocks (no-changes, deleted, empty-new-note keyboard paths), live refresh on typing-timer + tag-update (existing notes) and on typing into a new note, and a no-op test for the non-AnkiHub hotkey path (logged-in / logged-out). All 26 `TestEditor` tests pass; mypy + ruff clean.

[NRT-751]: https://ankihub.atlassian.net/browse/NRT-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-749]: https://ankihub.atlassian.net/browse/NRT-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-508]: https://ankihub.atlassian.net/browse/NRT-508






