### PR TITLE
[NRT-826] Remove orphaned optional tag group config entries on sync

### DIFF
--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -185,7 +185,11 @@ class _AnkiHubDeckUpdater:
 
     def _fetch_and_apply_deck_extension_updates(self, ankihub_did: uuid.UUID) -> bool:
         # returns True if the update was successful, False if the user cancelled it
-        if not (deck_extensions := self._client.get_deck_extensions_by_deck_id(ankihub_did)):
+        deck_extensions = self._client.get_deck_extensions_by_deck_id(ankihub_did)
+
+        self._remove_deck_extensions_gone_from_ankihub(ankihub_did, deck_extensions)
+
+        if not deck_extensions:
             LOGGER.info("No extensions to update for deck", ah_did=ankihub_did)
             return True
 
@@ -194,6 +198,15 @@ class _AnkiHubDeckUpdater:
                 return False
 
         return True
+
+    @staticmethod
+    def _remove_deck_extensions_gone_from_ankihub(ankihub_did: uuid.UUID, deck_extensions: List[DeckExtension]) -> None:
+        # Drop config entries for extensions the user no longer has on this deck (unsubscribed
+        # or deleted on AnkiHub). Optional tags already applied to notes are intentionally kept.
+        server_extension_ids = {deck_extension.id for deck_extension in deck_extensions}
+        local_extension_ids = set(config.deck_extensions_ids_for_ah_did(ankihub_did))
+        for extension_id in local_extension_ids - server_extension_ids:
+            config.remove_deck_extension(extension_id)
 
     def _download_updates_for_extension(self, deck_extension: DeckExtension) -> bool:
         # returns True if the update was successful, False if the user cancelled it

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6951,18 +6951,11 @@ class TestDeckUpdater:
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
-        import_ah_note: ImportAHNote,
         mocker: MockerFixture,
         mock_ankihub_sync_dependencies: None,
     ):
         with anki_session_with_addon_data.profile_loaded():
             ah_did = install_ah_deck()
-
-            # A note already carries an optional tag from the group
-            note_info = import_ah_note(ah_did=ah_did)
-            note = aqt.mw.col.get_note(NoteId(note_info.anki_nid))
-            note.tags = ["AnkiHub_Optional::tag_group::test1"]
-            aqt.mw.col.update_note(note)
 
             # The add-on still has a local config entry for the extension
             deck_extension = DeckExtensionFactory.create(ah_did=ah_did, tag_group_name="tag_group")
@@ -6991,9 +6984,45 @@ class TestDeckUpdater:
             # The orphaned config entry is removed
             assert config.deck_extension_config(extension_id=deck_extension.id) is None
 
-            # The optional tags already applied to the note are left intact
-            note.load()
-            assert "AnkiHub_Optional::tag_group::test1" in note.tags
+    def test_removing_orphaned_deck_extension_config_is_scoped_to_the_synced_deck(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        mocker: MockerFixture,
+        mock_ankihub_sync_dependencies: None,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            synced_ah_did = install_ah_deck()
+            other_ah_did = install_ah_deck()
+
+            # Local config entries for an extension on each deck
+            synced_deck_extension = DeckExtensionFactory.create(ah_did=synced_ah_did, tag_group_name="tag_group_a")
+            other_deck_extension = DeckExtensionFactory.create(ah_did=other_ah_did, tag_group_name="tag_group_b")
+            config.create_or_update_deck_extension_config(synced_deck_extension)
+            config.create_or_update_deck_extension_config(other_deck_extension)
+
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_by_id",
+                return_value=DeckFactory.create(ah_did=synced_ah_did),
+            )
+            # The synced deck no longer has its extension on the server
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_extensions_by_deck_id",
+                return_value=[],
+            )
+
+            deck_updater = _AnkiHubDeckUpdater()
+            deck_updater.update_decks_and_media(
+                ah_dids=[synced_ah_did],
+                start_media_sync=False,
+                raise_if_full_sync_required=True,
+            )
+
+            # Only the synced deck's orphaned entry is removed; the other deck's entry is left intact
+            assert config.deck_extension_config(extension_id=synced_deck_extension.id) is None
+            assert config.deck_extension_config(extension_id=other_deck_extension.id) is not None
 
     @pytest.mark.parametrize(
         "current_relation, incoming_relation",

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6947,6 +6947,54 @@ class TestDeckUpdater:
                 latest_update=latest_update,
             )
 
+    def test_removes_deck_extension_config_when_no_longer_on_ankihub(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
+        mocker: MockerFixture,
+        mock_ankihub_sync_dependencies: None,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            ah_did = install_ah_deck()
+
+            # A note already carries an optional tag from the group
+            note_info = import_ah_note(ah_did=ah_did)
+            note = aqt.mw.col.get_note(NoteId(note_info.anki_nid))
+            note.tags = ["AnkiHub_Optional::tag_group::test1"]
+            aqt.mw.col.update_note(note)
+
+            # The add-on still has a local config entry for the extension
+            deck_extension = DeckExtensionFactory.create(ah_did=ah_did, tag_group_name="tag_group")
+            config.create_or_update_deck_extension_config(deck_extension)
+            assert config.deck_extension_config(extension_id=deck_extension.id) is not None
+
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_by_id",
+                return_value=DeckFactory.create(ah_did=ah_did),
+            )
+            # The extension is no longer returned by the server (unsubscribed or deleted)
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_extensions_by_deck_id",
+                return_value=[],
+            )
+
+            deck_updater = _AnkiHubDeckUpdater()
+            deck_updater.update_decks_and_media(
+                ah_dids=[ah_did],
+                start_media_sync=False,
+                raise_if_full_sync_required=True,
+            )
+
+            # The orphaned config entry is removed
+            assert config.deck_extension_config(extension_id=deck_extension.id) is None
+
+            # The optional tags already applied to the note are left intact
+            note.load()
+            assert "AnkiHub_Optional::tag_group::test1" in note.tags
+
     @pytest.mark.parametrize(
         "current_relation, incoming_relation",
         [


### PR DESCRIPTION
When an optional tag group (deck extension) is unsubscribed or deleted on AnkiHub, the add-on kept its record in the local config indefinitely, so the dead group still showed up in the optional-tags UI and could cause errors when acted on. This adds reconciliation on sync: for each deck, any locally-stored extension the server no longer returns is dropped from the config. Optional tags already applied to notes are intentionally left in place.

## Related issues
- [x] Closes NRT-826: https://ankihub.atlassian.net/browse/NRT-826
- Relates to NRT-825 (backend half, the 504 timeout): https://ankihub.atlassian.net/browse/NRT-825
- Fixes TRIAGE-284 (add-on keeps record of old optional tag groups): https://ankihub.atlassian.net/browse/TRIAGE-284

## Proposed changes
- `_fetch_and_apply_deck_extension_updates` now reconciles local vs server extensions before processing updates, and crucially before the early return when the server returns no extensions for a deck, so a deck whose last group was removed still gets cleaned up.
- New `_remove_deck_extensions_gone_from_ankihub` helper diffs `config.deck_extensions_ids_for_ah_did(ah_did)` against the ids the server returns for that deck and removes the difference via `config.remove_deck_extension`. This mirrors the existing deck-level reconciliation (`_uninstall_decks_the_user_is_not_longer_subscribed_to`).
- Only the config entry is removed; `AnkiHub_Optional::*` tags already on notes are not touched (we don't delete user content).

### Why this is safe
- The endpoint backing `get_deck_extensions_by_deck_id` (`/users/deck_extensions`) returns extensions where the user is subscriber, owner, or maintainer, so dropping out of that response covers both unsubscribe and upstream deletion.
- The client raises `AnkiHubHTTPError` on any non-200, so a transient API error raises instead of returning an empty list, meaning a failed request will not wipe config entries.
- Reconciliation is scoped per deck, so it never touches other decks' extensions (covered by a test).

## How to reproduce
1. Install a deck with optional tag groups (e.g. the Step deck) and subscribe to a tag group, then sync.
2. Unsubscribe from (or delete) that tag group on the website.
3. Sync again from the add-on.
4. Before: the group still appears under Suggest Optional Tags. After: it is removed from the add-on, while any tags already applied to notes remain.

## Screenshots and videos
N/A, no UI changes. Behavior is covered by tests.

## Further comments
Added `TestDeckUpdater::test_removes_deck_extension_config_when_no_longer_on_ankihub` and `test_removing_orphaned_deck_extension_config_is_scoped_to_the_synced_deck`. Ran them with the existing `test_update_optional_tags` cases locally (all pass).

Note on an accepted assumption: reconciliation treats the `get_deck_extensions_by_deck_id` response as the complete set for the deck. The endpoint is not paginated today (its `list()` returns the full queryset), so this holds; if pagination were ever added to that endpoint, the add-on would need updating.
