### PR TITLE
Set custom sync url to ANKIWEB_URL

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -11,9 +11,8 @@ from anki.hooks import wrap
 from aqt.gui_hooks import profile_did_open, profile_will_close, sync_did_finish
 from aqt.main import AnkiQt
 
-from .ankihub_client import DEFAULT_ANKIWEB_URL
-
 from . import LOGGER, anki_logger
+from .ankihub_client import DEFAULT_ANKIWEB_URL
 from .db import ankihub_db
 from .gui import (
     browser,

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -11,6 +11,8 @@ from anki.hooks import wrap
 from aqt.gui_hooks import profile_did_open, profile_will_close, sync_did_finish
 from aqt.main import AnkiQt
 
+from ankihub.ankihub_client.ankihub_client import DEFAULT_ANKIWEB_URL
+
 from . import LOGGER, anki_logger
 from .db import ankihub_db
 from .gui import (
@@ -191,6 +193,9 @@ def _after_profile_setup() -> None:
     # just a temporary fix for notes that were already manually deleted on the webapp.
     # Later we should handle note deletion in the sync process.
     handle_notes_deleted_from_webapp()
+
+    if config.ankiweb_url != DEFAULT_ANKIWEB_URL:  # For testing
+        aqt.mw.pm.set_custom_sync_url(config.ankiweb_url)
 
     media_sync.allow_background_threads()
 

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -11,7 +11,7 @@ from anki.hooks import wrap
 from aqt.gui_hooks import profile_did_open, profile_will_close, sync_did_finish
 from aqt.main import AnkiQt
 
-from ankihub.ankihub_client.ankihub_client import DEFAULT_ANKIWEB_URL
+from .ankihub_client import DEFAULT_ANKIWEB_URL
 
 from . import LOGGER, anki_logger
 from .db import ankihub_db


### PR DESCRIPTION
Calls `aqt.mw.pm.set_custom_sync_url(override_url)` where `override_url` is the `ANKIWEB_URL` environment variable.

See https://github.com/AnkiHubSoftware/ankihub_addon/pull/1330