### PR TITLE
[KNW-206] Fix negative countdown timer in Email Confirmation

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -700,15 +700,10 @@ class SignupEmailVerificationWidget(BaseSignupWidget):
 
 
 class SignupCodeVerificationWidget(BaseSignupWidget):
-    def __init__(
-        self, email: str, code_ttl_secs: int, dialog: AnkiwebDialog, error: str = "", remaining_seconds: int = 0
-    ):
+    def __init__(self, email: str, dialog: AnkiwebDialog, error: str = "", remaining_seconds: int = 0):
         self.email = email
-        if remaining_seconds > 0:
-            self.remaining_seconds = remaining_seconds
-        else:
-            self.remaining_seconds = code_ttl_secs
         self._dialog = dialog
+        self.remaining_seconds = remaining_seconds
         self._is_retry = bool(error)
         super().__init__(
             heading="Email confirmation",
@@ -822,13 +817,16 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
+                if self._timer.remaining_seconds > 0:
+                    remaining_seconds = self._timer.remaining_seconds
+                else:
+                    remaining_seconds = self.remaining_seconds
                 self._dialog.replace_widget(
                     SignupCodeVerificationWidget(
                         email=self._get_email(),
-                        code_ttl_secs=self.remaining_seconds,
                         dialog=self._dialog,
                         error=str(exc),
-                        remaining_seconds=self._timer.remaining_seconds,
+                        remaining_seconds=remaining_seconds,
                     )
                 )
 
@@ -936,7 +934,7 @@ class BaseSignupFirstPageWidget(BaseSignupWidget):
                 hkey_or_ttl = fut.result()
                 kwargs: dict[str, Any] = dict(email=self.email_input.text(), dialog=self._dialog)
                 if self.is_code_signup:
-                    kwargs["code_ttl_secs"] = hkey_or_ttl
+                    kwargs["remaining_seconds"] = hkey_or_ttl
                     self._dialog.replace_widget(SignupCodeVerificationWidget(**kwargs))
                 else:
                     kwargs["host_key"] = hkey_or_ttl

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -704,7 +704,10 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
         self, email: str, code_ttl_secs: int, dialog: AnkiwebDialog, error: str = "", remaining_seconds: int = 0
     ):
         self.email = email
-        self.code_ttl_secs = remaining_seconds or code_ttl_secs
+        if remaining_seconds > 0:
+            self.code_ttl_secs = remaining_seconds
+        else:
+            self.code_ttl_secs = code_ttl_secs
         self._dialog = dialog
         self._is_retry = bool(error)
         super().__init__(
@@ -714,7 +717,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
             bottom_label=f"{html_link(AnkiwebLinkIds.LOGIN_CODE.value, 'Have an account? Sign in.')}",
             dialog=dialog,
         )
-        if not self._is_retry or remaining_seconds:
+        if not self._is_retry or remaining_seconds > 0:
             self._start_timer()
         else:
             self._update_code_button_state()

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -705,9 +705,9 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
     ):
         self.email = email
         if remaining_seconds > 0:
-            self.code_ttl_secs = remaining_seconds
+            self.remaining_seconds = remaining_seconds
         else:
-            self.code_ttl_secs = code_ttl_secs
+            self.remaining_seconds = code_ttl_secs
         self._dialog = dialog
         self._is_retry = bool(error)
         super().__init__(
@@ -782,7 +782,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
             if not remaining_secs:
                 self._update_code_button_state()
 
-        self.init_timer(on_timeout, self.code_ttl_secs)
+        self.init_timer(on_timeout, self.remaining_seconds)
         self._update_code_button_state()
 
     def _on_code_changed(self, text: str) -> None:
@@ -793,7 +793,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
 
     def _on_get_code(self) -> None:
         def on_success(code_ttl_secs: int) -> None:
-            self.code_ttl_secs = code_ttl_secs
+            self.remaining_seconds = code_ttl_secs
             self._start_timer()
 
         email = self._get_email()
@@ -825,7 +825,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                 self._dialog.replace_widget(
                     SignupCodeVerificationWidget(
                         email=self._get_email(),
-                        code_ttl_secs=self.code_ttl_secs,
+                        code_ttl_secs=self.remaining_seconds,
                         dialog=self._dialog,
                         error=str(exc),
                         remaining_seconds=self._timer.remaining_seconds,

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1223,7 +1223,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         dialog.show()
         # Freshly created (not a retry after an error), so the widget only has
         # `self.email` and no `email_input` field.
-        widget = SignupCodeVerificationWidget(email="user@example.com", code_ttl_secs=300, dialog=dialog)
+        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=300, dialog=dialog)
         dialog.replace_widget(widget)
         widget.code_input.setText("123456")
 
@@ -1246,7 +1246,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         # Passing an error makes this a retry widget, which shows an editable
         # email field instead of the original read-only `self.email`.
         widget = SignupCodeVerificationWidget(
-            email="user@example.com", code_ttl_secs=300, dialog=dialog, error="Some unknown error"
+            email="user@example.com", remaining_seconds=300, dialog=dialog, error="Some unknown error"
         )
         dialog.replace_widget(widget)
         widget.email_input.setText("other@example.com")

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1257,6 +1257,56 @@ class TestAnkiwebLoginAndSignupSubmission:
         verify_mock.assert_called_once_with("other@example.com", "123456")
         persist_mock.assert_called_once_with(email="other@example.com", host_key="hostkey123")
 
+    def test_signup_code_verification_reuses_timer(self, qtbot: QtBot, mocker: MockerFixture):
+        code_ttl_secs = 300
+        elapsed_secs = 5
+        mocker.patch.object(AddonAnkiHubClient, "ankiweb_verify_signup_code", side_effect=Exception("some error"))
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=code_ttl_secs, dialog=dialog)
+        dialog.replace_widget(widget)
+        # Simulate the countdown having run for a few seconds, so the time left is
+        # distinguishable from the full TTL. `Countdown` also counts down once on
+        # construction, hence the extra second.
+        for _ in range(elapsed_secs):
+            widget._timer._on_timeout()
+        remaining_seconds = code_ttl_secs - elapsed_secs - 1
+        assert widget._timer.remaining_seconds == remaining_seconds
+
+        widget.code_input.setText("123456")
+        widget._on_verify_or_resend()
+
+        # The retry widget resumes the countdown of the failed one instead of
+        # restarting it from the full TTL.
+        retry_widget = dialog._widget
+        assert retry_widget is not widget
+        assert isinstance(retry_widget, SignupCodeVerificationWidget)
+        assert retry_widget.remaining_seconds == remaining_seconds
+
+    def test_signup_code_verification_restarts_timer_when_it_ran_out(self, qtbot: QtBot, mocker: MockerFixture):
+        code_ttl_secs = 3
+        mocker.patch.object(AddonAnkiHubClient, "ankiweb_verify_signup_code", side_effect=Exception("some error"))
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=code_ttl_secs, dialog=dialog)
+        dialog.replace_widget(widget)
+        # Let the countdown run out. `Countdown` counts down once on construction,
+        # hence one tick less than the TTL.
+        for _ in range(code_ttl_secs - 1):
+            widget._timer._on_timeout()
+        assert widget._timer.remaining_seconds == 0
+
+        widget.code_input.setText("123456")
+        widget._on_verify_or_resend()
+
+        # There is no countdown left to resume, so the retry widget starts over from
+        # the full TTL instead of inheriting the expired one.
+        retry_widget = dialog._widget
+        assert retry_widget is not widget
+        assert isinstance(retry_widget, SignupCodeVerificationWidget)
+        assert retry_widget.remaining_seconds == code_ttl_secs
+        assert retry_widget._timer.remaining_seconds == code_ttl_secs - 1
+
     def test_signup_with_password_success_shows_email_verification_widget(self, qtbot: QtBot, mocker: MockerFixture):
         from ankihub.gui.ankiweb import SignupEmailVerificationWidget
 


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-206

## Proposed changes

If the user enters an expired AnkiWeb signup code, the screen incorrectly displays "Resend available in -1s".


## How to reproduce

1. Click the sync button to show the new signup screen (assuming you're logged out and the feature flag is active).
2. Go to the code signup page and enter an email.
3. Wait for the code to expire then enter it.
4. Confirm the "Resend available" message is not displayed.


## Screenshots and videos
<img width="527" height="318" alt="image" src="https://github.com/user-attachments/assets/c3bcd8f1-0a57-4b4c-a311-b3a8086b69e0" />

