### PR TITLE
[ACTV-392] step deck tour improvement on unsuspending cards

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1441,7 +1441,7 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
                 "they show with a <span class='bg-[#FFE77E] dark:text-dialog-background'>"
                 "yellow background</span>.<br>"
                 "To unsuspend a card there, you right-click it and uncheck Toggle Suspend.<br><br>"
-                "Click on the <b>Unsuspend</b> button below and we'll make a few cards available for you."
+                "Click on the <b>Unsuspend</b> button below and we'll make a few cards available for you.<br><br>"
                 f"<img src='{media_base}/toggle_suspend.png'>",
                 qt_target=lambda: OverlayTarget(self._browser, self._browser.form.tableView.viewport()),
                 parent_widget=lambda: self._browser,

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1347,7 +1347,7 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         def success(_):
             self._browser_closed_by_us = True
             self._browser.close()
-            on_done()
+            self.next()
 
         unsuspend_cards(parent=self._browser, card_ids=list(cids)).success(success).run_in_background()
 
@@ -1436,32 +1436,33 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         media_base = f"/_addons/{aqt.mw.addonManager.addonFromModule(__name__)}/gui/web/media"
         steps.append(
             QtTutorialStep(
-                body="<b>Suspended cards</b> won't appear in study sessions. In the Browser, "
-                "they're shown with a <span class='bg-[#FFE77E] dark:text-dialog-background'>"
+                body="<b>Suspended cards</b> won't appear in study sessions, and in Browse, "
+                "they show with a <span class='bg-[#FFE77E] dark:text-dialog-background'>"
                 "yellow background</span>.<br><br>"
-                "During the tour, you can’t perform actions. Normally, to unsuspend a card, "
-                "you would right-click it and uncheck <b>Toggle Suspend</b>.<br><br>"
-                "Click <b>Next</b> and we'll unsuspend a few cards for you as an example.<br><br>"
+                "To unsuspend a card, you right-click it and uncheck Toggle Suspend. "
+                "Click <b>Unsuspend</b> to unlock all <b>‘Starter_Cards’</b> cards and begin studying.<br><br>"
                 f"<img src='{media_base}/toggle_suspend.png'>",
                 qt_target=lambda: OverlayTarget(self._browser, self._browser.form.tableView.viewport()),
                 parent_widget=lambda: self._browser,
                 target_outline=True,
-                next_callback=self._unsuspend_cards_and_move_to_next_step,
+                back_label="Unsuspend",
+                back_callback=self._unsuspend_cards_and_move_to_next_step,
+                next_label="End Tour",
+                next_callback=lambda _: self.end(),
+                auto_advance=False,
             )
         )
 
         forum_link = render_link("https://community.ankihub.net/c/support/5", "forum")
         steps.append(
             TutorialStep(
-                body="We've unsuspended some cards for you and they are ready for study. Check them out, "
-                "then try selecting cards on your own!<br><br>"
+                body="These cards are ready for study. Check them out, then try selecting cards on your own!<br><br>"
+                "To remove them later, look for the <b>‘Starter_Cards’</b> tag and suspend the cards.<br><br>"
                 f"<b>Need help?</b> Post in the {forum_link} and our support team will be happy to assist.",
                 target=f"[id='{self._anking_deck_config.anki_id}']",
                 click_target=f"[id='{self._anking_deck_config.anki_id}'] a.deck",
                 tooltip_context=aqt.mw.deckBrowser,
                 next_label="End tour",
-                back_label="Restart tour",
-                back_callback=lambda _: self.restart(),
                 close_button=False,
             )
         )
@@ -1471,7 +1472,8 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
     @cached_property
     def steps(self) -> list[TutorialStep]:
         steps = self._steps()
-        # Hide back button for all but the last step
-        for step in steps[:-1]:
-            step.back_label = ""
+        # Hide back button for all but the penultimate step
+        for step in steps:
+            if step != steps[-2]:
+                step.back_label = ""
         return steps

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1349,6 +1349,7 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             self._browser.close()
             self.next()
 
+        self._track_tutorial("tour_unsuspend_cards")
         unsuspend_cards(parent=self._browser, card_ids=list(cids)).success(success).run_in_background()
 
     def _steps(self) -> list[TutorialStep]:
@@ -1438,18 +1439,17 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             QtTutorialStep(
                 body="<b>Suspended cards</b> won't appear in study sessions, and in Browse, "
                 "they show with a <span class='bg-[#FFE77E] dark:text-dialog-background'>"
-                "yellow background</span>.<br><br>"
-                "To unsuspend a card, you right-click it and uncheck Toggle Suspend. "
-                "Click <b>Unsuspend</b> to unlock all <b>‘Starter_Cards’</b> cards and begin studying.<br><br>"
+                "yellow background</span>.<br>"
+                "To unsuspend a card there, you right-click it and uncheck Toggle Suspend.<br><br>"
+                "Click on the <b>Unsuspend</b> button below and we'll make a few cards available for you."
                 f"<img src='{media_base}/toggle_suspend.png'>",
                 qt_target=lambda: OverlayTarget(self._browser, self._browser.form.tableView.viewport()),
                 parent_widget=lambda: self._browser,
                 target_outline=True,
-                back_label="Unsuspend",
-                back_callback=self._unsuspend_cards_and_move_to_next_step,
-                next_label="End Tour",
-                next_callback=lambda _: self.end(),
-                auto_advance=False,
+                next_label="Unsuspend",
+                next_callback=self._unsuspend_cards_and_move_to_next_step,
+                back_label="End Tour",
+                back_callback=lambda _: self.end(),
             )
         )
 
@@ -1457,7 +1457,6 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         steps.append(
             TutorialStep(
                 body="These cards are ready for study. Check them out, then try selecting cards on your own!<br><br>"
-                "To remove them later, look for the <b>‘Starter_Cards’</b> tag and suspend the cards.<br><br>"
                 f"<b>Need help?</b> Post in the {forum_link} and our support team will be happy to assist.",
                 target=f"[id='{self._anking_deck_config.anki_id}']",
                 click_target=f"[id='{self._anking_deck_config.anki_id}'] a.deck",


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-392](https://ankihub.atlassian.net/browse/ACTV-392)


## Proposed changes
Updates the step 8 and step 9 from the Step Deck Tour


## How to reproduce
1. Trigger the step deck tour
2. Go until the step 8
3. Check for the changes according to the design
4. Go until the step 9
5. Check for the changes according to the design

## Screenshots and videos

<img width="460" height="541" alt="image" src="https://github.com/user-attachments/assets/6fa2a3d8-8e08-400b-98f4-b87d0cdd8299" />

<img width="592" height="438" alt="image" src="https://github.com/user-attachments/assets/70bf9c90-e20e-4c3a-aa54-91eb19178da0" />


[ACTV-392]: https://ankihub.atlassian.net/browse/ACTV-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ