### PR TITLE
[NRT-781] Fix two flaky tests: subdeck flashcard-selector button and reminder dialog

### DIFF
--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -7479,15 +7479,19 @@ class TestFlashCardSelector:
 
             aqt.mw.deckBrowser.set_current_deck(subdeck_anki_id)
 
-            qtbot.wait(500)
-
             overview_web: AnkiWebView = aqt.mw.overview.web
-            with qtbot.wait_callback() as callback:
-                overview_web.evalWithCallback(
-                    f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}') !== null",
-                    callback,
-                )
-            callback.assert_called_with(True)
+
+            def button_exists() -> bool:
+                with qtbot.wait_callback() as callback:
+                    overview_web.evalWithCallback(
+                        f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}') !== null",
+                        callback,
+                    )
+                return bool(callback.args[0])
+
+            # The button is injected asynchronously after the overview re-renders for the
+            # subdeck; poll instead of asserting once after a fixed wait (flaky under CI load).
+            qtbot.wait_until(button_exists)
 
     @pytest.mark.sequential
     def test_clicking_button_opens_flashcard_selector_dialog(

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -256,6 +256,18 @@ skip_test_fsrs_unsupported = pytest.mark.skipif(
 )
 
 
+def wait_for_js_truthy(qtbot: QtBot, web: AnkiWebView, js_expr: str) -> None:
+    """Poll the webview until `js_expr` evaluates truthy. Replaces fixed-wait + one-shot
+    DOM checks, which are unreliable when content is injected asynchronously (CI load)."""
+
+    def predicate() -> bool:
+        with qtbot.wait_callback() as callback:
+            web.evalWithCallback(js_expr, callback)
+        return bool(callback.args[0])
+
+    qtbot.wait_until(predicate)
+
+
 class InstallSampleAHDeck(Protocol):
     def __call__(self) -> Tuple[DeckId, uuid.UUID]: ...
 
@@ -7480,18 +7492,11 @@ class TestFlashCardSelector:
             aqt.mw.deckBrowser.set_current_deck(subdeck_anki_id)
 
             overview_web: AnkiWebView = aqt.mw.overview.web
-
-            def button_exists() -> bool:
-                with qtbot.wait_callback() as callback:
-                    overview_web.evalWithCallback(
-                        f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}') !== null",
-                        callback,
-                    )
-                return bool(callback.args[0])
-
-            # The button is injected asynchronously after the overview re-renders for the
-            # subdeck; poll instead of asserting once after a fixed wait (flaky under CI load).
-            qtbot.wait_until(button_exists)
+            wait_for_js_truthy(
+                qtbot,
+                overview_web,
+                f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}') !== null",
+            )
 
     @pytest.mark.sequential
     def test_clicking_button_opens_flashcard_selector_dialog(

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3804,21 +3804,25 @@ class TestSetSubdeckDueDate:
         )
 
 
+@pytest.fixture
+def _reset_reminder_dialog_state():
+    # Real-dialog tests connect dialog.finished → QTimer.singleShot(0,
+    # _show_next_due_date_reminder_dialog). A late timer firing inside a
+    # @patch window otherwise records a call on the mocked dialog class with
+    # the real aqt.mw as parent. Clear state and drain pending callbacks
+    # before/after each test so stray timers hit the empty-queue early-return
+    # instead of acting on residue from another test.
+    _reminder_dialog_state.queue = []
+    _reminder_dialog_state.dialog = None
+    QApplication.processEvents()
+    yield
+    _reminder_dialog_state.queue = []
+    _reminder_dialog_state.dialog = None
+
+
+@pytest.mark.usefixtures("_reset_reminder_dialog_state")
 class TestShowNextDueDateReminderDialog:
     """Tests for _show_next_due_date_reminder_dialog function."""
-
-    @pytest.fixture(autouse=True)
-    def _reset_reminder_dialog_state(self):
-        # Real-dialog tests connect dialog.finished → QTimer.singleShot(0,
-        # _show_next_due_date_reminder_dialog). A late timer firing inside this
-        # test's @patch window otherwise records a call on the mocked dialog
-        # class with the real aqt.mw as parent. Clear state and drain pending
-        # callbacks before the patches activate so any stray timer hits the
-        # empty-queue early-return.
-        _reminder_dialog_state.queue = []
-        _reminder_dialog_state.dialog = None
-        QApplication.processEvents()
-        yield
 
     @patch("ankihub.gui.subdeck_due_date_dialog.get_subdeck_log_context")
     @patch("ankihub.gui.subdeck_due_date_dialog.SubdeckDueDateReminderDialog")
@@ -3858,6 +3862,7 @@ class TestShowNextDueDateReminderDialog:
         assert _reminder_dialog_state.dialog is None
 
 
+@pytest.mark.usefixtures("_reset_reminder_dialog_state")
 class TestShowSubdeckDueDateReminders:
     """Tests for maybe_show_subdeck_due_date_reminders function."""
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -20,7 +20,7 @@ from anki.models import NotetypeDict
 from anki.notes import Note, NoteId
 from approvaltests.approvals import verify  # type: ignore
 from approvaltests.namer import NamerFactory  # type: ignore
-from aqt.qt import QDialog, QDialogButtonBox, QLineEdit, QMenu, Qt, QTimer, QWidget
+from aqt.qt import QApplication, QDialog, QDialogButtonBox, QLineEdit, QMenu, Qt, QTimer, QWidget
 from pytest import MonkeyPatch
 from pytest_anki import AnkiSession
 from pytest_mock import MockerFixture
@@ -3806,6 +3806,19 @@ class TestSetSubdeckDueDate:
 
 class TestShowNextDueDateReminderDialog:
     """Tests for _show_next_due_date_reminder_dialog function."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_reminder_dialog_state(self):
+        # Real-dialog tests connect dialog.finished → QTimer.singleShot(0,
+        # _show_next_due_date_reminder_dialog). A late timer firing inside this
+        # test's @patch window otherwise records a call on the mocked dialog
+        # class with the real aqt.mw as parent. Clear state and drain pending
+        # callbacks before the patches activate so any stray timer hits the
+        # empty-queue early-return.
+        _reminder_dialog_state.queue = []
+        _reminder_dialog_state.dialog = None
+        QApplication.processEvents()
+        yield
 
     @patch("ankihub.gui.subdeck_due_date_dialog.get_subdeck_log_context")
     @patch("ankihub.gui.subdeck_due_date_dialog.SubdeckDueDateReminderDialog")


### PR DESCRIPTION
## Related issues
- [x] Closes [NRT-781](https://ankihub.atlassian.net/browse/NRT-781)

Flakes spotted on the [NRT-749 / 751 / 763 / 764 CI runs](https://github.com/AnkiHubSoftware/ankihub_addon/actions). Findings written up in `.claude/worktrees/NRT-749-qa-followup/notes/nrt_flaky_tests.md`.

## Proposed changes

Two unrelated CI flakes, fixed in one PR off `main` so they don't get tied to any in-flight feature branch.

**1. `tests/addon/test_integration.py` — `test_flashcard_selector_button_exists_for_subdeck_of_deck_with_note_embeddings`**

Replace fixed `qtbot.wait(500)` + one-shot `evalWithCallback` DOM check with `qtbot.wait_until` polling. The flashcard-selector button is injected asynchronously after `set_current_deck` fires `overview_did_refresh`, and the subdeck path is a touch slower than the parent-deck path because it walks ancestors to find the AnkiHub deck. A fixed 500ms wait is unreliable under CI load.

The polling logic is extracted into a reusable `wait_for_js_truthy(qtbot, web, js_expr)` helper. Note it's *not* a drop-in for every fixed-wait + eval site: `test_flashcard_selector_send_note_suspension_states_message` was left on its `qtbot.wait(500)` because it depends on that wait to let the webview's `_domDone` flip true before any eval runs — polling immediately would queue an eval that sits until the callback times out.

**2. `tests/addon/test_unit.py` — `TestShowNextDueDateReminderDialog` / `TestShowSubdeckDueDateReminders`**

Add a module-level fixture (applied to both reminder-dialog test classes via `pytest.mark.usefixtures`) that clears `_reminder_dialog_state.queue / .dialog` and drains pending `QTimer.singleShot` callbacks **before** each test's `@patch` decorators activate, plus a symmetric post-test reset so each test cleans up after itself.

Root cause: real-dialog tests connect `dialog.finished` → `QTimer.singleShot(0, _show_next_due_date_reminder_dialog)`. A stray late timer was firing inside this unit test's mock window and recording a `SubdeckDueDateReminderDialog(parent=<real AnkiQt>)` call on the mocked dialog class, making `assert_called_once_with(parent=mock_aqt.mw)` fail with the real `aqt.mw` as the parent. Clearing the queue + draining `processEvents()` before mocks bind means any stray timer hits the empty-queue early-return without touching the mocks. `TestShowSubdeckDueDateReminders` also touches the shared state (and leaves the queue populated, since it mocks out `_show_next_due_date_reminder_dialog`), so it gets the same fixture.

Not in this PR: a single sighting of `tests/addon/performance/test_subdeck_operations.py::TestFlattenDeck::test_basic` flaked once on NRT-751 — not investigated; revisit if it recurs.

## How to reproduce

These are CI flakes; locally they pass consistently. To verify the fixes:

```
xvfb-run -a uv run pytest tests/addon/test_unit.py::TestShowNextDueDateReminderDialog tests/addon/test_unit.py::TestShowSubdeckDueDateReminders -n 0
xvfb-run -a uv run pytest "tests/addon/test_integration.py::TestFlashCardSelector::test_flashcard_selector_button_exists_for_subdeck_of_deck_with_note_embeddings" -m sequential -n 0
```

Both pass; the subdeck integration test runs in ~1.3s.

## Screenshots and videos

N/A — test-only change.

## Further comments

Intentionally scoped: only the two flakes I could root-cause. The flatten-deck performance test gets a fresh look if it shows up again.


[NRT-781]: https://ankihub.atlassian.net/browse/NRT-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ