### PR TITLE
[NRT-822] Qt5: open Terms & Conditions and Flashcard Selector in the external browser

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1287,6 +1287,21 @@ class AnkiHubClient:
 
         return response.json()
 
+    def is_terms_agreement_accepted(self) -> bool:
+        """Return whether the user has accepted the terms & conditions (and filled the required
+        personal info gated by the same permission).
+
+        There is no dedicated terms-status endpoint, so this re-issues a lightweight request guarded
+        by that permission: a 200 means accepted, a 403 means not accepted yet. Used to poll for
+        acceptance when the terms page is opened in the external browser (Qt5 builds, see NRT-822).
+        """
+        response = self._send_request("GET", API.ANKIHUB, "/users/decks/")
+        if response.status_code == 200:
+            return True
+        if response.status_code == 403:
+            return False
+        raise AnkiHubHTTPError(response)
+
     def owned_deck_ids(self) -> List[uuid.UUID]:
         data = self.get_user_details()
         result = [uuid.UUID(deck["id"]) for deck in data["created_decks"]]

--- a/ankihub/gui/errors.py
+++ b/ankihub/gui/errors.py
@@ -338,6 +338,18 @@ def _is_internet_available():
         return False
 
 
+def _resume_sync_after_terms_accepted() -> None:
+    """Resume the AnkiHub sync that was blocked by an unaccepted terms agreement (Qt5 path).
+
+    On Qt5 the terms page is opened in the external browser and acceptance is detected by polling;
+    once accepted we re-trigger the sync the user originally attempted (see NRT-822).
+    """
+    from .operations.ankihub_sync import sync_with_ankihub
+
+    show_tooltip("Terms accepted. Syncing with AnkiHub…", parent=aqt.mw)
+    sync_with_ankihub(on_done=lambda future: future.result())
+
+
 def _maybe_handle_ankihub_http_error(error: AnkiHubHTTPError) -> bool:
     """Return True if the error was handled, False otherwise."""
     response = error.response
@@ -354,7 +366,11 @@ def _maybe_handle_ankihub_http_error(error: AnkiHubHTTPError) -> bool:
             return False
 
         if response_data.get("detail") == TERMS_AGREEMENT_NOT_ACCEPTED_DETAIL:
-            run_with_delay_when_progress_dialog_is_open(TermsAndConditionsDialog.display, parent=aqt.mw)
+            run_with_delay_when_progress_dialog_is_open(
+                TermsAndConditionsDialog.display,
+                parent=aqt.mw,
+                on_accepted=_resume_sync_after_terms_accepted,
+            )
             return True
 
     elif response.status_code == 406:

--- a/ankihub/gui/flashcard_selector_dialog.py
+++ b/ankihub/gui/flashcard_selector_dialog.py
@@ -14,7 +14,7 @@ from ..settings import (
     url_plans_page,
 )
 from ..user_state import check_user_feature_access
-from .utils import show_dialog
+from .utils import show_dialog, show_tooltip, using_qt5
 
 
 class FlashCardSelectorDialog(AnkiHubWebViewDialog):
@@ -26,10 +26,20 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
         self.ah_did = ah_did
 
     @classmethod
-    def display_for_ah_did(cls, ah_did: uuid.UUID, parent: Any) -> "FlashCardSelectorDialog":
+    def display_for_ah_did(cls, ah_did: uuid.UUID, parent: Any) -> Optional["FlashCardSelectorDialog"]:
         """Display the flashcard selector dialog for the given deck.
         Reuses the dialog if it is already open for the same deck.
-        Otherwise, closes the existing dialog and opens a new one."""
+        Otherwise, closes the existing dialog and opens a new one.
+
+        On Qt5 builds the embedded Chromium-77 webview can't render the flashcard selector page, so
+        the full page is opened in the user's external browser instead and ``None`` is returned (see
+        NRT-822)."""
+        if using_qt5():
+            openLink(url_flashcard_selector(ah_did))
+            show_tooltip("Opening the Flashcard Selector in your web browser…", parent=parent)
+            LOGGER.info("Opened flashcard selector in external browser (Qt5).")
+            return None
+
         if cls.dialog and cls.dialog.ah_did != ah_did and not sip.isdeleted(cls.dialog):
             cls.dialog.close()
             cls.dialog = None

--- a/ankihub/gui/terms_dialog.py
+++ b/ankihub/gui/terms_dialog.py
@@ -1,14 +1,43 @@
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
-from aqt.qt import QColor, QDialog, Qt, QUrl, QVBoxLayout
+from aqt import sip
+from aqt.qt import (
+    QColor,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    Qt,
+    QTimer,
+    QUrl,
+    QVBoxLayout,
+    qconnect,
+)
+from aqt.utils import openLink
 from aqt.webview import AnkiWebPage, AnkiWebView
 
+from .. import LOGGER
+from ..addon_ankihub_client import AddonAnkiHubClient
 from ..gui.webview import AuthenticationRequestInterceptor
 from ..settings import config
+from .operations import AddonQueryOp
+from .utils import using_qt5
+
+# How often, and for how long, to auto-poll for terms acceptance after opening the page in the
+# external browser. After the window elapses, auto-polling stops and the manual "Check now" button
+# remains as the fallback (see NRT-822).
+_AUTO_POLL_INTERVAL_MS = 3_000
+_AUTO_POLL_WINDOW_MS = 3 * 60 * 1_000
+
+
+def _terms_url() -> str:
+    return f"{config.app_url}/users/school-info-and-terms-and-conditions/"
 
 
 class TermsAndConditionsDialog(QDialog):
     dialog: Optional["TermsAndConditionsDialog"] = None
+    # The Qt5 variant, which opens the page in the external browser instead of the embedded webview.
+    external_dialog: Optional["ExternalBrowserTermsDialog"] = None
 
     def __init__(self, parent: Any = None) -> None:
         super().__init__(parent)
@@ -28,7 +57,7 @@ class TermsAndConditionsDialog(QDialog):
         self.web.setPage(page)
         self.web.page().profile().setUrlRequestInterceptor(self.interceptor)
         self.web.page().setBackgroundColor(QColor("white"))
-        self.web.page().setUrl(QUrl(f"{config.app_url}/users/school-info-and-terms-and-conditions/"))
+        self.web.page().setUrl(QUrl(_terms_url()))
 
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -36,14 +65,160 @@ class TermsAndConditionsDialog(QDialog):
         self.setLayout(layout)
 
     @classmethod
-    def display(cls, parent: Any) -> None:
+    def display(cls, parent: Any, on_accepted: Optional[Callable[[], None]] = None) -> None:
+        """Display the terms & conditions for the user to accept.
+
+        On Qt5 builds the embedded Chromium-77 webview can't render the page, so it is opened in the
+        user's external browser and acceptance is detected via polling instead (see NRT-822).
+        ``on_accepted`` is invoked (Qt5 path only) once acceptance is detected, to resume the action
+        that was blocked by the missing agreement.
+        """
+        if using_qt5():
+            cls._display_external(parent=parent, on_accepted=on_accepted)
+            return
+
         if not cls.dialog:
             cls.dialog = cls(parent=parent)
 
         cls.dialog.show()
 
     @classmethod
+    def _display_external(cls, parent: Any, on_accepted: Optional[Callable[[], None]]) -> None:
+        openLink(_terms_url())
+
+        if cls.external_dialog and not sip.isdeleted(cls.external_dialog):
+            cls.external_dialog.activateWindow()
+            cls.external_dialog.raise_()
+            return
+
+        cls.external_dialog = ExternalBrowserTermsDialog(parent=parent, on_accepted=on_accepted)
+        cls.external_dialog.show()
+
+    @classmethod
     def hide(cls):
         if cls.dialog:
             cls.dialog.close()
             cls.dialog = None
+        if cls.external_dialog:
+            if not sip.isdeleted(cls.external_dialog):
+                cls.external_dialog.close()
+            cls.external_dialog = None
+
+
+class ExternalBrowserTermsDialog(QDialog):
+    """Shown on Qt5 builds, where the embedded webview can't render the terms page.
+
+    The terms page is opened in the system browser; this dialog waits for the user to accept there.
+    Acceptance is detected by auto-polling AnkiHub for a bounded window, with a manual "Check now"
+    button as the fallback once the window elapses. Both paths share the same check + resume logic.
+    """
+
+    def __init__(self, parent: Any = None, on_accepted: Optional[Callable[[], None]] = None) -> None:
+        super().__init__(parent)
+        self._on_accepted = on_accepted
+        self._is_checking = False
+        self._setup_ui()
+        self._start_auto_poll()
+
+    def _setup_ui(self) -> None:
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        self.setWindowTitle("AnkiHub | Terms & Conditions")
+
+        message = QLabel(
+            "Please accept the AnkiHub Terms &amp; Conditions in the web browser window that just "
+            "opened, then return here.<br><br>"
+            "This window will close automatically once acceptance is detected. If it doesn't, click "
+            "<b>Check now</b>."
+        )
+        message.setWordWrap(True)
+        message.setTextFormat(Qt.TextFormat.RichText)
+
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        self.status_label.setTextFormat(Qt.TextFormat.RichText)
+
+        self.open_again_button = QPushButton("Open page again")
+        self.open_again_button.setAutoDefault(False)
+        qconnect(self.open_again_button.clicked, lambda: openLink(_terms_url()))
+
+        self.check_now_button = QPushButton("Check now")
+        self.check_now_button.setDefault(True)
+        qconnect(self.check_now_button.clicked, lambda: self._check_acceptance(is_manual=True))
+
+        self.close_button = QPushButton("Close")
+        self.close_button.setAutoDefault(False)
+        qconnect(self.close_button.clicked, self.close)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self.open_again_button)
+        button_layout.addStretch()
+        button_layout.addWidget(self.close_button)
+        button_layout.addWidget(self.check_now_button)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(20, 20, 20, 15)
+        layout.addWidget(message)
+        layout.addWidget(self.status_label)
+        layout.addSpacing(10)
+        layout.addLayout(button_layout)
+        self.setLayout(layout)
+
+        self.setMinimumWidth(440)
+        self.check_now_button.setFocus()
+
+    def _start_auto_poll(self) -> None:
+        self._auto_poll_timer = QTimer(self)
+        qconnect(self._auto_poll_timer.timeout, lambda: self._check_acceptance(is_manual=False))
+        self._auto_poll_timer.start(_AUTO_POLL_INTERVAL_MS)
+
+        # Stop auto-polling once the window elapses; the manual "Check now" button remains.
+        QTimer.singleShot(_AUTO_POLL_WINDOW_MS, self._stop_auto_poll)
+
+    def _stop_auto_poll(self) -> None:
+        if sip.isdeleted(self):
+            return
+        if self._auto_poll_timer.isActive():
+            self._auto_poll_timer.stop()
+            self.status_label.setText("Still waiting? Accept the terms in your browser, then click <b>Check now</b>.")
+
+    def _check_acceptance(self, *, is_manual: bool) -> None:
+        if self._is_checking:
+            return
+        self._is_checking = True
+
+        if is_manual:
+            self.status_label.setText("Checking…")
+
+        def on_done(accepted: bool) -> None:
+            self._is_checking = False
+            if sip.isdeleted(self):
+                return
+            if accepted:
+                self._on_acceptance_detected()
+            elif is_manual:
+                self.status_label.setText(
+                    "Not accepted yet. Finish accepting in your browser, then click <b>Check now</b>."
+                )
+
+        def on_failure(exc: Exception) -> None:
+            self._is_checking = False
+            LOGGER.warning("Failed to check terms acceptance.", exc_info=exc)
+            if sip.isdeleted(self):
+                return
+            if is_manual:
+                self.status_label.setText("Couldn't check right now. Please try again in a moment.")
+
+        AddonQueryOp(
+            op=lambda _: AddonAnkiHubClient().is_terms_agreement_accepted(),
+            success=on_done,
+            parent=self,
+        ).without_collection().failure(on_failure).run_in_background()
+
+    def _on_acceptance_detected(self) -> None:
+        if self._auto_poll_timer.isActive():
+            self._auto_poll_timer.stop()
+        LOGGER.info("Terms acceptance detected; closing external-browser terms dialog.")
+        self.close()
+        TermsAndConditionsDialog.external_dialog = None
+        if self._on_accepted:
+            self._on_accepted()


### PR DESCRIPTION
## What & why

On **Qt5** builds of Anki the embedded webview is Qt WebEngine 5.x (Chromium 77), which can't run the modern JS used by two AnkiHub pages we render in-app, so they show up **blank/broken** for these users:

- **Terms & Conditions** — a **sync-blocker**: a user asked to accept (updated) terms can't, so they can't sync or use AnkiHub at all.
- **Flashcard Selector** — non-functional.

These are old-macOS (10.13/10.14) users who **can't** upgrade to Qt6 Anki yet meet `min_anki_version`, so it's a supported config. Refs: TRIAGE-147, ACTV-94; Sentry JAVASCRIPT-18 / JAVASCRIPT-E / JAVASCRIPT-4 (`Qt Web Engine 5.14.2`).

## Approach

Gate both surfaces on `using_qt5()` and open them in the user's **external** (modern) browser instead of the dead embedded engine — mirroring how the chatbot is Qt6-gated. **No backend changes.**

- **Flashcard Selector** (`flashcard_selector_dialog.py`) — on Qt5, `openLink(url_flashcard_selector(ah_did))` + a short toast instead of building the embedded dialog.
- **Terms & Conditions** (`terms_dialog.py`) — on Qt5, open the terms page externally and show a new `ExternalBrowserTermsDialog` that detects acceptance:
  - **bounded auto-poll** (every 3s, up to 3min), then stops; a manual **"Check now"** button remains as the fallback. Both share the same check + resume logic.
  - on detection → close dialog and **resume the blocked sync** (`errors.py`).
- **Acceptance check** — new `AnkiHubClient.is_terms_agreement_accepted()` re-issues a request guarded by `HasFilledPersonalInfo` (`GET /users/decks/`): **200 = accepted, 403 = not yet**. Verified against the webapp: the terms page sets all gated fields (terms + country + study prefs) atomically, so the 403→200 flip maps exactly onto "user completed the page".

## Status / open question

The Jira issue is in **Ready for Design** — the `ExternalBrowserTermsDialog` UX (auto-poll vs. manual-only, copy, whether it blocks Anki) is pending a designer's review. **This PR is a draft implementation/reference**, not final; the Terms dialog UI may change after design.

## Test plan

- [ ] Qt5 Anki: Terms page + Flashcard Selector open in the system browser and work.
- [ ] After accepting terms in the browser, the add-on auto-detects (within the poll window) or via "Check now", closes the dialog, and sync proceeds.
- [ ] Qt6 Anki: unchanged (embedded dialogs still used).
- [ ] Verify on **macOS** (per repo policy for UI changes).

https://claude.ai/code/session_01E1qJDe6g6ea63Fusg9fViv