### PR TITLE
chore: Remove gemini config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,7 +1,0 @@
-code_review:
-  disable: false
-  comment_severity_threshold: MEDIUM
-  max_review_comments: -1
-  pull_request_opened:
-    code_review: false
-ignore_patterns: []


### PR DESCRIPTION
## Related issues

None

## Proposed changes

The Gemini bot no longer works. This removes its config so it stops commenting on PRs.



## Screenshots and videos
<img width="1284" height="303" alt="image" src="https://github.com/user-attachments/assets/8e51d272-5b60-4600-bf90-8e50886e31ed" />
