### PR TITLE
[NRT-864] Last QA fixes

### DIFF
--- a/ankihub/gui/js_message_handling.py
+++ b/ankihub/gui/js_message_handling.py
@@ -25,7 +25,7 @@ from ..settings import config, url_view_note
 from .config_dialog import get_config_dialog_manager
 from .operations.scheduling import suspend_notes, unsuspend_notes
 from .utils import bring_to_front, robust_filter
-from .webview import AnkiHubWebViewDialog
+from .webview import WEBVIEW_DIALOG_ESCAPE_PYCMD, AnkiHubWebViewDialog
 
 VIEW_NOTE_PYCMD = "ankihub_view_note"
 VIEW_NOTE_BUTTON_ID = "ankihub-view-note-button"
@@ -174,6 +174,12 @@ def _on_js_message(handled: Tuple[bool, Any], message: str, context: Any) -> Any
 
         qconnect(dialog.finished, on_dialog_finished)
         dialog.show()
+
+        return (True, None)
+    elif message == WEBVIEW_DIALOG_ESCAPE_PYCMD:
+        # Only sent for Escape presses the page didn't consume, so the dialog is what closes.
+        if isinstance(context, AnkiHubWebViewDialog):
+            context.close()
 
         return (True, None)
 

--- a/ankihub/gui/web/webview_dialog_escape.js
+++ b/ankihub/gui/web/webview_dialog_escape.js
@@ -1,0 +1,29 @@
+// Reports Escape presses the page didn't consume, so the hosting AnkiHubWebViewDialog closes
+// only when nothing inside the page handled the key. A page keeps the window open by calling
+// preventDefault() on the keydown event.
+(function () {
+    if (window.ankihubEscapeHandlerInstalled) {
+        return;
+    }
+    window.ankihubEscapeHandlerInstalled = true;
+
+    window.addEventListener(
+        "keydown",
+        (event) => {
+            if (event.key !== "Escape") {
+                return;
+            }
+
+            // Deferred to a macrotask so every synchronous handler has run and
+            // defaultPrevented is final. Reading it inline would depend on listener
+            // registration order, and page code commonly listens on window.
+            setTimeout(() => {
+                if (!event.defaultPrevented) {
+                    pycmd("{{ ESCAPE_PYCMD }}");
+                }
+            }, 0);
+        },
+        // Capture phase, so this runs even if page code calls stopPropagation().
+        true
+    );
+})();

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional
 
 from aqt import Qt, QWebEnginePage, QWebEngineProfile, pyqtSlot
@@ -17,10 +18,29 @@ from aqt.qt import (
 from aqt.theme import theme_manager
 from aqt.utils import openLink
 from aqt.webview import AnkiWebPage, AnkiWebView
+from jinja2 import Template
 
 from .. import LOGGER
 from ..settings import config
 from .utils import using_qt5
+
+WEBVIEW_DIALOG_ESCAPE_PYCMD = "ankihub_webview_dialog_escape"
+
+WEBVIEW_DIALOG_ESCAPE_JS_PATH = Path(__file__).parent / "web/webview_dialog_escape.js"
+
+
+class AnkiHubWebView(AnkiWebView):
+    """An AnkiWebView that leaves Escape handling to its hosting dialog.
+
+    AnkiWebView closes the nearest parent dialog on any Escape press, without checking whether
+    the page handled the key first. Its injected listener can't be removed from JS and the
+    resulting "close" command is consumed before the webview_did_receive_js_message hook runs,
+    so onEsc() is the only place to intercept it. See webview_dialog_escape.js for the
+    handling that replaces it.
+    """
+
+    def onEsc(self) -> None:
+        LOGGER.debug("Ignored Anki's Escape close request; the dialog decides when to close.")
 
 
 class AnkiHubWebViewDialog(QDialog):
@@ -50,7 +70,7 @@ class AnkiHubWebViewDialog(QDialog):
         return True
 
     def _setup_ui(self) -> None:
-        self.web = AnkiWebView(parent=self)
+        self.web = AnkiHubWebView(parent=self)
         self.web.set_open_links_externally(False)
 
         # Use a page that opens the file picker as a window-modal sheet attached to this
@@ -141,7 +161,13 @@ class AnkiHubWebViewDialog(QDialog):
             return  # pragma: no cover
 
         self._adjust_web_styling()
+        self._setup_escape_handling()
         self._on_successful_page_load()
+
+    def _setup_escape_handling(self) -> None:
+        """Close this dialog on Escape only when the page didn't consume the key press."""
+        js = Template(WEBVIEW_DIALOG_ESCAPE_JS_PATH.read_text()).render(ESCAPE_PYCMD=WEBVIEW_DIALOG_ESCAPE_PYCMD)
+        self.web.eval(js)
 
     def _handle_auth_failure_if_needed(self) -> None:
         def check_auth_failure_callback(value: str) -> None:

--- a/ankihub/gui/webview.py
+++ b/ankihub/gui/webview.py
@@ -207,8 +207,9 @@ class AnkiHubWebViewDialog(QDialog):
         self.web.eval(css_code)
 
     def _on_view_in_web_browser_button_clicked(self) -> None:
+        # Leaves the dialog open on purpose: closing it would discard state the external page
+        # can't reproduce, e.g. the user's search results.
         openLink(self._get_non_embed_url())
-        self.close()
 
 
 class AuthenticationRequestInterceptor(QWebEngineUrlRequestInterceptor):

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -138,6 +138,7 @@ from ankihub.gui.auto_sync import SYNC_RATE_LIMIT_SECONDS, _setup_ankihub_sync_o
 from ankihub.gui.browser import custom_columns
 from ankihub.gui.browser import setup as setup_browser
 from ankihub.gui.browser.browser import (
+    ChatbotDialog,
     ModifiedAfterSyncSearchNode,
     NewNoteSearchNode,
     SuggestionTypeSearchNode,
@@ -201,7 +202,12 @@ from ankihub.gui.suggestion_dialog import (
     open_suggestion_dialog_for_single_suggestion,
 )
 from ankihub.gui.utils import _Dialog, bring_to_front, robust_filter
-from ankihub.gui.webview import SheetFilePickerWebPage
+from ankihub.gui.webview import (
+    WEBVIEW_DIALOG_ESCAPE_PYCMD,
+    AnkiHubWebView,
+    AnkiHubWebViewDialog,
+    SheetFilePickerWebPage,
+)
 from ankihub.main.deck_creation import create_ankihub_deck, modified_note_type
 from ankihub.main.deck_options import ANKIHUB_PRESET_NAME, get_fsrs_parameters
 from ankihub.main.deck_unsubscribtion import uninstall_deck
@@ -8407,6 +8413,22 @@ class TestConfigDialog:
             qtbot.wait(500)
 
 
+def mock_load_url_to_show_page(mocker: MockerFixture, body: str, url_substring: str = "flashcard-selector") -> None:
+    """Make AnkiWebView.load_url render `body` instead of fetching the AnkiHub web app page."""
+    original_load_url = aqt.webview.AnkiWebView.load_url
+
+    def new_load_url(self, url: QUrl, *args, **kwargs):
+        self = cast(AnkiWebView, self)
+        # Only intercept the web app page itself - stdHtml relies on other load_url calls
+        # to load the page.
+        if url_substring in url.toString():
+            return self.stdHtml(body)
+        else:
+            return original_load_url(self, url, *args, **kwargs)
+
+    mocker.patch("aqt.webview.AnkiWebView.load_url", new=new_load_url)
+
+
 class TestFlashCardSelector:
     @pytest.mark.sequential
     @pytest.mark.parametrize(
@@ -8711,7 +8733,7 @@ class TestFlashCardSelector:
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "token", return_value="test_token")
 
-            self._mock_load_url_to_show_page(mocker, body="Invalid token")
+            mock_load_url_to_show_page(mocker, body="Invalid token")
 
             dialog = FlashCardSelectorDialog.display_for_ah_did(
                 ah_did=next_deterministic_uuid(),
@@ -8764,7 +8786,7 @@ class TestFlashCardSelector:
             )
 
             # Mock the page so that it's loaded and we can run javascript on it
-            self._mock_load_url_to_show_page(mocker, body="")
+            mock_load_url_to_show_page(mocker, body="")
 
             ah_did = next_deterministic_uuid()
             dialog = FlashCardSelectorDialog.display_for_ah_did(
@@ -8792,7 +8814,7 @@ class TestFlashCardSelector:
         with anki_session_with_addon_data.profile_loaded():
             mocker.patch.object(config, "token", return_value="test_token")
 
-            self._mock_load_url_to_show_page(mocker, body="")
+            mock_load_url_to_show_page(mocker, body="")
 
             dialog = FlashCardSelectorDialog.display_for_ah_did(
                 ah_did=next_deterministic_uuid(),
@@ -8818,19 +8840,206 @@ class TestFlashCardSelector:
             qtbot.wait_until(lambda: raise_mock.called)
             assert activate_mock.called
 
-    def _mock_load_url_to_show_page(self, mocker: MockerFixture, body: str):
-        original_load_url = aqt.webview.AnkiWebView.load_url
 
-        def new_load_url(self, url: QUrl, *args, **kwargs):
-            self = cast(AnkiWebView, self)
-            # Check if the URL is the flashcard selector page.
-            # This is necessary, because stdHtml relies on other load_url calls to load the page.
-            if "flashcard-selector" in url.toString():
-                return self.stdHtml(body)
+class TestAnkiHubWebViewDialogEscape:
+    """Escape closes the dialog only when nothing in the page consumed the key press."""
+
+    # A page that handles Escape itself, the way an AnkiHub web app modal does.
+    PAGE_CONSUMING_ESCAPE = """
+        <script>
+            window.addEventListener("keydown", (event) => {
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                }
+            });
+        </script>
+    """
+
+    @pytest.mark.sequential
+    def test_escape_closes_dialog_when_page_does_not_consume_it(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(mocker, body="")
+
+            dialog = FlashCardSelectorDialog.display_for_ah_did(
+                ah_did=next_deterministic_uuid(),
+                parent=aqt.mw,
+            )
+            self._wait_until_escape_handler_installed(dialog, qtbot)
+
+            self._press_escape(dialog)
+
+            qtbot.wait_until(lambda: not dialog.isVisible())
+
+    @pytest.mark.sequential
+    def test_escape_does_not_close_dialog_when_page_consumes_it(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(mocker, body=self.PAGE_CONSUMING_ESCAPE)
+
+            dialog = FlashCardSelectorDialog.display_for_ah_did(
+                ah_did=next_deterministic_uuid(),
+                parent=aqt.mw,
+            )
+            self._wait_until_escape_handler_installed(dialog, qtbot)
+
+            self._press_escape(dialog)
+
+            # Give the deferred check and the resulting pycmd round trip time to happen.
+            qtbot.wait(1000)
+            assert dialog.isVisible()
+
+    @pytest.mark.sequential
+    def test_escape_pycmd_closes_dialog(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(mocker, body="")
+
+            dialog = FlashCardSelectorDialog.display_for_ah_did(
+                ah_did=next_deterministic_uuid(),
+                parent=aqt.mw,
+            )
+
+            dialog.web.eval(f"pycmd('{WEBVIEW_DIALOG_ESCAPE_PYCMD}')")
+
+            qtbot.wait_until(lambda: not dialog.isVisible())
+
+    @pytest.mark.sequential
+    def test_ankis_own_escape_close_path_is_disabled(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        # Fails loudly if a future Anki bump reworks onEsc(), instead of silently restoring the
+        # old close-everything behaviour.
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(mocker, body="")
+
+            dialog = FlashCardSelectorDialog.display_for_ah_did(
+                ah_did=next_deterministic_uuid(),
+                parent=aqt.mw,
+            )
+
+            assert isinstance(dialog.web, AnkiHubWebView)
+
+            dialog.web.onEsc()
+
+            qtbot.wait(500)
+            assert dialog.isVisible()
+
+    @pytest.mark.sequential
+    def test_escape_handler_is_installed_once_when_dialog_is_displayed_again(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+    ):
+        # Displaying the dialog again connects another loadFinished handler, so the snippet is
+        # evaluated more than once per page. It must not stack listeners and close twice.
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(mocker, body="")
+
+            ah_did = next_deterministic_uuid()
+            dialog = FlashCardSelectorDialog.display_for_ah_did(ah_did=ah_did, parent=aqt.mw)
+            self._wait_until_escape_handler_installed(dialog, qtbot)
+
+            assert FlashCardSelectorDialog.display_for_ah_did(ah_did=ah_did, parent=aqt.mw) is dialog
+            self._wait_until_escape_handler_installed(dialog, qtbot)
+
+            close_mock = mocker.patch.object(dialog, "close")
+
+            self._press_escape(dialog)
+
+            qtbot.wait_until(lambda: close_mock.called)
+            qtbot.wait(500)
+            assert close_mock.call_count == 1
+
+    @pytest.mark.sequential
+    @pytest.mark.parametrize(
+        "page_consumes_escape, expected_still_visible",
+        [
+            (False, False),
+            (True, True),
+        ],
+    )
+    def test_escape_in_chatbot_dialog(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        next_deterministic_uuid: Callable[[], uuid.UUID],
+        page_consumes_escape: bool,
+        expected_still_visible: bool,
+    ):
+        # The chatbot dialog is application-modal and has no footer, so it is built along a
+        # different path than the flashcard selector.
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            mocker.patch.object(config, "token", return_value="test_token")
+            mock_load_url_to_show_page(
+                mocker,
+                body=self.PAGE_CONSUMING_ESCAPE if page_consumes_escape else "",
+                url_substring="/ai/chatbot/",
+            )
+
+            dialog = ChatbotDialog.display_for_ah_nid(ah_nid=next_deterministic_uuid(), parent=aqt.mw)
+            assert dialog is not None
+            self._wait_until_escape_handler_installed(dialog, qtbot)
+
+            self._press_escape(dialog)
+
+            if expected_still_visible:
+                qtbot.wait(1000)
+                assert dialog.isVisible()
             else:
-                return original_load_url(self, url, *args, **kwargs)
+                qtbot.wait_until(lambda: not dialog.isVisible())
 
-        mocker.patch("aqt.webview.AnkiWebView.load_url", new=new_load_url)
+    def _press_escape(self, dialog: AnkiHubWebViewDialog) -> None:
+        """Dispatch an Escape keydown in the page, the way a real key press arrives."""
+        dialog.web.eval(
+            """
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", {key: "Escape", bubbles: true, cancelable: true})
+            );
+            """
+        )
+
+    def _wait_until_escape_handler_installed(self, dialog: AnkiHubWebViewDialog, qtbot: QtBot) -> None:
+        results: List[Any] = []
+
+        def handler_installed() -> bool:
+            dialog.web.evalWithCallback("window.ankihubEscapeHandlerInstalled === true", results.append)
+            return bool(results) and bool(results[-1])
+
+        qtbot.wait_until(handler_installed)
 
 
 @pytest.mark.qt_no_exception_capture

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -8743,7 +8743,8 @@ class TestFlashCardSelector:
             dialog.view_in_web_browser_button.click()
 
             openLink_mock.assert_called_once_with(url_flashcard_selector(ah_did))
-            assert not dialog.isVisible()
+            # The dialog stays open so the user doesn't lose their search when they come back.
+            assert dialog.isVisible()
 
     @pytest.mark.sequential
     def test_sync_notes_actions(


### PR DESCRIPTION
## Related issues
- Me smash item 3 (ESC key) and item 6 (View in Web Browser) of [NRT-864](https://ankihub.atlassian.net/browse/NRT-864). Other items live in web app. Ticket stay open.

## Proposed changes
- **ESC key bad before.** Man open small dialog in Smart Search. Man press ESC. WHOLE WINDOW DIE. Man angry. Man lose search.
- **Why window die?** Anki put secret listener in every page. Listener see ESC, shout `pycmd("close")`. Then `onEsc()` kill nearest dialog. Listener never ask page "you already eat this key?". Rude listener.
- **Now polite.** `AnkiHubWebView` sit on rude listener. New listener ask first: page call `preventDefault()`? Yes → window live. No → window die. Small dialog close, big window stay. Same as Anki own windows: ESC close Preview, ESC again close Browse.
- **No need ship two repo same day.** Page that not touch ESC behave same as before. Web app opt in one overlay at a time. Note preview modal and YouTube modal already opt in free — a11y-dialog do `preventDefault()` inside. Filter drawer and add-source menu fixed in web app repo already.
- **View in web browser no more kill window.** Before: click button, window die, man come back to Anki, search gone. Now: browser open, window stay, search stay. Man happy.

## How to reproduce
1. Open Smart Search from deck overview page.
2. Make window skinny (below `lg`) so **Filters** button show. Open filter drawer. Press ESC. Only drawer die. Press ESC again. Now window die. Good.
3. Do search. Open note preview modal. Press ESC. Only modal die.
4. Do search. Click **View in web browser**. Browser open. Look back at Anki — window still there, results still there.


## Screenshots 


[screen-capture (14).webm](https://github.com/user-attachments/assets/ef8e22e3-ed60-4b9a-b535-47120d651bed)




## Further comments
Contract is `event.defaultPrevented`. Chromium already use same signal to decide if key escape page. No new magic global like `window.ankihubEscapeHandled()` — two repo must agree on magic global, magic global rot. Browser signal not rot.

Check happen inside `setTimeout(…, 0)`. Why wait? Listener order not promise anything. Smart Search overlay listen on `window`, that run AFTER `document` when bubble. Read too early, read wrong answer. Wait one tick, answer final.

Warning for reviewer: `tests/addon` blow up (signal 11) on my macOS, also on old test me not touch — so machine bad, not test bad. 7 new test only collected, never run. CI must run. Test marked `sequential`, so local run need `pytest tests/addon -m sequential -n 0`.


[NRT-864]: https://ankihub.atlassian.net/browse/NRT-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ