### PR TITLE
[ACTV-436] unsupend cards by default

### DIFF
--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -24,6 +24,7 @@ from ..ankihub_client.models import SuggestionType
 from ..db import ankihub_db
 from ..settings import (
     TAG_FOR_INSTRUCTION_NOTES,
+    TAG_STARTER_NOTES,
     BehaviorOnRemoteNoteDeleted,
     SuspendNewCardsOfExistingNotes,
     config,
@@ -678,6 +679,11 @@ class AnkiHubImporter:
         suspend_new_cards_of_existing_notes: SuspendNewCardsOfExistingNotes,
     ) -> Collection[Card]:
         if is_tag_in_list(TAG_FOR_INSTRUCTION_NOTES, note.tags):
+            return []
+
+        if config.get_feature_flags().get("unsuspend_card_by_default", False) and is_tag_in_list(
+            TAG_STARTER_NOTES, note.tags
+        ):
             return []
 
         def new_cards() -> List[Card]:

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -67,6 +67,7 @@ PROFILE_ID_FIELD_NAME = "ankihub_id"
 
 TAG_FOR_INSTRUCTION_NOTES = "AnkiHub_Instructions"
 
+TAG_STARTER_NOTES = "#AK_Other::Card_Features::Starter_Cards"
 
 ENABLE_FSRS_LAST_REMINDER_DATE_KEY = "ankihub_enable_fsrs_last_reminder_date"
 


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-436](https://ankihub.atlassian.net/browse/ACTV-436)


## Proposed changes
Unsuspend Starter Cards by default

## How to reproduce
#### Setup
1.Ensure you don't have the Step Deck

#### Test Case
1. Subscribe to Step Deck
2. Download the step deck
3. Check if the cards of the tag `#AK_Other::Card_Features::Starter_Cards` are unsuspended



[ACTV-436]: https://ankihub.atlassian.net/browse/ACTV-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ