### PR TITLE
fix: Ankiweb code validator not accepting leading zeroes

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -17,12 +17,13 @@ from aqt.qt import (
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
-    QIntValidator,
     QLabel,
     QLayout,
     QLineEdit,
     QProgressBar,
     QPushButton,
+    QRegularExpression,
+    QRegularExpressionValidator,
     QSize,
     Qt,
     QTimer,
@@ -198,7 +199,7 @@ class PasswordInput(BaseInput):
 class CodeInput(BaseInput):
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
-        code_validator = QIntValidator(100000, 999999)
+        code_validator = QRegularExpressionValidator(QRegularExpression(r"\d{6}"))
         self.setValidator(code_validator)
         self.setStyleSheet("""QLineEdit {letter-spacing: 2px}""")
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -19,7 +19,18 @@ from anki.models import NotetypeDict
 from anki.notes import Note, NoteId
 from approvaltests.approvals import verify  # type: ignore
 from approvaltests.namer import NamerFactory  # type: ignore
-from aqt.qt import QApplication, QCheckBox, QDialog, QDialogButtonBox, QLineEdit, QMenu, Qt, QTimer, QWidget
+from aqt.qt import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QLineEdit,
+    QMenu,
+    Qt,
+    QTimer,
+    QValidator,
+    QWidget,
+)
 from pytest import MonkeyPatch
 from pytest_anki import AnkiSession
 from pytest_mock import MockerFixture
@@ -1013,6 +1024,25 @@ class TestAnkiwebLoginWithCodeWidget:
 
         widget.code_input.setText("")
         assert widget.code_box.button.isEnabled() is False
+
+    @pytest.mark.parametrize(
+        "value, expected_state",
+        [
+            ("123456", QValidator.State.Acceptable),
+            ("012345", QValidator.State.Acceptable),
+            ("000000", QValidator.State.Acceptable),
+            ("033563", QValidator.State.Acceptable),
+            ("12345", QValidator.State.Intermediate),
+            ("", QValidator.State.Intermediate),
+            ("12345a", QValidator.State.Invalid),
+            ("1234567", QValidator.State.Invalid),
+        ],
+    )
+    def test_code_input_validator(self, qtbot: QtBot, value: str, expected_state: QValidator.State):
+        widget = self._widget(qtbot)
+        validator = widget.code_input.validator()
+        state, _, _ = validator.validate(value, len(value))
+        assert state == expected_state
 
     def test_get_code_disables_button_until_countdown_reaches_zero(self, qtbot: QtBot):
         widget = self._widget(qtbot)


### PR DESCRIPTION


## Related issues

None

## Proposed changes

The new AnkiWeb signup/login screens added in #1324 accepts a 6-digit code, but leading zeroes were incorrectly rejected.

## How to reproduce

- Set the `ankiweb_magic_code_login` feature flag to enable the new dialogs.
- Click Sync, fill in your email and click Get code.
- Fill in `033563` as the code and confirm the Sign in button is enabled.