### PR TITLE
[KNW-186] Patch AnkiWeb login dialog

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -25,6 +25,7 @@ from .gui import (
     tutorial,
 )
 from .gui.addons import setup_addons
+from .gui.ankiweb import setup_sync_dialog_patch
 from .gui.auto_sync import setup_auto_sync
 from .gui.config_dialog import setup_config_dialog_manager
 from .gui.enable_fsrs_dialog import maybe_show_enable_fsrs_reminder
@@ -263,6 +264,9 @@ def _general_setup() -> None:
 
     setup_full_sync_patch()
     LOGGER.info("Set up AnkiWeb full sync patch.")
+
+    setup_sync_dialog_patch()
+    LOGGER.info("Set up AnkiWeb sync dialog patch.")
 
     deckbrowser.setup()
     LOGGER.info("Set up deck browser")

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -4,9 +4,13 @@ import os
 import time
 from concurrent.futures import Future
 from enum import Enum
-from typing import Callable, NoReturn, Union
+from typing import Any, Callable, NoReturn, Union
 
 import aqt
+import aqt.main
+import aqt.preferences
+import aqt.sync
+from anki.hooks import wrap
 from aqt.qt import (
     QCheckBox,
     QDialog,
@@ -29,6 +33,7 @@ from aqt.qt import (
 )
 from aqt.utils import openLink, tooltip
 
+from .. import LOGGER
 from ..settings import config
 from .utils import error_icon, is_email
 
@@ -271,9 +276,15 @@ class FixedDialogLayout(QVBoxLayout):
 
 
 class AnkiwebDialog(QDialog):
-    def __init__(self, initial_widget: BaseAnkiwebWidget, parent: QWidget | None = None):
+    def __init__(
+        self,
+        initial_widget: BaseAnkiwebWidget,
+        on_success: Callable[[], None] = lambda: None,
+        parent: QWidget | None = None,
+    ):
         super().__init__(parent)
         self._progress_widget: InlineProgressWidget | None = None
+        self._on_success = on_success
         self._setup_ui(initial_widget)
 
     def _setup_ui(self, initial_widget: BaseAnkiwebWidget) -> None:
@@ -513,6 +524,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
                 fut.result()
                 self._dialog.close()
                 tooltip("Sign-in successful!", parent=aqt.mw)
+                self._dialog._on_success()
             except Exception as exc:
                 self.form_widget.error_label.set_error(str(exc))
                 self.code_input.clear()
@@ -567,6 +579,7 @@ class LoginWithPasswordWidget(BaseLoginWidget):
                 fut.result()
                 self._dialog.close()
                 tooltip("Sign-in successful!", parent=aqt.mw)
+                self._dialog._on_success()
             except Exception as exc:
                 self.form_widget.error_label.set_error(str(exc))
 
@@ -781,6 +794,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                 fut.result()
                 self._dialog.close()
                 tooltip("Sign-in successful!", parent=aqt.mw)
+                self._dialog._on_success()
             except Exception as exc:
                 self._dialog.replace_widget(SignupCodeVerificationWidget(self.email, self._dialog, str(exc)))
 
@@ -912,10 +926,30 @@ class SignupWithCodeWidget(BaseSignupFirstPageWidget):
 
 
 class AnkiwebLoginDialog(AnkiwebDialog):
-    def __init__(self, parent: QWidget | None = None):
-        super().__init__(initial_widget=LoginWithCodeWidget(self), parent=parent)
+    def __init__(self, on_success: Callable[[], None] = lambda: None, parent: QWidget | None = None):
+        super().__init__(initial_widget=LoginWithCodeWidget(self), on_success=on_success, parent=parent)
 
 
 class AnkiwebSignupDialog(AnkiwebDialog):
     def __init__(self, parent: QWidget | None = None):
         super().__init__(initial_widget=SignupWithCodeWidget(self), parent=parent)
+
+
+def patched_sync_login(mw: aqt.main.AnkiQt, on_success: Callable[[], None], *args: Any, **kwargs: Any) -> None:
+    dialog = AnkiwebLoginDialog(on_success=on_success, parent=mw)
+    dialog.setModal(True)
+    dialog.show()
+
+
+def setup_sync_dialog_patch() -> None:
+    try:
+        patch = wrap(  # type: ignore
+            aqt.sync.sync_login,
+            patched_sync_login,
+            "around",
+        )
+        aqt.sync.sync_login = patch
+        aqt.main.sync_login = patch
+        aqt.preferences.sync_login = patch
+    except Exception:
+        LOGGER.exception("Failed to set up AnkiWeb sync dialog patch")

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1183,6 +1183,9 @@ class TestSetupSyncDialogPatchFailure:
     def test_missing_sync_login_is_logged_and_native_dialog_keeps_working(self, mocker: MockerFixture):
         original_sync_login = aqt.sync.sync_login
         get_id_and_pass_mock = mocker.patch("aqt.sync.get_id_and_pass_from_user")
+        # Older Anki versions call this synchronously and unpack the result as
+        # (username, password)
+        get_id_and_pass_mock.return_value = ("", "")
         logger_mock = mocker.patch("ankihub.gui.ankiweb.LOGGER")
 
         del aqt.sync.sync_login

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -102,6 +102,7 @@ from ankihub.gui.ankiweb import (
     SignupErrorWidget,
     SignupWithCodeWidget,
     SignupWithPasswordWidget,
+    setup_sync_dialog_patch,
 )
 from ankihub.gui.bulk_suggestion_summary_dialog import (
     BulkSuggestionSummaryDialog,
@@ -1142,6 +1143,60 @@ class TestAnkiwebLoginAndSignupSubmission:
         widget._on_sign_up()
 
         assert isinstance(dialog._widget, SignupEmailVerificationWidget)
+
+
+class TestSetupSyncDialogPatch:
+    """Tests for the aqt.sync.sync_login() patch that opens our custom
+    sign-in dialog instead of Anki's password-based dialog.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_sync_login(self):
+        original_sync_login = aqt.sync.sync_login
+        yield
+        aqt.sync.sync_login = original_sync_login
+        aqt.main.sync_login = original_sync_login
+        aqt.preferences.sync_login = original_sync_login
+
+    def test_all_three_entry_points_route_through_the_patch(self, mocker: MockerFixture):
+        dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
+
+        setup_sync_dialog_patch()
+
+        # aqt.sync, aqt.main and aqt.preferences each bind their own module-level
+        # name to sync_login, so all three have to be reassigned individually.
+        assert aqt.sync.sync_login is aqt.main.sync_login
+        assert aqt.sync.sync_login is aqt.preferences.sync_login
+
+        on_success = Mock()
+        for module in (aqt.sync, aqt.main, aqt.preferences):
+            dialog_mock.reset_mock()
+            module.sync_login(aqt.mw, on_success)
+            dialog_mock.assert_called_once_with(on_success=on_success, parent=aqt.mw)
+
+
+class TestSetupSyncDialogPatchFailure:
+    def test_missing_sync_login_is_logged_and_native_dialog_keeps_working(self, mocker: MockerFixture):
+        original_sync_login = aqt.sync.sync_login
+        get_id_and_pass_mock = mocker.patch("aqt.sync.get_id_and_pass_from_user")
+        logger_mock = mocker.patch("ankihub.gui.ankiweb.LOGGER")
+
+        del aqt.sync.sync_login
+        try:
+            setup_sync_dialog_patch()  # must not raise, even though sync_login is gone
+
+            logger_mock.exception.assert_called_once()
+
+            # aqt.main and aqt.preferences were never reassigned, since the
+            # failure happened before any of the three names were patched
+            assert aqt.main.sync_login is original_sync_login
+            assert aqt.preferences.sync_login is original_sync_login
+
+            on_success = Mock()
+            aqt.main.sync_login(aqt.mw, on_success)
+            get_id_and_pass_mock.assert_called_once()
+        finally:
+            aqt.sync.sync_login = original_sync_login
 
 
 class TestSuggestionDialog:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -154,6 +154,7 @@ from ankihub.gui.utils import (
     is_email,
     show_dialog,
     show_error_dialog,
+    using_qt5,
 )
 from ankihub.main import suggestions
 from ankihub.main.deck_creation import DeckCreationResult
@@ -1156,7 +1157,8 @@ class TestSetupSyncDialogPatch:
         yield
         aqt.sync.sync_login = original_sync_login
         aqt.main.sync_login = original_sync_login
-        aqt.preferences.sync_login = original_sync_login
+        if not using_qt5():
+            aqt.preferences.sync_login = original_sync_login
 
     def test_all_three_entry_points_route_through_the_patch(self, mocker: MockerFixture):
         dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
@@ -1166,7 +1168,9 @@ class TestSetupSyncDialogPatch:
         # aqt.sync, aqt.main and aqt.preferences each bind their own module-level
         # name to sync_login, so all three have to be reassigned individually.
         assert aqt.sync.sync_login is aqt.main.sync_login
-        assert aqt.sync.sync_login is aqt.preferences.sync_login
+        if not using_qt5():
+            # Skip check in older Anki (2.1.56) where the preferences screen used to have an inline login form
+            assert aqt.sync.sync_login is aqt.preferences.sync_login
 
         on_success = Mock()
         for module in (aqt.sync, aqt.main, aqt.preferences):
@@ -1190,7 +1194,8 @@ class TestSetupSyncDialogPatchFailure:
             # aqt.main and aqt.preferences were never reassigned, since the
             # failure happened before any of the three names were patched
             assert aqt.main.sync_login is original_sync_login
-            assert aqt.preferences.sync_login is original_sync_login
+            if not using_qt5():
+                assert aqt.preferences.sync_login is original_sync_login
 
             on_success = Mock()
             aqt.main.sync_login(aqt.mw, on_success)


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-186

## Proposed changes

This patches the AnkiWeb login dialog (`aqt.sync.sync_login`) to show our custom dialog implemented in #1324.


## How to reproduce

- Click the Sync button in the main window while logged out and confirm you see our custom dialog instead of the native one.
- Go to _Tools>Preferences>Syncing_, click _Log In_ and confirm you see the same dialog.

