### PR TITLE
[ACTV-431] Fix intercom loading delay

### DIFF
--- a/ankihub/gui/intercom.py
+++ b/ankihub/gui/intercom.py
@@ -15,7 +15,7 @@ launcher stays visible but behind the tour backdrop.
 """
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import aqt
 from aqt.webview import WebContent
@@ -50,7 +50,12 @@ window.intercomSettings = __SETTINGS__;
 
 
 def setup() -> None:
+    from ..user_state import add_user_state_refreshed_callback
+
     aqt.gui_hooks.webview_will_set_content.append(_inject_intercom)
+    # Feature flags / login land asynchronously; re-apply so home screens that
+    # rendered while logged out (or before flags arrived) pick up the launcher.
+    add_user_state_refreshed_callback(sync_with_user_preference)
 
 
 def shutdown() -> None:
@@ -79,32 +84,36 @@ def is_enabled_for_user() -> bool:
 
 
 def sync_with_user_preference() -> None:
-    """Apply the Support button preference after Config is closed.
+    """Apply Intercom visibility after Config changes or user-state refresh.
 
-    When disabled, shut Intercom down immediately. When enabled, reset the main
-    window so the deck browser / overview re-injects the snippet.
+    When disabled, shut Intercom down immediately. When enabled on the deck
+    browser / overview, boot (or update) the Messenger in the current webview
+    without requiring a navigation.
     """
     if not is_enabled_for_user():
         shutdown()
         return
-    if aqt.mw and aqt.mw.state in ("deckBrowser", "overview"):
-        aqt.mw.reset()
+    _boot_on_current_home_screen()
 
 
-def _inject_intercom(web_content: WebContent, context: object) -> None:
-    from aqt.deckbrowser import DeckBrowser
-    from aqt.overview import Overview
-
-    if not isinstance(context, (DeckBrowser, Overview)):
+def _boot_on_current_home_screen() -> None:
+    if not (aqt.mw and aqt.mw.web and aqt.mw.state in ("deckBrowser", "overview")):
         return
-
-    if not is_enabled_for_user():
+    boot_js = _build_boot_js()
+    if not boot_js:
         return
+    aqt.mw.web.eval(boot_js)
+    LOGGER.info(
+        "Booted Intercom Messenger on current home screen.",
+        state=aqt.mw.state,
+    )
 
+
+def _build_boot_js() -> Optional[str]:
     user_details = config.get_user_details() or {}
     app_id = config.intercom_app_id
     if not app_id:
-        return
+        return None
     intercom_settings: Dict[str, Any] = {
         "api_base": "https://api-iam.intercom.io",
         "app_id": app_id,
@@ -120,10 +129,27 @@ def _inject_intercom(web_content: WebContent, context: object) -> None:
     if user_hash := user_details.get("intercom_user_hash"):
         intercom_settings["user_hash"] = user_hash
 
-    boot_js = _INTERCOM_LOADER_JS.replace("__SETTINGS__", json.dumps(intercom_settings)).replace("__APP_ID__", app_id)
+    return _INTERCOM_LOADER_JS.replace("__SETTINGS__", json.dumps(intercom_settings)).replace("__APP_ID__", app_id)
+
+
+def _inject_intercom(web_content: WebContent, context: object) -> None:
+    from aqt.deckbrowser import DeckBrowser
+    from aqt.overview import Overview
+
+    if not isinstance(context, (DeckBrowser, Overview)):
+        return
+
+    if not is_enabled_for_user():
+        return
+
+    boot_js = _build_boot_js()
+    if not boot_js:
+        return
+
+    user_details = config.get_user_details() or {}
     web_content.body += f"<script>{boot_js}</script>"
     LOGGER.info(
         "Injected Intercom Messenger.",
         context=type(context).__name__,
-        identity_verified=bool(user_hash),
+        identity_verified=bool(user_details.get("intercom_user_hash")),
     )

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -5465,24 +5465,50 @@ class TestIntercom:
 
         config.public_config["ankihub_support_button"] = False
         shutdown = mocker.patch.object(intercom, "shutdown")
-        reset = mocker.patch.object(aqt.mw, "reset")
+        boot = mocker.patch.object(intercom, "_boot_on_current_home_screen")
 
         intercom.sync_with_user_preference()
 
         shutdown.assert_called_once()
-        reset.assert_not_called()
+        boot.assert_not_called()
 
-    def test_sync_with_user_preference_resets_when_enabled(self, mocker: MockerFixture) -> None:
+    def test_sync_with_user_preference_boots_when_enabled_on_home(self, mocker: MockerFixture) -> None:
         from ankihub.gui import intercom
 
+        web = mocker.Mock()
         mocker.patch.object(aqt.mw, "state", "deckBrowser")
+        mocker.patch.object(aqt.mw, "web", web)
         shutdown = mocker.patch.object(intercom, "shutdown")
-        reset = mocker.patch.object(aqt.mw, "reset")
 
         intercom.sync_with_user_preference()
 
         shutdown.assert_not_called()
-        reset.assert_called_once()
+        web.eval.assert_called_once()
+        assert "widget.intercom.io/widget/test_app_id" in web.eval.call_args[0][0]
+
+    def test_sync_with_user_preference_skips_boot_off_home(self, mocker: MockerFixture) -> None:
+        from ankihub.gui import intercom
+
+        web = mocker.Mock()
+        mocker.patch.object(aqt.mw, "state", "review")
+        mocker.patch.object(aqt.mw, "web", web)
+        shutdown = mocker.patch.object(intercom, "shutdown")
+
+        intercom.sync_with_user_preference()
+
+        shutdown.assert_not_called()
+        web.eval.assert_not_called()
+
+    def test_setup_registers_user_state_refresh_callback(self, mocker: MockerFixture) -> None:
+        from ankihub.gui import intercom
+
+        append = mocker.patch.object(aqt.gui_hooks.webview_will_set_content, "append")
+        add_callback = mocker.patch("ankihub.user_state.add_user_state_refreshed_callback")
+
+        intercom.setup()
+
+        append.assert_called_once_with(intercom._inject_intercom)
+        add_callback.assert_called_once_with(intercom.sync_with_user_preference)
 
     def test_close_messenger_evals_hide(self, mocker: MockerFixture) -> None:
         from ankihub.gui import intercom


### PR DESCRIPTION
## Related issues
- [x] Closes [ACTV-431](https://ankihub.atlassian.net/browse/ACTV-431)

## Proposed changes
Intercom on Anki’s home screens only injected via `webview_will_set_content`. If the deck browser/overview rendered while the user was logged out (or before feature flags arrived), the launcher stayed missing until a later navigation forced a re-render.

This PR boots (or updates) Intercom as soon as user state becomes eligible:
- Register `sync_with_user_preference` on user-state refresh (login / flags / details).
- When enabled on deck browser or overview, `eval` the loader into the current webview instead of calling `mw.reset()`.
- Shared `_build_boot_js()` for inject + live boot.

## How to reproduce
**Before**
1. Open Anki while signed out of AnkiHub (or with Intercom not yet eligible).
2. Stay on the deck browser.
3. Sign into AnkiHub (with `intercom_desktop_enabled` + Support button on).
4. Intercom does not appear until you leave and return to home (e.g. open a deck, then go back).

**After**
1. Same steps 1–3.
2. After login / user-state refresh, the Intercom launcher appears on the current home screen without navigating away.


[ACTV-431]: https://ankihub.atlassian.net/browse/ACTV-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ