### PR TITLE
[ACTV-435][Onboarding Tour] Adjust "learning card" copy in Step 4

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1141,7 +1141,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
         )
         steps.append(
             TutorialStep(
-                "These daily stats show you:<br><ul>"
+                "These daily stats show you:<br><ul style='list-style: disc; padding-left: 1.25rem;'>"
                 "<li><b class='text-text-information-main'>New</b>: cards that you have downloaded or created yourself,"
                 " but have never studied before</li>"
                 "<li><b class='text-text-destructive-main'>Learning</b>: cards that are still being learned</li>"

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1144,8 +1144,7 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
                 "These daily stats show you:<br><ul>"
                 "<li><b class='text-text-information-main'>New</b>: cards that you have downloaded or created yourself,"
                 " but have never studied before</li>"
-                "<li><b class='text-text-destructive-main'>Learning</b>: cards that were seen "
-                "for the first time recently, and are still being learned</li>"
+                "<li><b class='text-text-destructive-main'>Learning</b>: cards that are still being learned</li>"
                 "<li><b class='text-text-confirmation-main'>To Review</b>: cards that you have finished learning. "
                 "They will be shown again after their delay has elapsed</li></ul>",
                 target="td",


### PR DESCRIPTION
## Related issues

- [x] Closes # [ACTV-435](https://ankihub.atlassian.net/browse/ACTV-435)

## Proposed changes
Adjusts the copy of the step 5 of the Onboarding tour.


## How to reproduce
1. Take the Onboarding tour and see that the step 5 changed to be in accordance with Figma.

[ACTV-435]: https://ankihub.atlassian.net/browse/ACTV-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ