### PR TITLE
[NRT-764] Fix macOS install deadlock by closing Deck Management during install

### DIFF
--- a/ankihub/gui/decks_dialog.py
+++ b/ankihub/gui/decks_dialog.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import aqt
 from anki.decks import DeckId
 from anki.models import NotetypeId, NotetypeNameId
+from aqt import props
 from aqt.qt import (
     QApplication,
     QBoxLayout,
@@ -20,6 +21,7 @@ from aqt.qt import (
     QLabel,
     QListWidget,
     QListWidgetItem,
+    QPropertyAnimation,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -317,15 +319,31 @@ class DeckManagementDialog(QDialog):
 
         def on_done(future: Future) -> None:
             future.result()
-            self._refresh_box_bottom_right()
 
-        def install_deck_and_refresh_dialog() -> None:
-            sync_with_ankihub(on_done=on_done)
+        def install_deck() -> None:
+            # Fade this dialog out and close it, then run the install: the install triggers Anki's
+            # AnkiWeb sync, whose dialogs are attached to the main window. With this modal dialog in
+            # front, they'd be hidden behind it on macOS and deadlock. The import summary's "Go to
+            # Deck Management" button brings the user back once the deck is installed.
+            self.sync_to_install_btn.setEnabled(False)  # prevent a second trigger during the fade
+
+            def on_faded_out() -> None:
+                self.close()
+                self.setWindowOpacity(1.0)  # restore for next time the dialog is shown
+                self.sync_to_install_btn.setEnabled(True)
+                sync_with_ankihub(on_done=on_done)
+
+            animation = QPropertyAnimation(self, b"windowOpacity", self)
+            animation.setDuration(int(theme_manager.var(props.TRANSITION)))
+            animation.setStartValue(1.0)
+            animation.setEndValue(0.0)
+            qconnect(animation.finished, on_faded_out)
+            animation.start()
 
         self.sync_to_install_btn = QPushButton("🔃️ Sync to install")
         qconnect(
             self.sync_to_install_btn.clicked,
-            install_deck_and_refresh_dialog,
+            install_deck,
         )
 
         self.sync_to_install_btn_row = QHBoxLayout()


### PR DESCRIPTION
## Related issues
- [NRT-764](https://ankihub.atlassian.net/browse/NRT-764) — "AnkiHub | Sync" install sheet appears behind Deck Management dialog on macOS → modal deadlock

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6e6aef0d-04e5-45eb-9b5d-65765b58d3a2" />


## Proposed changes
Clicking **Sync to install** in the Deck Management dialog deadlocked the UI on macOS: the install flow hands control to Anki's AnkiWeb sync, whose dialogs (full-sync prompt, sync errors, progress popup) are parented to the **main Anki window** by Anki itself. With the `ApplicationModal` Deck Management dialog in front, those rendered as sheets hidden *behind* it, unreachable, and Deck Management couldn't be closed because the hidden sheet blocked it — force-kill required.

This PR **closes Deck Management before starting the install**. The entire flow (confirmation, AnkiWeb sync, download progress, import summary, full upload) then runs on the main window with nothing in front for anything to hide behind — so no dialog, ours or Anki's, can deadlock. The import summary's existing **"Go to Deck Management"** button brings the user back to a freshly-refreshed dialog showing the deck installed.

To keep the transition smooth (per design feedback), Deck Management **fades out** over Anki's standard transition duration (~180 ms, `props.TRANSITION`) before it closes, rather than vanishing abruptly. The install starts once the fade completes, so the dialog is provably gone before any sync UI appears.

### Why this approach
We explored two families of fix:
- **Layer everything on Deck Management** (parent our dialogs to it, make them macOS sheets attached to it). This works for *our* dialogs, but Anki's own AnkiWeb sync UI is parented to the main window and can't be cleanly re-layered. The install flow also interleaves AnkiWeb syncs *around* the import summary (a full upload fires after the summary when the install changes the schema), which makes "hide Deck Management during sync" fragile — a sync firing while the summary is layered on the dialog would take the summary down with it.
- **Close Deck Management for the install (this PR).** Eliminates the entire class of deadlock at the source rather than re-layering around it, and is far simpler. It also makes installing-from-Deck-Management consistent with installing-from-the-main-window-sync: both run on the main window and offer the same "Go to Deck Management" return path.

The one behavior change: Deck Management no longer persists *through* the install — the user returns via the summary's existing button (one click) instead of it staying open behind the flow. During the install itself the dialog wasn't adding value (the user is watching progress, not managing decks).

## How to reproduce
**Before (bug), on macOS:**
1. Open Deck Management.
2. Select a subscribed-but-not-installed deck → "Sync to install".
3. Click through to the point where Anki needs to sync with AnkiWeb (most reliably with a schema-dirty collection, which triggers Anki's full-sync prompt).
4. Anki's prompt is hidden behind Deck Management; it can't be clicked and Deck Management can't be closed → force-kill.

**After (fixed):** Deck Management fades out and closes on "Sync to install"; the install runs on the main window with all dialogs visible; the import summary offers "Go to Deck Management" to return.

Linux/Windows render free-floating dialogs, so the deadlock never manifested there; this change is behavior-neutral on those platforms.

## Further comments
- Supersedes #1295 (the layered-approach attempt), which grew complex precisely because Anki's own sync UI can't be re-layered.
- The "Sync to install" button is disabled during the fade so a double-click can't start two installs.
- Testing: `ruff` + `mypy` clean; `TestDeckManagementDialog` and the download/install integration tests pass. Manually verified on macOS.


[NRT-764]: https://ankihub.atlassian.net/browse/NRT-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
