### PR TITLE
[ACTV-425] Create and set an attribute on Intercom to store client type

### DIFF
--- a/ankihub/gui/intercom.py
+++ b/ankihub/gui/intercom.py
@@ -108,6 +108,7 @@ def _inject_intercom(web_content: WebContent, context: object) -> None:
     intercom_settings: Dict[str, Any] = {
         "api_base": "https://api-iam.intercom.io",
         "app_id": app_id,
+        "source": "anki_desktop",
     }
     if (user_id := user_details.get("id")) is not None:
         intercom_settings["user_id"] = str(user_id)

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -5362,6 +5362,7 @@ class TestIntercom:
         assert '"user_hash": "hash123"' in web_content.body
         assert '"name": "Test User"' in web_content.body
         assert '"email": "test@example.com"' in web_content.body
+        assert '"source": "anki_desktop"' in web_content.body
 
     def test_inject_intercom_on_overview(self) -> None:
         from aqt.overview import Overview


### PR DESCRIPTION
## Related issues
- [x] Closes [#ACTV-425](https://ankihub.atlassian.net/browse/ACTV-425)

## Proposed changes
When booting Intercom from the Anki add-on, we now send a `source` custom attribute set to `anki_desktop`.

This matches the webapp pattern (`source: web_app` / `anki_webview`) so Intercom contacts can be distinguished by client type.

## How to reproduce
1. Sign in to Anki with an AnkiHub account that has Intercom desktop enabled (`intercom_desktop_enabled` + Support button preference on).
2. Open the deck browser (or deck overview) so Intercom injects.
3. In Intercom, open that user/contact and confirm `source` is `anki_desktop`.
4. (Optional) Open the webapp as the same user and confirm `source` becomes `web_app`.

## Further comments
`source` is passed as a top-level key in `window.intercomSettings` (same as the web template). The People attribute must already exist in Intercom for the value to stick.