### PR TITLE
[ACTV-424] Remove second step of the Step Deck tour

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1366,21 +1366,6 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
         steps.append(
             TutorialStep(
-                body="Here, you can set your daily limits.<br><br>"
-                "<b>Recommended:</b><br>"
-                "maximum reviews = 10x new cards.<br><br>"
-                "Ex. If you plan to study 10 new cards daily, set your maximum reviews to 100 per day.<br><br>"
-                "Click <b>Next</b> when you're done.",
-                # NOTE: This assumes Daily Limits is the first section.
-                # We should add section IDs to Anki
-                target=".row",
-                shown_callback=self._on_deckoptions_step,
-                next_callback=self._on_deckoptions_next,
-            )
-        )
-
-        steps.append(
-            TutorialStep(
                 id="browse_button",
                 body="Now click on <b>Browse</b>.",
                 target="#browse",

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -899,7 +899,7 @@ def prompt_for_step_deck_tutorial(on_skip: Optional[Callable[[], None]] = None) 
         dialog_kwargs=dict(
             title="📘 Add cards to your study queue",
             body="When installed, the AnKing Step Deck comes with all cards hidden (suspended). "
-            "Take this tour to learn how to <b>select cards to study</b> and <b>set your daily limits</b>.<br><br>"
+            "Take this tour to learn how to <b>select cards to study</b>.<br><br>"
             "You can revisit this anytime in AnkiHub's Help menu.",
             secondary_button_label="Not now",
             main_button_label="Take tour",
@@ -1354,20 +1354,11 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
     def _steps(self) -> list[TutorialStep]:
         steps = []
-        steps.append(
-            TutorialStep(
-                body="Click on the deck’s gear icon and select <b>Options</b>.",
-                target=f"[id='{self._anking_deck_config.anki_id}'] .opts",
-                tooltip_context=aqt.mw.deckBrowser,
-                shown_callback=self._on_gears_icon_step,
-                hidden_callback=self._on_gears_icon_step_hidden,
-            )
-        )
 
         steps.append(
             TutorialStep(
                 id="browse_button",
-                body="Now click on <b>Browse</b>.",
+                body="Click on <b>Browse</b>.",
                 target="#browse",
                 tooltip_context=aqt.mw.deckBrowser,
                 target_context=aqt.mw.toolbar,


### PR DESCRIPTION
## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-424](https://ankihub.atlassian.net/browse/ACTV-424)


## Proposed changes
Removes the second step of the Step Deck Tour

## How to reproduce
1. Start the `Step Deck` tour
2. See that the `Daily Limit` step no longer appears


## Screenshots and videos

[Screencast from 2026-07-23 15-54-15.webm](https://github.com/user-attachments/assets/76705322-c08c-45a1-a857-839a0d281a5c)

[ACTV-424]: https://ankihub.atlassian.net/browse/ACTV-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ