### PR TITLE
[ACTV-383] Tour going to the back when clicking on control bar on MacOS

### DIFF
--- a/ankihub/gui/overlay_dialog.py
+++ b/ankihub/gui/overlay_dialog.py
@@ -51,12 +51,16 @@ class OverlayDialog(QDialog):
     def __init__(self, parent: QWidget, target: Optional[OverlayTarget]) -> None:
         self._tracked_widgets: Set[Union[QWidget, OverlayTarget]] = set()
         self._browser_search_focus_policy: Optional[Qt.FocusPolicy] = None
-        super().__init__(parent, Qt.WindowType.FramelessWindowHint)
+        window_flags = Qt.WindowType.FramelessWindowHint
+        if is_mac:
+            # On macOS a window-modal QDialog is rendered as a native "sheet"
+            # with an opaque background, which defeats the translucent overlay.
+            # Keep the overlay above its parent with a stays-on-top hint instead.
+            window_flags |= Qt.WindowType.WindowStaysOnTopHint
+        super().__init__(parent, window_flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setAutoFillBackground(False)
         self.setStyleSheet("background: transparent;")
-        if is_mac:
-            self.setWindowModality(Qt.WindowModality.WindowModal)
         self.target = target
         self.setup_ui()
         self._install_event_filter()

--- a/ankihub/gui/overlay_dialog.py
+++ b/ankihub/gui/overlay_dialog.py
@@ -1,5 +1,8 @@
 from typing import Optional, Set, Union
 
+import aqt
+from anki.utils import is_mac
+from aqt.browser import Browser
 from aqt.qt import (
     QDialog,
     QEvent,
@@ -47,28 +50,80 @@ class OverlayTarget:
 class OverlayDialog(QDialog):
     def __init__(self, parent: QWidget, target: Optional[OverlayTarget]) -> None:
         self._tracked_widgets: Set[Union[QWidget, OverlayTarget]] = set()
+        self._browser_search_focus_policy: Optional[Qt.FocusPolicy] = None
         super().__init__(parent, Qt.WindowType.FramelessWindowHint)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAutoFillBackground(False)
+        self.setStyleSheet("background: transparent;")
+        if is_mac:
+            self.setWindowModality(Qt.WindowModality.WindowModal)
         self.target = target
         self.setup_ui()
         self._install_event_filter()
+        self._configure_browser_focus(parent)
         self.on_position()
         qconnect(self.finished, self._on_finished)
 
     def setup_ui(self) -> None:
         pass
 
+    @staticmethod
+    def _browser_from_widget(widget: Optional[QWidget]) -> Optional[Browser]:
+        if widget is None:
+            return None
+        window = widget if isinstance(widget, Browser) else widget.window()
+        return window if isinstance(window, Browser) else None
+
+    def _configure_browser_focus(self, parent: QWidget) -> None:
+        browser = self._browser_from_widget(parent)
+        if browser is None:
+            return
+        search_edit = browser.form.searchEdit
+        self._browser_search_focus_policy = search_edit.focusPolicy()
+        search_edit.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        browser.clearFocus()
+
+    def _restore_browser_focus(self) -> None:
+        if self._browser_search_focus_policy is None:
+            return
+        browser = self._browser_from_widget(self.parentWidget())
+        if browser is not None:
+            browser.form.searchEdit.setFocusPolicy(self._browser_search_focus_policy)
+        self._browser_search_focus_policy = None
+
     def _install_event_filter(self) -> None:
         if self.target:
             self._tracked_widgets.add(self.target)
             self.target.installEventFilter(self)
-        self._tracked_widgets.add(self.parentWidget())
-        self.parentWidget().installEventFilter(self)
+        parent = self.parentWidget()
+        self._tracked_widgets.add(parent)
+        parent.installEventFilter(self)
+        browser = self._browser_from_widget(parent)
+        if browser is not None:
+            search_edit = browser.form.searchEdit
+            self._tracked_widgets.add(search_edit)
+            search_edit.installEventFilter(self)
+
+    def _focus_overlay(self) -> None:
+        pass
+
+    def _bring_to_front(self) -> None:
+        self.on_position()
+        self.raise_()
+        self._focus_overlay()
 
     def eventFilter(self, obj: Optional[QObject], event: QEvent) -> bool:
-        if obj in self._tracked_widgets:
+        if obj in self._tracked_widgets and event is not None:
             if isinstance(event, (QMoveEvent, QResizeEvent, QWindowStateChangeEvent)):
                 self.on_position()
+            elif event.type() == QEvent.Type.WindowActivate:
+                self._bring_to_front()
+            elif event.type() == QEvent.Type.FocusIn:
+                browser = self._browser_from_widget(self.parentWidget())
+                if browser is not None and obj is browser.form.searchEdit:
+                    browser.form.searchEdit.clearFocus()
+                    self._bring_to_front()
+                    return True
         return super().eventFilter(obj, event)
 
     def on_position(self) -> None:
@@ -77,9 +132,12 @@ class OverlayDialog(QDialog):
 
     def showEvent(self, event) -> None:
         super().showEvent(event)
-        self.on_position()
+        self._bring_to_front()
+        if is_mac:
+            aqt.mw.progress.single_shot(0, self._bring_to_front)
 
     def _on_finished(self) -> None:
+        self._restore_browser_focus()
         for widget in self._tracked_widgets:
             if widget:
                 widget.removeEventFilter(self)

--- a/ankihub/gui/overlay_dialog.py
+++ b/ankihub/gui/overlay_dialog.py
@@ -66,7 +66,18 @@ class OverlayDialog(QDialog):
         self._install_event_filter()
         self._configure_browser_focus(parent)
         self.on_position()
+        # The stays-on-top hint would otherwise keep the overlay above other
+        # applications too, so hide it whenever Anki is not the active app.
+        if is_mac:
+            qconnect(aqt.mw.app.applicationStateChanged, self._on_application_state_changed)
         qconnect(self.finished, self._on_finished)
+
+    def _on_application_state_changed(self, state: Qt.ApplicationState) -> None:
+        if state == Qt.ApplicationState.ApplicationActive:
+            self.show()
+            self._bring_to_front()
+        else:
+            self.hide()
 
     def setup_ui(self) -> None:
         pass
@@ -142,6 +153,11 @@ class OverlayDialog(QDialog):
 
     def _on_finished(self) -> None:
         self._restore_browser_focus()
+        if is_mac:
+            try:
+                aqt.mw.app.applicationStateChanged.disconnect(self._on_application_state_changed)
+            except (TypeError, RuntimeError):
+                pass
         for widget in self._tracked_widgets:
             if widget:
                 widget.removeEventFilter(self)

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -220,6 +220,9 @@ class TutorialOverlayDialog(OverlayDialog):
         self.web.set_bridge_command(self.on_bridge_cmd, self)
         vbox.addWidget(self.web)
         gui_hooks.theme_did_change.append(self._apply_web_transparency)
+        # QWebEngine can paint the first frame opaque before the page finishes
+        # loading, so re-apply the transparent background once the load completes.
+        qconnect(self.web.loadFinished, lambda _ok: self._apply_web_transparency())
         self.refresh()
         qconnect(self.finished, self._cleanup_web)
 

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -194,18 +194,37 @@ class TutorialOverlayDialog(OverlayDialog):
         self.target_outline = target_outline
         super().__init__(parent, target)
 
+    def _focus_overlay(self) -> None:
+        self.web.setFocus()
+
+    def _apply_web_transparency(self) -> None:
+        self.web.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.web.setAutoFillBackground(False)
+        self.web.setStyleSheet("background: transparent;")
+        self.web.page().setBackgroundColor(Qt.GlobalColor.transparent)
+
+    def _cleanup_web(self) -> None:
+        try:
+            gui_hooks.theme_did_change.remove(self._apply_web_transparency)
+        except ValueError:
+            pass
+        self.web.cleanup()
+
     def setup_ui(self) -> None:
         vbox = QVBoxLayout()
         vbox.setContentsMargins(0, 0, 0, 0)
         self.setLayout(vbox)
         self.web = AnkiWebView(self)
+        self._apply_web_transparency()
         self.web.disable_zoom()
         self.web.set_bridge_command(self.on_bridge_cmd, self)
         vbox.addWidget(self.web)
+        gui_hooks.theme_did_change.append(self._apply_web_transparency)
         self.refresh()
-        qconnect(self.finished, lambda: self.web.cleanup())
+        qconnect(self.finished, self._cleanup_web)
 
     def refresh(self) -> None:
+        self._apply_web_transparency()
         web_base = f"/_addons/{aqt.mw.addonManager.addonFromModule(__name__)}/gui/web"
         self.web.stdHtml(
             "<div id=target></div>",
@@ -214,7 +233,6 @@ class TutorialOverlayDialog(OverlayDialog):
             default_css=False,
             context=self,
         )
-        self.web.page().setBackgroundColor(Qt.GlobalColor.transparent)
 
     def on_bridge_cmd(self, cmd: str) -> None:
         if cmd == FLASHCARD_SELECTOR_OPEN_PYCMD:

--- a/ankihub/gui/web/overlay.css
+++ b/ankihub/gui/web/overlay.css
@@ -5,6 +5,7 @@ html, body {
     height: 100%;
     width: 100%;
     box-sizing: border-box;
+    background: transparent;
 }
 
 #target {


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-383](https://ankihub.atlassian.net/browse/ACTV-383)


## Proposed changes
Fixes the tour going back when clicking on control bar on MacOS.

Integrates the modal overlay in the same window as the browse to not display the modal as a separate window and allow the modal to go to the back.

[ACTV-383]: https://ankihub.atlassian.net/browse/ACTV-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ