### PR TITLE
[ACTV-297] Fix top toolbar's tour backdrop stuck after closing browser

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1181,8 +1181,8 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         def before_setup_table(browser: Browser) -> None:
             aqt.mw.col.set_config_bool(Config.Bool.BROWSER_TABLE_SHOW_NOTES_MODE, False)
 
-        def before_close(browser: Browser, evt: Optional[QCloseEvent]) -> None:
-            if not self._browser_closed_by_us:
+        def after_close(browser: Browser, evt: Optional[QCloseEvent]) -> None:
+            if not self._browser_closed_by_us and evt.isAccepted():
                 self.go_to_step("browse_button")
 
         def wrapped_init(*args, **kwargs) -> None:
@@ -1195,7 +1195,7 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             is_startup = True
 
         unwrap_init = wrap_method(Browser, "__init__", wrapped_init, "around")
-        unwrap_close = wrap_method(Browser, "closeEvent", before_close, "before")
+        unwrap_close = wrap_method(Browser, "closeEvent", after_close, "after")
         unwrap_setup = wrap_method(Browser, "setup_table", before_setup_table, "before")
         unwrap_build = wrap_method(SidebarTreeView, "_deck_tree", _build_deck_tree, "around")
 


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/ACTV-297

## Proposed changes

This fixes the top toolbar's tour backdrop getting stuck after closing the browser in the Step Deck tour in some cases:

This was caused by a race condition:
- Our Browser.closeEvent() patch was getting called twice because Anki calls the method again after ensuring the editor's note is saved, which we were not taking account of: https://github.com/ankitects/anki/blob/5e46fc4494b428387f1d3f5c19d0ed19a089705e/qt/aqt/browser/browser.py#L411
- The resulting double _cleanup_step()/show_current() calls were causing a race issue that prevented a proper cleanup in some cases.

## How to reproduce

1. Start the Anki Step Deck Tour
2. Advance through steps 1, 2, 3
3. Click Next on step 3 to trigger the transition to step 4
4. Close the window immediately, before step 4 finishes loading
5. Observe that the screen may get stuck with a dark overlay. If you can't reproduce this, try minimizing both the browser and the main window then focusing the browser and closing it. According to my tests, the issue can be reproduced reliably in this case.
6. Attempting to restart the tour and repeat makes the overlay progressively darker