### PR TITLE
Fix Unicode line separators in fields causing JSON errors

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -682,7 +682,7 @@ class AnkiHubClient:
         else:
             deck_csv_content = s3_response_content.decode("utf-8")
 
-        reader = csv.DictReader(deck_csv_content.splitlines(), delimiter=CSV_DELIMITER, quotechar="'")
+        reader = csv.DictReader(re.split(r"\r\n|\n|\r", deck_csv_content), delimiter=CSV_DELIMITER, quotechar="'")
         # TODO Validate .csv
         notes_data_raw = [row for row in reader]
         notes_data_raw = _transform_notes_data(notes_data_raw)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -68,6 +68,7 @@ TEST_DATA_PATH = Path(__file__).parent.parent / "test_data"
 DECK_CSV = TEST_DATA_PATH / "deck_with_one_basic_note.csv"
 DECK_CSV_GZ = TEST_DATA_PATH / "deck_with_one_basic_note.csv.gz"
 DECK_CSV_WITH_ONE_DELETED_BASIC_NOTE = TEST_DATA_PATH / "deck_with_one_deleted_basic_note.csv"
+DECK_CSV_WITH_UNICODE_LINE_SEPARATOR = TEST_DATA_PATH / "deck_with_one_basic_note_with_unicode_line_separator.csv"
 
 DECK_CSV_WITHOUT_DELETED_COLUMN = TEST_DATA_PATH / "deck_with_one_basic_note_without_deleted_column.csv"
 DECK_CSV_GZ_WITHOUT_DELETED_COLUMN = TEST_DATA_PATH / "deck_with_one_basic_note_without_deleted_column.csv.gz"
@@ -548,6 +549,22 @@ class TestDownloadDeck:
 
         assert len(notes_data) == 1
         assert notes_data[0].tags == ["asdf"]
+
+    def test_download_deck_preserves_unicode_line_separator_in_field(
+        self, authorized_client_for_user_test1: AnkiHubClient
+    ):
+        client = authorized_client_for_user_test1
+        field_value = "front\u2028more content<br>"
+        deck_file_presigned_url = f"{DEFAULT_S3_BUCKET_URL}/{DECK_CSV_WITH_UNICODE_LINE_SEPARATOR.name}?auth=123"
+        with requests_mock.Mocker(real_http=True) as m:
+            m.get(deck_file_presigned_url, content=DECK_CSV_WITH_UNICODE_LINE_SEPARATOR.read_bytes())
+            notes_data = client.download_deck(
+                ah_did=ID_OF_DECK_OF_USER_TEST1,
+                s3_presigned_url=deck_file_presigned_url,
+            )
+
+        assert len(notes_data) == 1
+        assert notes_data[0].fields[0].value == field_value
 
 
 def create_note_on_ankihub_and_assert(client, new_note_suggestion, uuid_of_deck: uuid.UUID):

--- a/tests/test_data/deck_with_one_basic_note_with_unicode_line_separator.csv
+++ b/tests/test_data/deck_with_one_basic_note_with_unicode_line_separator.csv
@@ -1,0 +1,2 @@
+anki_id;deck;deleted;fields;guid;id;last_sync;note_type;note_type_id;tags
+1662901432199;8e2cb80a-e37c-43b3-8b1a-974d6d976808;;[{"name": "Front", "order": 0, "value": "front more content<br>"}, {"name": "Back", "order": 1, "value": "back<br>"}];NJ<Ow469E>;fe39b7ce-14a5-4efa-b517-bd87c4cc9ace;2022-09-15 09:46:33.341093+00:00;Basic (basic notes / user);1662973152114;["asdf"]


### PR DESCRIPTION
## Related issues

https://community.ankihub.net/t/anatoking-download-error/601183/

https://ankihub.sentry.io/issues/7447487725/?project=6546414&query=id%3A33321a0acae34a17a2f85709d3f9185a&referrer=issue-stream


## Proposed changes

str.splitlines() is used to split the CSV content into lines, but this function [also splits on unprintable characters such as Line Separator](https://docs.python.org/3/library/stdtypes.html#str.splitlines
), which causes errors if some field happens to contain these characters.


## How to reproduce

### Before

Import the [AnatoKing](https://app.ankihub.net/decks/bea25743-706a-4bff-a043-efcc0a617121) deck and confirms you get a JSON parsing error.

### After

Confirm deck import works with no errors.
