### PR TITLE
increase duration_seconds for tests

### DIFF
--- a/tests/addon/performance/test_subdeck_operations.py
+++ b/tests/addon/performance/test_subdeck_operations.py
@@ -45,7 +45,7 @@ class TestBuildSubdecksAndMoveCardsToThem:
             # Profile the operation
             duration_seconds = profile(lambda: build_subdecks_and_move_cards_to_them(ankihub_did=ah_did, nids=nids))
             print(f"Moving {len(nids)} cards to their subdecks took {duration_seconds} seconds")
-            assert duration_seconds < 0.2
+            assert duration_seconds < 0.5
 
 
 @pytest.mark.performance
@@ -76,4 +76,4 @@ class TestFlattenDeck:
             # Profile the operation
             duration_seconds = profile(lambda: flatten_deck(ankihub_did=ah_did))
             print(f"Flattening deck with {len(nids)} cards took {duration_seconds} seconds")
-            assert duration_seconds < 0.2
+            assert duration_seconds < 0.5


### PR DESCRIPTION
```
[324](https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/30450704674/job/90577745848#step:7:1325)
    def test_basic(
        self,
        anki_session_with_addon_data: AnkiSession,
        import_ah_notes: ImportAHNotes,
        install_ah_deck: InstallAHDeck,
        profile: Profile,
        ankihub_basic_note_type: NotetypeDict,
    ):
        with anki_session_with_addon_data.profile_loaded():
            ah_did = install_ah_deck()
    
            # Create 1000 notes with subdeck tags
            note_infos = NoteInfoFactory.create_batch(
                size=1000,
                tags=[f"{SUBDECK_TAG}::test::test"],
                mid=ankihub_basic_note_type["id"],
            )
            import_ah_notes(note_infos=note_infos, ah_did=ah_did)
            nids = [note_info.anki_nid for note_info in note_infos]
    
            # Profile the operation
            duration_seconds = profile(lambda: build_subdecks_and_move_cards_to_them(ankihub_did=ah_did, nids=nids))
            print(f"Moving {len(nids)} cards to their subdecks took {duration_seconds} seconds")
>           assert duration_seconds < 0.2
E           assert 0.26471284900000003 < 0.2

tests/addon/performance/test_subdeck_operations.py:48: AssertionError
```
This is causing random test failures in the CI
https://github.com/AnkiHubSoftware/ankihub_addon/actions/runs/30450704674/job/90577745848#step:7:1348