### PR TITLE
Move magic-code endpoints to the user_backend sync server

### DIFF
--- a/ankihub/addon_ankihub_client.py
+++ b/ankihub/addon_ankihub_client.py
@@ -70,7 +70,6 @@ class AddonAnkiHubClient(AnkiHubClient):
             api_url=config.api_url,
             s3_bucket_url=config.s3_bucket_url,
             ankiweb_url=config.ankiweb_url,
-            ankiweb_api_url=config.ankiweb_api_url,
             response_hooks=hooks if hooks is not None else DEFAULT_RESPONSE_HOOKS,
             get_token=lambda: config.token(),
             local_media_dir_path_cb=lambda: (Path(aqt.mw.col.media.dir()) if aqt.mw.col else None),

--- a/ankihub/addon_ankihub_client.py
+++ b/ankihub/addon_ankihub_client.py
@@ -69,6 +69,7 @@ class AddonAnkiHubClient(AnkiHubClient):
         super().__init__(
             api_url=config.api_url,
             s3_bucket_url=config.s3_bucket_url,
+            ankiweb_url=config.ankiweb_url,
             ankiweb_api_url=config.ankiweb_api_url,
             response_hooks=hooks if hooks is not None else DEFAULT_RESPONSE_HOOKS,
             get_token=lambda: config.token(),

--- a/ankihub/ankihub_client/__init__.py
+++ b/ankihub/ankihub_client/__init__.py
@@ -5,7 +5,6 @@ The ankihub.common_utils module is an exception.
 
 from .ankihub_client import (  # noqa: F401
     API_VERSION,
-    DEFAULT_ANKIWEB_API_URL,
     DEFAULT_ANKIWEB_URL,
     DEFAULT_API_URL,
     DEFAULT_APP_URL,

--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -73,7 +73,6 @@ DEFAULT_API_URL = f"{DEFAULT_APP_URL}/api"
 DEFAULT_S3_BUCKET_URL = "https://ankihub.s3.amazonaws.com"
 DEFAULT_INTERCOM_APP_ID = "vm55jg8j"
 DEFAULT_ANKIWEB_URL = "https://ankiweb.net"
-DEFAULT_ANKIWEB_API_URL = f"{DEFAULT_ANKIWEB_URL}/svc"
 
 STAGING_APP_URL = "https://staging.ankihub.net"
 STAGING_API_URL = f"{STAGING_APP_URL}/api"
@@ -209,8 +208,6 @@ class API(Enum):
     ANKIHUB = "ankihub"
     S3 = "s3"
     ANKIWEB = "ankiweb"
-    # The user_backend sync server, which serves the magic-code endpoints
-    ANKIWEB_USER_BACKEND = "ankiweb_user_backend"
 
 
 if TYPE_CHECKING or sys.version_info >= (3, 10):
@@ -233,7 +230,6 @@ class AnkiHubClient(AnkiWebClientMixin):
         api_url: str = DEFAULT_API_URL,
         s3_bucket_url: str = DEFAULT_S3_BUCKET_URL,
         ankiweb_url: str = DEFAULT_ANKIWEB_URL,
-        ankiweb_api_url: str = DEFAULT_ANKIWEB_API_URL,
     ):
         """Create a new AnkiHubClient.
         The token can be set with the token parameter or with the get_token parameter.
@@ -243,7 +239,6 @@ class AnkiHubClient(AnkiWebClientMixin):
         self.api_url = api_url
         self.s3_bucket_url = s3_bucket_url
         self.ankiweb_url = ankiweb_url
-        self.ankiweb_api_url = ankiweb_api_url
         self.local_media_dir_path_cb = local_media_dir_path_cb
         self.token = token
         self.get_token = get_token
@@ -274,8 +269,6 @@ class AnkiHubClient(AnkiWebClientMixin):
         elif api == API.S3:
             url = f"{self.s3_bucket_url}{url_suffix}"
         elif api == API.ANKIWEB:
-            url = f"{self.ankiweb_api_url}{url_suffix}"
-        elif api == API.ANKIWEB_USER_BACKEND:
             url = f"{self.ankiweb_url}{url_suffix}"
         else:
             raise ValueError(f"Unknown API: {api}")
@@ -325,7 +318,7 @@ class AnkiHubClient(AnkiWebClientMixin):
         If the last request failed because of an exception, that exception is raised.
         """
         timeout: Union[int, Tuple[int, int]]
-        if api in (API.ANKIHUB, API.ANKIWEB, API.ANKIWEB_USER_BACKEND):
+        if api in (API.ANKIHUB, API.ANKIWEB):
             read_timeout = LONG_READ_TIMEOUT if is_long_running else STANDARD_READ_TIMEOUT
             timeout = (CONNECTION_TIMEOUT, read_timeout)
         else:

--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -209,6 +209,8 @@ class API(Enum):
     ANKIHUB = "ankihub"
     S3 = "s3"
     ANKIWEB = "ankiweb"
+    # The user_backend sync server, which serves the magic-code endpoints
+    ANKIWEB_USER_BACKEND = "ankiweb_user_backend"
 
 
 if TYPE_CHECKING or sys.version_info >= (3, 10):
@@ -230,6 +232,7 @@ class AnkiHubClient(AnkiWebClientMixin):
         get_token: Callable[[], str] = lambda: None,
         api_url: str = DEFAULT_API_URL,
         s3_bucket_url: str = DEFAULT_S3_BUCKET_URL,
+        ankiweb_url: str = DEFAULT_ANKIWEB_URL,
         ankiweb_api_url: str = DEFAULT_ANKIWEB_API_URL,
     ):
         """Create a new AnkiHubClient.
@@ -239,6 +242,7 @@ class AnkiHubClient(AnkiWebClientMixin):
         """
         self.api_url = api_url
         self.s3_bucket_url = s3_bucket_url
+        self.ankiweb_url = ankiweb_url
         self.ankiweb_api_url = ankiweb_api_url
         self.local_media_dir_path_cb = local_media_dir_path_cb
         self.token = token
@@ -271,6 +275,8 @@ class AnkiHubClient(AnkiWebClientMixin):
             url = f"{self.s3_bucket_url}{url_suffix}"
         elif api == API.ANKIWEB:
             url = f"{self.ankiweb_api_url}{url_suffix}"
+        elif api == API.ANKIWEB_USER_BACKEND:
+            url = f"{self.ankiweb_url}{url_suffix}"
         else:
             raise ValueError(f"Unknown API: {api}")
 
@@ -319,7 +325,7 @@ class AnkiHubClient(AnkiWebClientMixin):
         If the last request failed because of an exception, that exception is raised.
         """
         timeout: Union[int, Tuple[int, int]]
-        if api in (API.ANKIHUB, API.ANKIWEB):
+        if api in (API.ANKIHUB, API.ANKIWEB, API.ANKIWEB_USER_BACKEND):
             read_timeout = LONG_READ_TIMEOUT if is_long_running else STANDARD_READ_TIMEOUT
             timeout = (CONNECTION_TIMEOUT, read_timeout)
         else:

--- a/ankihub/ankihub_client/ankiweb_client.py
+++ b/ankihub/ankihub_client/ankiweb_client.py
@@ -61,46 +61,42 @@ class AnkiWebClientMixin:
 
     def ankiweb_login(self, username: str, password: str) -> LoginResponse:
         data = LoginRequest(username=username, password=password)
-        response = self._send_request("post", API.ANKIWEB, "/account/login", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB, "/svc/account/login", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return LoginResponse.from_binary(response.content)
 
     def ankiweb_signup(self, username: str, password: str) -> SignupResponse:
         data = SignupRequest(username=username, password=password)
-        response = self._send_request("post", API.ANKIWEB, "/account/signup", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB, "/svc/account/signup", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return SignupResponse.from_binary(response.content)
 
     def ankiweb_request_signup_code(self, email: str, terms: bool) -> MagicCodeSignupResponse:
         data = MagicCodeSignupRequest(email=email, terms=terms)
-        response = self._send_request("post", API.ANKIWEB_USER_BACKEND, "/magic-code/signup", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB, "/magic-code/signup", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeSignupResponse.from_binary(response.content)
 
     def ankiweb_verify_signup_code(self, email: str, code: str) -> MagicCodeSignupVerifyResponse:
         data = MagicCodeSignupVerifyRequest(email=email, code=code)
-        response = self._send_request(
-            "post", API.ANKIWEB_USER_BACKEND, "/magic-code/signup-verify", data=data.to_binary()
-        )
+        response = self._send_request("post", API.ANKIWEB, "/magic-code/signup-verify", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeSignupVerifyResponse.from_binary(response.content)
 
     def ankiweb_request_login_code(self, email: str) -> MagicCodeLoginResponse:
         data = MagicCodeLoginRequest(email=email)
-        response = self._send_request("post", API.ANKIWEB_USER_BACKEND, "/magic-code/login", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB, "/magic-code/login", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeLoginResponse.from_binary(response.content)
 
     def ankiweb_verify_login_code(self, email: str, code: str) -> MagicCodeLoginVerifyResponse:
         data = MagicCodeLoginVerifyRequest(email=email, code=code)
-        response = self._send_request(
-            "post", API.ANKIWEB_USER_BACKEND, "/magic-code/login-verify", data=data.to_binary()
-        )
+        response = self._send_request("post", API.ANKIWEB, "/magic-code/login-verify", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeLoginVerifyResponse.from_binary(response.content)
@@ -108,7 +104,7 @@ class AnkiWebClientMixin:
     # FIXME: this only works with cookie authentication
     def ankiweb_resend_verification(self) -> ResendVerificationResponse:
         data = ResendVerificationRequest()
-        response = self._send_request("post", API.ANKIWEB, "/account/resend-verification", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB, "/svc/account/resend-verification", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return ResendVerificationResponse.from_binary(response.content)

--- a/ankihub/ankihub_client/ankiweb_client.py
+++ b/ankihub/ankihub_client/ankiweb_client.py
@@ -10,6 +10,12 @@ from requests import Response
 from ..proto.account_pb import (
     LoginRequest,
     LoginResponse,
+    ResendVerificationRequest,
+    ResendVerificationResponse,
+    SignupRequest,
+    SignupResponse,
+)
+from ..proto.magic_code_pb import (
     MagicCodeLoginRequest,
     MagicCodeLoginResponse,
     MagicCodeLoginVerifyRequest,
@@ -18,10 +24,6 @@ from ..proto.account_pb import (
     MagicCodeSignupResponse,
     MagicCodeSignupVerifyRequest,
     MagicCodeSignupVerifyResponse,
-    ResendVerificationRequest,
-    ResendVerificationResponse,
-    SignupRequest,
-    SignupResponse,
 )
 from .ankihub_client import API
 
@@ -73,28 +75,32 @@ class AnkiWebClientMixin:
 
     def ankiweb_request_signup_code(self, email: str, terms: bool) -> MagicCodeSignupResponse:
         data = MagicCodeSignupRequest(email=email, terms=terms)
-        response = self._send_request("post", API.ANKIWEB, "/account/magic-code-signup", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB_USER_BACKEND, "/magic-code/signup", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeSignupResponse.from_binary(response.content)
 
     def ankiweb_verify_signup_code(self, email: str, code: str) -> MagicCodeSignupVerifyResponse:
         data = MagicCodeSignupVerifyRequest(email=email, code=code)
-        response = self._send_request("post", API.ANKIWEB, "/account/magic-code-signup-verify", data=data.to_binary())
+        response = self._send_request(
+            "post", API.ANKIWEB_USER_BACKEND, "/magic-code/signup-verify", data=data.to_binary()
+        )
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeSignupVerifyResponse.from_binary(response.content)
 
     def ankiweb_request_login_code(self, email: str) -> MagicCodeLoginResponse:
         data = MagicCodeLoginRequest(email=email)
-        response = self._send_request("post", API.ANKIWEB, "/account/magic-code-login", data=data.to_binary())
+        response = self._send_request("post", API.ANKIWEB_USER_BACKEND, "/magic-code/login", data=data.to_binary())
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeLoginResponse.from_binary(response.content)
 
     def ankiweb_verify_login_code(self, email: str, code: str) -> MagicCodeLoginVerifyResponse:
         data = MagicCodeLoginVerifyRequest(email=email, code=code)
-        response = self._send_request("post", API.ANKIWEB, "/account/magic-code-login-verify", data=data.to_binary())
+        response = self._send_request(
+            "post", API.ANKIWEB_USER_BACKEND, "/magic-code/login-verify", data=data.to_binary()
+        )
         if response.status_code != 200:
             raise AnkiWebHTTPError(response)
         return MagicCodeLoginVerifyResponse.from_binary(response.content)

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -39,7 +39,6 @@ from structlog.typing import Processor
 from . import LOGGER
 from .ankihub_client import (
     ANKIHUB_DATETIME_FORMAT_STR,
-    DEFAULT_ANKIWEB_API_URL,
     DEFAULT_ANKIWEB_URL,
     DEFAULT_API_URL,
     DEFAULT_APP_URL,
@@ -276,7 +275,6 @@ class _Config:
 
         # There's no staging website for AnkiWeb yet
         self.ankiweb_url = DEFAULT_ANKIWEB_URL
-        self.ankiweb_api_url = DEFAULT_ANKIWEB_API_URL
 
         # Priority chain for app_url (lowest to highest):
         # staging/prod (above) < user config (non-null) < build_config.json < env var
@@ -305,7 +303,6 @@ class _Config:
         if override_url := os.getenv("ANKIWEB_URL"):
             override_url = override_url.rstrip("/")
             self.ankiweb_url = override_url
-            self.ankiweb_api_url = f"{override_url}/svc"
 
     def ankihub_server(self) -> str:
         """Returns which AnkiHub server the client is configured to connect to.

--- a/proto/account.proto
+++ b/proto/account.proto
@@ -17,12 +17,6 @@ service AccountService {
   rpc ResendVerification(ResendVerificationRequest)
       returns (ResendVerificationResponse);
   rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse);
-  rpc MagicCodeSignup(MagicCodeSignupRequest) returns (MagicCodeSignupResponse);
-  rpc MagicCodeSignupVerify(MagicCodeSignupVerifyRequest)
-      returns (MagicCodeSignupVerifyResponse);
-  rpc MagicCodeLogin(MagicCodeLoginRequest) returns (MagicCodeLoginResponse);
-  rpc MagicCodeLoginVerify(MagicCodeLoginVerifyRequest)
-      returns (MagicCodeLoginVerifyResponse);
 }
 
 message LoginRequest {
@@ -198,49 +192,4 @@ message GetAccountStatusRequest {}
 message GetAccountStatusResponse {
   bool logged_in = 1;
   optional string redirect_to = 2;
-}
-
-// Magic-code (passwordless) signup/login. Errors travel as HTTP status codes,
-// not body enums: 400 invalid input, 401 invalid/expired code, 409 account
-// already exists, 429 throttled. 403 is never used (the web client
-// auto-redirects it to the login page).
-
-message MagicCodeSignupRequest {
-  string email = 1;
-  bool terms = 2;
-}
-
-// 200 = account created, code email sent. Errors: 400 invalid email or
-// terms != true, 409 account already exists (client should redirect to
-// login), 429 throttled.
-message MagicCodeSignupResponse {}
-
-message MagicCodeSignupVerifyRequest {
-  string email = 1;
-  string code = 2;
-}
-
-// 200 = code accepted, email confirmed. Errors: 401 invalid/expired code,
-// 429 throttled.
-message MagicCodeSignupVerifyResponse {
-  string ankiuser_login_token = 1;
-}
-
-message MagicCodeLoginRequest {
-  string email = 1;
-}
-
-// Always empty 200 whether or not the account exists (anti-enumeration).
-// Only a per-IP 429 may surface, as it reveals nothing about the email.
-message MagicCodeLoginResponse {}
-
-message MagicCodeLoginVerifyRequest {
-  string email = 1;
-  string code = 2;
-}
-
-// 200 = code accepted. Errors: 401 invalid/expired code OR email not found
-// (indistinguishable by design), 429 throttled.
-message MagicCodeLoginVerifyResponse {
-  string ankiuser_login_token = 1;
 }

--- a/proto/magic_code.proto
+++ b/proto/magic_code.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package ankiweb.user_backend.magic_code;
+
+// Magic-code (passwordless) auth for Anki clients. These are HTTP
+// endpoints on the user_backend sync server (no service block): the
+// verify responses hand out the account's sync host key, which must
+// never transit the web frontend surface.
+//
+// Status codes: 400 = input validation, 401 = invalid/expired code (or
+// unknown email, indistinguishable by design), 409 = account already
+// exists (signup only), 429 = throttled.
+
+message MagicCodeSignupRequest {
+  string email = 1;
+  bool terms = 2;
+}
+
+// 200 = account created, code email sent. Errors: 400 invalid email or
+// terms != true, 409 account already exists (client should redirect to
+// login), 429 throttled.
+message MagicCodeSignupResponse {
+  // Conservative lifetime of the emailed code, in seconds. Provided so
+  // clients can drive countdown/resend UX without hardcoding the value.
+  uint32 code_ttl_secs = 1;
+}
+
+message MagicCodeSignupVerifyRequest {
+  string email = 1;
+  string code = 2;
+}
+
+// 200 = code accepted, email confirmed. Errors: 401 invalid/expired code,
+// 429 throttled.
+message MagicCodeSignupVerifyResponse {
+  // The account's sync host key — the same value the collection sync
+  // hostKey endpoint returns after a password login. Anki clients store
+  // this as their sync credential.
+  string host_key = 1;
+}
+
+message MagicCodeLoginRequest {
+  string email = 1;
+}
+
+// Always the same 200 whether or not the account exists (anti-enumeration).
+// Only a per-IP 429 may surface, as it reveals nothing about the email.
+// The login flow implementation should mirror MagicCodeSignupResponse and
+// return code_ttl_secs here (constant, so it leaks nothing).
+message MagicCodeLoginResponse {}
+
+message MagicCodeLoginVerifyRequest {
+  string email = 1;
+  string code = 2;
+}
+
+// 200 = code accepted. Errors: 401 invalid/expired code OR email not found
+// (indistinguishable by design), 429 throttled.
+message MagicCodeLoginVerifyResponse {
+  // The account's sync host key — the same value the collection sync
+  // hostKey endpoint returns after a password login. Anki clients store
+  // this as their sync credential.
+  string host_key = 1;
+}


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-188

## Proposed changes

The magic-code endpoints moved from the web frontend to the user_backend sync server (ankitects/ankiweb#<PR-do-backend>). The add-on now calls `{ankiweb_url}/magic-code/*` instead of `{ankiweb_url}/svc/account/magic-code-*`.

- New `API.ANKIWEB_USER_BACKEND` entry routing these requests to the host root.
- `MagicCode*` protos moved to `proto/magic_code.proto` (package `ankiweb.user_backend.magic_code`): verify responses now return `host_key` instead of `ankiuser_login_token`.

## How to reproduce

- Run AnkiWeb locally and launch the add-on with the `ANKIWEB_URL` env var set.
- Test the different login/signup flows and error states.

