### PR TITLE
[NRT-799] Improve suggestion dialog copy and protected-field discoverability

### DIFF
--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -84,9 +84,10 @@ from .utils import (
     warning_triangle_icon,
 )
 
-# "Include in suggestion" panel copy. The subtitle switches to the EMPTY variant
+# "Select fields to include" panel copy. The subtitle switches to the EMPTY variant
 # (plus the warning) when the note has no edited fields and no tag changes.
-INCLUDE_SUBTITLE = "Select which fields you want to submit changes for"
+INCLUDE_TITLE = "Select fields to include"
+INCLUDE_SUBTITLE = "Choose which fields to submit changes for."
 EMPTY_STATE_SUBTITLE = "Edit a note field to create a change suggestion"
 EMPTY_STATE_TITLE = "No changes detected"
 EMPTY_STATE_HINT = "Edit a field to suggest a change, or select Delete on change type."
@@ -1429,7 +1430,7 @@ class IncludeInSuggestionWidget(QWidget):
         frame.setLayout(frame_layout)
 
         title_row = QHBoxLayout()
-        self._title_label = QLabel("<b>Include in suggestion</b>")
+        self._title_label = QLabel(f"<b>{INCLUDE_TITLE}</b>")
         self._counter_label = QLabel("")
         counter_font = self._counter_label.font()
         counter_font.setPointSize(max(counter_font.pointSize() - 2, 8))

--- a/ankihub/gui/suggestion_dialog.py
+++ b/ankihub/gui/suggestion_dialog.py
@@ -487,7 +487,7 @@ class SuggestionDialog(QDialog):
         super().__init__(parent)
         # Block input to other Anki windows while the dialog is open — prevents
         # the user from editing the selected notes (or syncing) between dialog
-        # open and submit, which would invalidate the "Include in suggestion"
+        # open and submit, which would invalidate the "Select fields to include"
         # selection.
         self.setWindowModality(Qt.WindowModality.ApplicationModal)
         self._is_new_note_suggestion = is_new_note_suggestion

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -112,26 +112,34 @@ class _InfoIconDelegate(QStyledItemDelegate):
         self._pixmap = tooltip_icon().pixmap(QSize(self._ICON_SIZE, self._ICON_SIZE))
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
-        super().paint(painter, option, index)
         if not index.data(_INFO_ICON_ROLE):
+            super().paint(painter, option, index)
             return
-        rect = option.rect
-        # Place the icon just after the text, not pinned to the column's right
-        # edge. Re-init the option first: the one Qt hands to paint() lacks the
-        # laid-out sub-element geometry, so subElementRect(...ItemText) would
-        # otherwise report the text starting at x=0 (before the checkbox) and the
-        # icon would land on the text.
-        widget = option.widget
-        style = widget.style() if widget else QApplication.style()
+
+        # Re-init the option: the one Qt hands to paint() lacks the laid-out
+        # sub-element geometry, so subElementRect(...ItemText) would otherwise
+        # report the text starting at x=0 (before the checkbox). Narrow the rect
+        # before super().paint() to reserve room for the icon, so a long field
+        # name elides before the icon instead of being overpainted by it.
+        reserved = self._ICON_SIZE + 2 * self._MARGIN
         opt = QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
-        text_rect = style.subElementRect(QStyle.SubElement.SE_ItemViewItemText, opt, widget)
+        text_area = opt.rect
+        text_area.setRight(text_area.right() - reserved)
+        opt.rect = text_area
+        super().paint(painter, opt, index)
+
+        style = opt.widget.style() if opt.widget else QApplication.style()
+        text_rect = style.subElementRect(QStyle.SubElement.SE_ItemViewItemText, opt, opt.widget)
         text = index.data(Qt.ItemDataRole.DisplayRole) or ""
-        text_width = option.fontMetrics.horizontalAdvance(text)
-        x = text_rect.left() + text_width + self._MARGIN
-        # Don't let it spill past the right edge for very long field names.
-        x = min(x, rect.right() - self._ICON_SIZE - self._MARGIN)
-        y = rect.top() + (rect.height() - self._ICON_SIZE) // 2
+        # Qt insets item text from text_rect.left() by this margin (see QCommonStyle
+        # CE_ItemViewItem). It's larger on macOS than on Fusion, so omitting it makes
+        # the icon crowd the text there. Add it so the gap is consistent cross-platform.
+        text_margin = style.pixelMetric(QStyle.PixelMetric.PM_FocusFrameHMargin, opt, opt.widget) + 1
+        text_end = text_rect.left() + text_margin + opt.fontMetrics.horizontalAdvance(text)
+        # Sit just after the text, but never into the reserved gap at the edge.
+        x = min(text_end + self._MARGIN, option.rect.right() - self._ICON_SIZE - self._MARGIN)
+        y = option.rect.top() + (option.rect.height() - self._ICON_SIZE) // 2
         painter.drawPixmap(x, y, self._pixmap)
 
 

--- a/ankihub/gui/utils.py
+++ b/ankihub/gui/utils.py
@@ -23,6 +23,7 @@ from aqt.qt import (
     QLayout,
     QListWidget,
     QListWidgetItem,
+    QModelIndex,
     QPainter,
     QPixmap,
     QPropertyAnimation,
@@ -31,6 +32,8 @@ from aqt.qt import (
     QSize,
     QSizePolicy,
     QStyle,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
     Qt,
     QToolButton,
     QVBoxLayout,
@@ -90,6 +93,46 @@ def _show_tooltip(message: str, *args, **kwargs) -> None:
             tooltip(message)
         else:
             raise e
+
+
+# Per-item flag (read by _InfoIconDelegate) marking rows that should show a
+# trailing info icon hinting that a tooltip explains the row.
+_INFO_ICON_ROLE = Qt.ItemDataRole.UserRole + 1
+
+
+class _InfoIconDelegate(QStyledItemDelegate):
+    """Paints a small info icon just after the text of rows flagged with
+    `_INFO_ICON_ROLE`, after the native row (checkbox + text) is drawn."""
+
+    _ICON_SIZE = 16
+    _MARGIN = 6
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._pixmap = tooltip_icon().pixmap(QSize(self._ICON_SIZE, self._ICON_SIZE))
+
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
+        super().paint(painter, option, index)
+        if not index.data(_INFO_ICON_ROLE):
+            return
+        rect = option.rect
+        # Place the icon just after the text, not pinned to the column's right
+        # edge. Re-init the option first: the one Qt hands to paint() lacks the
+        # laid-out sub-element geometry, so subElementRect(...ItemText) would
+        # otherwise report the text starting at x=0 (before the checkbox) and the
+        # icon would land on the text.
+        widget = option.widget
+        style = widget.style() if widget else QApplication.style()
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        text_rect = style.subElementRect(QStyle.SubElement.SE_ItemViewItemText, opt, widget)
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
+        text_width = option.fontMetrics.horizontalAdvance(text)
+        x = text_rect.left() + text_width + self._MARGIN
+        # Don't let it spill past the right edge for very long field names.
+        x = min(x, rect.right() - self._ICON_SIZE - self._MARGIN)
+        y = rect.top() + (rect.height() - self._ICON_SIZE) // 2
+        painter.drawPixmap(x, y, self._pixmap)
 
 
 class _ChooseSubsetDialog(QDialog):
@@ -155,6 +198,7 @@ class _ChooseSubsetDialog(QDialog):
         locked_tooltip: Optional[str],
     ) -> None:
         self._list_widget = CustomListWidget()
+        self._list_widget.setItemDelegate(_InfoIconDelegate(self._list_widget))
         for choice in choices:
             item = QListWidgetItem(choice)
             if choice in locked_set:
@@ -162,6 +206,9 @@ class _ChooseSubsetDialog(QDialog):
                 item.setCheckState(Qt.CheckState.Checked)
                 if locked_tooltip:
                     item.setToolTip(locked_tooltip)
+                    # Flag the row so the delegate paints a trailing info icon —
+                    # a disabled row alone gives no hint the tooltip exists.
+                    item.setData(_INFO_ICON_ROLE, True)
             else:
                 item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)  # type: ignore
                 item.setCheckState(Qt.CheckState.Checked if choice in current else Qt.CheckState.Unchecked)

--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -102,7 +102,15 @@ def anki_session_with_addon_data(
         config_dict = json.load(f)
     anki_session.create_addon_config(package_name="ankihub", default_config=config_dict)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    # Use a temp dir as the ankihub base path to isolate tests. Clean it up
+    # manually with ignore_errors=True rather than via TemporaryDirectory's
+    # context manager: background tasks (e.g. refresh_user_state_in_background)
+    # can still be writing config/logs into it when the test ends, and a strict
+    # rmtree then races them and fails the test at teardown with
+    # "OSError: [Errno 39] Directory not empty". The dir is disposable, so
+    # tolerating a partial cleanup is fine.
+    tmpdir = tempfile.mkdtemp()
+    try:
         # Change the ankihub base path to a temporary folder to isolate the tests
         os.environ["ANKIHUB_BASE_PATH"] = tmpdir
 
@@ -120,6 +128,8 @@ def anki_session_with_addon_data(
         _mock_user_details(requests_mock)
 
         yield anki_session
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def _mock_all_feature_flags_to_default_values(monkeypatch: MonkeyPatch) -> None:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -2241,7 +2241,7 @@ class TestFieldsToSuggestFilters:
 
             # New-note candidate whose only non-empty fields are all globally-protected,
             # with no tags → not suggestible. (Otherwise the dialog would open with an
-            # empty "Include in suggestion" panel that the user can't submit from.)
+            # empty "Select fields to include" panel that the user can't submit from.)
             new_note_protected = add_anki_note(note_type=aqt.mw.col.models.get(NotetypeId(mid)))
             first_field_name = new_note_protected.note_type()["flds"][0]["name"]
             assert not any_suggestible_from_diffs(

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -7788,13 +7788,19 @@ def mock_client_media_upload(mocker: MockerFixture) -> Iterator[Mock]:
 
     # Create a temporary media folder and copy the test media files to it.
     # Patch the media folder path to point to the temporary folder.
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    # Clean up with ignore_errors=True rather than TemporaryDirectory's context
+    # manager: background media-sync tasks can still be writing here at teardown,
+    # and a strict rmtree would then race them and fail with "Directory not empty".
+    tmp_dir = tempfile.mkdtemp()
+    try:
         for file in (TEST_DATA_PATH / "media").glob("*"):
             shutil.copy(file, Path(tmp_dir) / file.name)
 
         mocker.patch("anki.media.MediaManager.dir", return_value=tmp_dir)
 
         yield upload_file_to_s3_with_reusable_presigned_url_mock
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 class TestSuggestionsWithMedia:


### PR DESCRIPTION
## Related issues
- [x] Closes [NRT-799](https://ankihub.atlassian.net/browse/NRT-799)

## Proposed changes
Addresses Ahmed's feedback on the protected-fields selection experience (NRT-799).

**1. Suggestion dialog copy** — the "Include in suggestion" wording was unclear without reading the supporting text:
- Title: `Include in suggestion` → **`Select fields to include`**
- Subtitle: `Select which fields you want to submit changes for` → **`Choose which fields to submit changes for.`**

**2. Protected-field discoverability** — in the browser's "Protect fields" dialog, globally-protected fields render checked + greyed out with an explanatory tooltip, but there was no visual cue the tooltip existed (it only appeared on hover). Added an **info icon after the field name** for those locked rows so the tooltip is discoverable.

Implementation note: Anki's Qt style lays out the checkbox + text inside `drawControl`, so the `QStyleOptionViewItem` handed to a delegate's `paint()` has no usable sub-element geometry. The new `_InfoIconDelegate` re-runs `initStyleOption` on a copy of the option before calling `subElementRect(SE_ItemViewItemText)`, which is what lets it place the icon immediately after the rendered text rather than at the row's far-right edge.

**3. Test-stability fix (drive-by)** — while iterating I hit a pre-existing flaky teardown: the shared `anki_session_with_addon_data` fixture points `ANKIHUB_BASE_PATH` at a `TemporaryDirectory`, and background tasks (e.g. `refresh_user_state_in_background`, exercised by `TestFeatureFlags`) can still be writing config/logs into it when a test ends — so the strict `rmtree` races them and intermittently fails at teardown with `OSError: [Errno 39] Directory not empty`. These disposable isolation dirs are now cleaned up with `shutil.rmtree(ignore_errors=True)` in `conftest.py` and the media-folder fixture (the other site exposed to background writers). The test bodies are unaffected — only the cleanup is made race-tolerant.

## How to reproduce
**Suggestion dialog copy:**
1. Open a deck synced with AnkiHub, edit a field on a note.
2. Right-click → AnkiHub → Suggest a change (or the editor button).
3. The "Select fields to include" panel shows the new title + subtitle.

**Protected-field icon:**
1. Have an AnkiHub deck with at least one globally-protected field (set on the AnkiHub website).
2. In the browser, select a note of that note type → right-click → AnkiHub → Protect fields.
3. The globally-protected field rows are greyed/checked and now show an info icon right after the field name; hovering reveals the "This field is globally protected" tooltip.

## Screenshots and videos

**Suggestion dialog — new title + subtitle**

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="100%" alt="Suggestion dialog before" src="https://github.com/user-attachments/assets/58846609-37aa-4842-bb5c-e463b853121b" /></td>
<td><img width="100%" alt="Suggestion dialog after" src="https://github.com/user-attachments/assets/8af75244-85fc-4945-a7f7-f57d6569f32a" /></td>
</tr>
</table>

**Protect fields dialog — info icon after globally-protected field names**

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="100%" alt="Protect fields dialog before" src="https://github.com/user-attachments/assets/eeac4ab6-7b03-4635-a58c-2a77a7dafb52" /></td>
<td><img width="100%" alt="Protect fields dialog after" src="https://github.com/user-attachments/assets/967d1115-33a0-4a61-a79f-08aa3dfa24c6" /></td>
</tr>
</table>

## Further comments
The info icon is positioned with a small `_InfoIconDelegate` rather than a leading item icon, because we want it *after* the field name. Getting "after the text" right cross-platform needs two style-geometry details: the option must be re-`initStyleOption`'d before `subElementRect(...ItemText)` returns usable geometry, and the text's left inset (`PM_FocusFrameHMargin`) must be added — it's larger on macOS than on Fusion, and omitting it made the icon crowd the text there. Long field names elide before the icon (space is reserved before the native paint).

Verified on **Linux** (headless render + `protect_fields_action` integration tests pass, mypy clean) and on **macOS** (built + installed on a Mac; icon spacing confirmed after the `PM_FocusFrameHMargin` fix).


[NRT-799]: https://ankihub.atlassian.net/browse/NRT-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





