### PR TITLE
[ACTV-432] Fix intercom bubble tour overlay

### DIFF
--- a/ankihub/gui/intercom.py
+++ b/ankihub/gui/intercom.py
@@ -118,6 +118,7 @@ def _build_boot_js() -> Optional[str]:
         "api_base": "https://api-iam.intercom.io",
         "app_id": app_id,
         "source": "anki_desktop",
+        "z_index": 2147483000,
     }
     if (user_id := user_details.get("id")) is not None:
         intercom_settings["user_id"] = str(user_id)


### PR DESCRIPTION
## Related issues
- [x] Closes [ACTV-432](https://ankihub.atlassian.net/browse/ACTV-432)

## Proposed changes
The native Intercom Messenger launcher is injected on the deck browser and deck overview. During the onboarding/step-deck tour, a full-screen tour host + backdrop renders at z-index `2147483001`. Without an explicit z-index, Intercom relied on its own default stacking, so the launcher bubble could paint above the tour backdrop.

This sets `z_index: 2147483000` in the Intercom boot settings (`_build_boot_js`), giving the launcher a deterministic stack order just below the tour host and backdrop, while leaving normal behavior untouched when no tour is active.

## How to reproduce
1. Log in with a user that has the `intercom_desktop_enabled` feature flag and the support button preference on.
2. On the deck browser / deck overview, confirm the Intercom launcher appears.
3. Start the onboarding tour and advance through the steps (including the deck overview step).
4. Confirm the launcher stays **behind** the tour backdrop for every step.
5. End the tour and confirm the launcher is visible and clickable again on the home screens.

[ACTV-432]: https://ankihub.atlassian.net/browse/ACTV-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ