### PR TITLE
[NRT-786] Only focus chatbot sidebar on explicit open, not on card change

### DIFF
--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -182,9 +182,8 @@ class ReviewerSidebar:
         self.page_type = SidebarPageType.CHATBOT
         self.resources = []
 
-        # Only focus the chatbot when explicitly requested (e.g. when the user opens it),
-        # not when it's refreshed on card change, so that the reviewer keeps keyboard focus
-        # (and shortcuts like the answer keys keep working) while reviewing with the sidebar open.
+        # Only focus the chatbot when explicitly requested (e.g. when the user opens it), not on
+        # card change, so that the reviewer keeps keyboard focus (and shortcuts) while reviewing.
         self._focus_content_webview_on_page_load = focus
 
         # The web app handles the case when ah_nid is None and shows the "note not found" screen.
@@ -289,13 +288,17 @@ class ReviewerSidebar:
         self.content_webview.eval(f"localStorage.setItem('theme', '{anki_theme()}');")
 
     def _on_content_page_loaded(self, ok: bool) -> None:
+        # Consume the one-shot focus request on every load, so that a stale request can't
+        # focus the webview on a later, unrelated page load.
+        focus_requested = self._focus_content_webview_on_page_load
+        self._focus_content_webview_on_page_load = False
+
         if url_login() in self.content_webview.url().toString():
             self._handle_auth_failure()
             return
 
         if ok:
-            if self._focus_content_webview_on_page_load:
-                self._focus_content_webview_on_page_load = False
+            if focus_requested and self.is_sidebar_open():
                 self.content_webview.setFocus()
             return
 

--- a/ankihub/gui/reviewer.py
+++ b/ankihub/gui/reviewer.py
@@ -91,6 +91,7 @@ class ReviewerSidebar:
         self.on_auth_failure_hook: Callable = None
         self.last_accessed_url: Optional[str] = None
         self.needs_to_accept_terms = False
+        self._focus_content_webview_on_page_load = False
 
         self._setup_ui()
 
@@ -177,16 +178,22 @@ class ReviewerSidebar:
 
         self._update_header_webview()
 
-    def show_chatbot(self, ah_nid: Optional[uuid.UUID]) -> None:
+    def show_chatbot(self, ah_nid: Optional[uuid.UUID], focus: bool = False) -> None:
         self.page_type = SidebarPageType.CHATBOT
         self.resources = []
+
+        # Only focus the chatbot when explicitly requested (e.g. when the user opens it),
+        # not when it's refreshed on card change, so that the reviewer keeps keyboard focus
+        # (and shortcuts like the answer keys keep working) while reviewing with the sidebar open.
+        self._focus_content_webview_on_page_load = focus
 
         # The web app handles the case when ah_nid is None and shows the "note not found" screen.
         url = f"{config.app_url}/ai/chatbot/{ah_nid}/?is_on_anki=true"
         self.set_content_url(url)
 
         self._update_header_webview()
-        self.content_webview.setFocus()
+        if focus:
+            self.content_webview.setFocus()
 
     def _update_header_button_state(self):
         if not self.resources:
@@ -287,7 +294,8 @@ class ReviewerSidebar:
             return
 
         if ok:
-            if self.page_type == SidebarPageType.CHATBOT:
+            if self._focus_content_webview_on_page_load:
+                self._focus_content_webview_on_page_load = False
                 self.content_webview.setFocus()
             return
 
@@ -470,9 +478,9 @@ def _notify_ankihub_ai_of_card_change(card: Card) -> None:
         _show_chatbot_for_current_card(card)
 
 
-def _show_chatbot_for_current_card(card: Card) -> None:
+def _show_chatbot_for_current_card(card: Card, focus: bool = False) -> None:
     ah_nid = ankihub_db.ankihub_nid_for_anki_nid(card.nid)
-    reviewer_sidebar.show_chatbot(ah_nid)
+    reviewer_sidebar.show_chatbot(ah_nid, focus=focus)
 
 
 def _remove_anking_button(_: Card) -> None:
@@ -614,7 +622,7 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
         if button_name == "chatbot":
             if is_active:
                 if reviewer_sidebar.open_sidebar():
-                    _show_chatbot_for_current_card(context.card)
+                    _show_chatbot_for_current_card(context.card, focus=True)
             else:
                 reviewer_sidebar.close_sidebar()
         else:


### PR DESCRIPTION
## Related issues

Closes [NRT-786](https://ankihub.atlassian.net/browse/NRT-786) — regression introduced by [NRT-713](https://ankihub.atlassian.net/browse/NRT-713).

## Summary

[NRT-713](https://ankihub.atlassian.net/browse/NRT-713) added focusing of the chatbot webview so the cursor lands in the chat input when the user opens the chatbot. However, the focus was applied in `show_chatbot()` and on every chatbot page load — both of which also run on **every card change** while the sidebar is open (via `reviewer_did_show_question` → `_notify_ankihub_ai_of_card_change`). This stole keyboard focus from the reviewer on every card, breaking review shortcuts (spacebar, answer keys) until the user clicked the card again ([Slack thread](https://ankihubllc.slack.com/archives/C08DWTDEDK8/p1776438061025219), [Loom](https://www.loom.com/share/10f56c2ea04b46fa855e2f6b3ec04152)).

## Changes

- The chatbot webview is now only focused when the user explicitly opens the chatbot via the reviewer button. The per-card refresh of the sidebar no longer takes focus.
- Implementation: `show_chatbot()` gained a `focus` parameter (only the chatbot-button handler passes `True`). Because the page loads asynchronously and the load can reset widget focus, the request is remembered in a one-shot flag and re-applied once when the load finishes.
- Safety: the flag is consumed on every `loadFinished` — including failed loads and login redirects — and ignored if the sidebar was closed in the meantime. A stale focus request can therefore never grab focus on a later, unrelated page load.

## Result

- Opening the chatbot via the reviewer button: cursor lands in the chat input (NRT-713 behavior preserved)
- Flipping to the next card with the sidebar open: reviewer keeps keyboard focus, shortcuts keep working

## Testing

- mypy clean
- Sequential reviewer-sidebar integration test passes headless
- Manually verified on Linux and macOS: focus lands in chat input on open; spacebar/answer keys keep working across card changes with the sidebar open

[NRT-786]: https://ankihub.atlassian.net/browse/NRT-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-713]: https://ankihub.atlassian.net/browse/NRT-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
