### PR TITLE
[KNW-197, KNW-208, KNW-209]Center error icon and message in AnkiWeb dialog, sizing to text length

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -154,6 +154,10 @@ class LabelWithLink(QLabel):
 
 
 class ErrorLabel(QWidget):
+    _ICON_SIZE = 20
+    # FormWidget's inner content width, given the dialog's fixed 525px width and margins.
+    _FALLBACK_MAX_WIDTH = 461
+
     def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
         self._setup_ui()
@@ -163,22 +167,48 @@ class ErrorLabel(QWidget):
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
         hbox.setSpacing(4)
-        hbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status = status = QLabel("")
         status.setWordWrap(True)
+        status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         font = self.font()
         font.setBold(True)
         status.setFont(font)
         status.setTextFormat(Qt.TextFormat.RichText)
         icon_label = QLabel()
-        icon_label.setPixmap(error_icon().pixmap(20, 20))
+        icon_label.setPixmap(error_icon().pixmap(self._ICON_SIZE, self._ICON_SIZE))
+        # status is given a shrink-to-fit width in _update_status_width (instead of
+        # stretch=1), so the row has a fixed sizeHint that setAlignment can center
+        # as a whole, with the row's width following the text length.
+        hbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
         hbox.addWidget(icon_label)
-        hbox.addWidget(status, stretch=1)
+        hbox.addWidget(status)
         self.setLayout(hbox)
 
     def set_error(self, text: str) -> None:
         self.setVisible(bool(text))
         self.status.setText(text)
+        self._update_status_width()
+
+    def _update_status_width(self) -> None:
+        # Measure the label's own sizeHint with word wrap temporarily disabled. This
+        # matches exactly how Qt will render the (rich) text on a single line, which
+        # a manual QFontMetrics calculation doesn't reliably reproduce (e.g. it
+        # ignores HTML formatting and any stylesheet font overrides applied at
+        # render time).
+        status = self.status
+        status.setWordWrap(False)
+        natural_width = status.sizeHint().width()
+        status.setWordWrap(True)
+        # Small buffer to avoid the rare case where sizeHint() is one pixel short
+        # of what's needed, which would otherwise force an unwanted wrap.
+        self.status.setFixedWidth(min(natural_width + 2, self._max_status_width()))
+
+    def _max_status_width(self) -> int:
+        # The dialog has a fixed width (see FixedDialogLayout), so relying on
+        # parentWidget().width() is unreliable here: set_error() often runs before
+        # the layout has been activated for the first time, when width() still
+        # reports a placeholder size instead of the final ~461px content width.
+        return max(self._FALLBACK_MAX_WIDTH - self._ICON_SIZE - 8, 0)
 
 
 class BaseInput(QLineEdit):


### PR DESCRIPTION
## Related issues
- [x] Closes [KNW-197](https://ankihub.atlassian.net/browse/KNW-197)
- [x] Closes [KNW-208](https://ankihub.atlassian.net/browse/KNW-208)
- [x] Closes [KNW-208](https://ankihub.atlassian.net/browse/KNW-209)

## Proposed changes
Fixes the error message row in the AnkiWeb sign-in/sign-up dialog (`ErrorLabel` in `ankihub/gui/ankiweb.py`), where the error icon and the error text were not visually centered as a single block.

Now:
- `status` gets a shrink-to-fit width, computed in `_update_status_width()` by measuring the label's own `sizeHint()` with word wrap temporarily disabled (this matches exactly how Qt renders the rich-text label on a single line, which a manual `QFontMetrics` calculation didn't reliably reproduce).
- That width is capped by `_max_status_width()`, based on the dialog's known fixed content width (the dialog uses `FixedDialogLayout` with a fixed 525px width), since querying `parentWidget().width()` at the time `set_error()` runs isn't reliable (the layout may not have been activated yet).
- `hbox.setAlignment(AlignCenter)` now correctly centers the icon+text row as a whole, since the row has a deterministic size instead of an expanding one.

As a result, short error messages appear as a compact, centered block next to the icon, while longer messages still wrap and use the full available width.

## How to reproduce
1. Open the "Sign into AnkiWeb" dialog (e.g. via the AnkiHub menu or sync flow).
2. Trigger any inline error in the form (e.g. request a login code, then enter an invalid/expired code and submit, or enter more requests than the throttle limit allows).
3. Before this change, the error icon appeared pinned to the left while the error text was centered only in the space to its right, making the pair look off-center. After this change, the icon and text are centered together as a single block, sized to the text.

## Further comments
This is a small, self-contained UI fix in `ErrorLabel._setup_ui`/`set_error`. No other files are affected by this change.

[KNW-197]: https://ankihub.atlassian.net/browse/KNW-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KNW-208]: https://ankihub.atlassian.net/browse/KNW-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KNW-208]: https://ankihub.atlassian.net/browse/KNW-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ