### PR TITLE
[KNW-214] refactor: rename magic-code proto field to resend_cooldown_secs

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import sys
+import time
 from concurrent.futures import Future
 from enum import Enum
+from math import ceil
 from typing import Any, Callable, NoReturn, Union
 
 import aqt
@@ -99,6 +101,39 @@ def destroy_timer(timer: QTimer | None) -> None:
 
 def timer_is_active(timer: Countdown | None) -> bool:
     return bool(timer) and not sip.isdeleted(timer) and timer.isActive() and timer.remaining_seconds > 0
+
+
+class ResendCooldownTracker:
+    """Tracks per-email magic-code resend cooldowns for the lifetime of the Anki
+    session (i.e. independently of any widget). Widgets only hold the cooldown's
+    remaining time in memory, so closing and reopening the AnkiWeb dialog
+    recreates them from scratch and would otherwise let the user bypass the
+    cooldown the server already enforces for that email.
+    """
+
+    def __init__(self) -> None:
+        self._deadlines: dict[tuple[str, str], float] = {}
+
+    def start(self, scope: str, email: str, seconds: int) -> None:
+        key = (scope, email)
+        if seconds > 0:
+            self._deadlines[key] = time.monotonic() + seconds
+        else:
+            self._deadlines.pop(key, None)
+
+    def remaining_seconds(self, scope: str, email: str) -> int:
+        key = (scope, email)
+        deadline = self._deadlines.get(key)
+        if deadline is None:
+            return 0
+        remaining = ceil(deadline - time.monotonic())
+        if remaining <= 0:
+            self._deadlines.pop(key, None)
+            return 0
+        return remaining
+
+
+_resend_cooldowns = ResendCooldownTracker()
 
 
 class Countdown(QTimer):
@@ -506,6 +541,8 @@ class BaseLoginWidget(BaseAnkiwebWidget):
 
 
 class LoginWithCodeWidget(BaseLoginWidget):
+    _COOLDOWN_SCOPE = "login"
+
     def __init__(self, dialog: AnkiwebDialog):
         self._dialog = dialog
         super().__init__(
@@ -515,6 +552,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
             bottom_label=f"{html_link(AnkiwebLinkIds.SIGNUP_CODE.value, 'Sign up for a new account')}",
             dialog=dialog,
         )
+        self._sync_state_for_email(self.email_input.text())
 
     def _create_form_widget(self) -> FormWidget:
         self.email_input = email_input = EmailInput()
@@ -537,13 +575,30 @@ class LoginWithCodeWidget(BaseLoginWidget):
         return form_widget
 
     def _on_email_changed(self, text: str) -> None:
-        self.email_box.button.setEnabled(is_email(text))
-        self.code_box.button.setEnabled(self.code_input.hasAcceptableInput() and is_email(text))
+        self._sync_state_for_email(text)
 
     def _on_code_changed(self, text: str) -> None:
         self.code_box.button.setEnabled(self.code_input.hasAcceptableInput() and is_email(self.email_input.text()))
 
-    def _on_get_code(self) -> None:
+    def _sync_state_for_email(self, email: str) -> None:
+        """Reflects any cooldown already tracked for `email` (e.g. from a code
+        requested before the dialog was closed and reopened) instead of always
+        allowing a new request whenever the email field shows a valid address.
+        """
+        email_valid = is_email(email)
+        remaining = _resend_cooldowns.remaining_seconds(self._COOLDOWN_SCOPE, email) if email_valid else 0
+        if remaining > 0:
+            self.code_input.setEnabled(True)
+            self._start_cooldown(remaining)
+        else:
+            if timer_is_active(self._timer):
+                destroy_timer(self._timer)
+                self._timer = None
+                self.status_label.setText("")
+            self.email_box.button.setEnabled(email_valid)
+        self.code_box.button.setEnabled(self.code_input.hasAcceptableInput() and email_valid)
+
+    def _start_cooldown(self, remaining_secs: int) -> None:
         def on_timeout(remaining_secs: int) -> None:
             email = self.email_input.text()
             resend_available_status = f"Resend available in {remaining_secs}s" if remaining_secs else "Resend available"
@@ -554,9 +609,13 @@ class LoginWithCodeWidget(BaseLoginWidget):
             if not remaining_secs:
                 self.email_box.button.setEnabled(True)
 
+        self.init_timer(on_timeout, remaining_secs)
+        self.email_box.button.setEnabled(False)
+
+    def _on_get_code(self) -> None:
         def on_success(resend_cooldown_secs: int) -> None:
-            self.init_timer(on_timeout, resend_cooldown_secs)
-            self.email_box.button.setEnabled(False)
+            _resend_cooldowns.start(self._COOLDOWN_SCOPE, email, resend_cooldown_secs)
+            self._start_cooldown(resend_cooldown_secs)
             self.code_input.setEnabled(True)
             self.form_widget.error_label.set_error("")
 

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -554,8 +554,8 @@ class LoginWithCodeWidget(BaseLoginWidget):
             if not remaining_secs:
                 self.email_box.button.setEnabled(True)
 
-        def on_success(code_ttl_secs: int) -> None:
-            self.init_timer(on_timeout, code_ttl_secs)
+        def on_success(resend_cooldown_secs: int) -> None:
+            self.init_timer(on_timeout, resend_cooldown_secs)
             self.email_box.button.setEnabled(False)
             self.code_input.setEnabled(True)
             self.form_widget.error_label.set_error("")
@@ -563,7 +563,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
         email = self.email_input.text()
         AddonQueryOp(
             parent=self,
-            op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
+            op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).resend_cooldown_secs,
             success=on_success,
         ).failure(lambda exc: self.form_widget.error_label.set_error(str(exc))).run_in_background()
 
@@ -759,7 +759,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
             bottom_label=f"{html_link(AnkiwebLinkIds.LOGIN_CODE.value, 'Have an account? Sign in.')}",
             dialog=dialog,
         )
-        if not self._is_retry or remaining_seconds > 0:
+        if not self._is_retry or self.remaining_seconds > 0:
             self._start_timer()
         else:
             self._update_code_button_state()
@@ -832,14 +832,14 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
         self.email_box.button.setEnabled(is_email(text))
 
     def _on_get_code(self) -> None:
-        def on_success(code_ttl_secs: int) -> None:
-            self.remaining_seconds = code_ttl_secs
+        def on_success(resend_cooldown_secs: int) -> None:
+            self.remaining_seconds = resend_cooldown_secs
             self._start_timer()
 
         email = self._get_email()
         AddonQueryOp(
             parent=self,
-            op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
+            op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).resend_cooldown_secs,
             success=on_success,
         ).failure(lambda exc: self.form_widget.error_label.set_error(str(exc))).run_in_background()
 
@@ -970,7 +970,7 @@ class BaseSignupFirstPageWidget(BaseSignupWidget):
             client = AnkiHubClient()
             terms = self.terms_checkbox.isChecked()
             if self.is_code_signup:
-                return client.ankiweb_request_signup_code(self.email_input.text(), terms).code_ttl_secs
+                return client.ankiweb_request_signup_code(self.email_input.text(), terms).resend_cooldown_secs
             else:
                 return client.ankiweb_signup(self.email_input.text(), self.password_input.text(), terms).host_key
 

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -104,11 +104,17 @@ def timer_is_active(timer: Countdown | None) -> bool:
 
 
 class ResendCooldownTracker:
-    """Tracks per-email magic-code resend cooldowns for the lifetime of the Anki
-    session (i.e. independently of any widget). Widgets only hold the cooldown's
-    remaining time in memory, so closing and reopening the AnkiWeb dialog
-    recreates them from scratch and would otherwise let the user bypass the
-    cooldown the server already enforces for that email.
+    """Remembers each email's magic-code resend cooldown independently of any
+    widget, so that closing and reopening the AnkiWeb dialog within the same
+    Anki session keeps showing the correct remaining countdown instead of
+    resetting it.
+
+    This is a UI convenience only, not an enforcement mechanism: the tracker
+    lives in memory for the current session, so restarting Anki clears it and
+    lets the resend button appear enabled again immediately. That's fine
+    because the actual cooldown is enforced server-side; this class only
+    avoids a redundant request (and confusing UI) in the common case where the
+    dialog is closed and reopened without restarting Anki.
     """
 
     def __init__(self) -> None:

--- a/proto/user_backend/magic_code.proto
+++ b/proto/user_backend/magic_code.proto
@@ -18,11 +18,13 @@ message MagicCodeSignupRequest {
 
 // 200 = account created, code email sent. Errors: 400 invalid email or
 // terms != true, 409 account already exists (client should redirect to
-// login), 429 throttled.
+// login). Only a per-IP 429 may surface; the per-email limits never 429
+// (see MagicCodeLoginResponse.resend_cooldown_secs).
 message MagicCodeSignupResponse {
-  // Conservative lifetime of the emailed code, in seconds. Provided so
-  // clients can drive countdown/resend UX without hardcoding the value.
-  uint32 code_ttl_secs = 1;
+  // Seconds the client should wait before offering to resend the code.
+  // Server-enforced per email, so the client countdown matches what the
+  // server will actually accept.
+  uint32 resend_cooldown_secs = 1;
 }
 
 message MagicCodeSignupVerifyRequest {
@@ -43,13 +45,16 @@ message MagicCodeLoginRequest {
   string email = 1;
 }
 
-// Always the same 200 whether or not the account exists (anti-enumeration).
-// Only a per-IP 429 may surface, as it reveals nothing about the email.
+// Always a 200 whether or not the account exists (anti-enumeration). Only a
+// per-IP 429 may surface, as it reveals nothing about the email; the per-email
+// send limits are reported through resend_cooldown_secs instead of a 429.
 message MagicCodeLoginResponse {
-  // Same constant as MagicCodeSignupResponse.code_ttl_secs, returned
-  // whether or not the account exists (and whether or not the send was
-  // throttled) so it leaks nothing.
-  uint32 code_ttl_secs = 1;
+  // Seconds the client should wait before offering to resend the code. This
+  // is the server-enforced per-email spacing: normally the 120s cooldown, but
+  // up to the send-cap window once that cap is exhausted. Keyed by email (not
+  // account), so it is identical whether or not the email maps to an account
+  // and whether or not a code was actually sent, and therefore leaks nothing.
+  uint32 resend_cooldown_secs = 1;
 }
 
 message MagicCodeLoginVerifyRequest {

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1081,6 +1081,46 @@ class TestAnkiwebLoginWithCodeWidget:
         assert widget.email_box.button.isEnabled() is True
         assert "Resend available" in widget.status_label.text()
 
+    def test_get_code_cooldown_persists_when_dialog_is_reopened(self, qtbot: QtBot, mocker: MockerFixture):
+        """Closing and reopening the AnkiWeb dialog recreates LoginWithCodeWidget from
+        scratch. The resend cooldown should still be enforced client-side (mirroring
+        what the server already enforces per email), instead of the button coming back
+        enabled with no countdown shown.
+        """
+        mocker.patch.object(
+            AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(resend_cooldown_secs=120)
+        )
+        mocker.patch.object(aqt.mw.taskman, "run_in_background", side_effect=_run_in_background_synchronously)
+
+        widget = self._widget(qtbot)
+        widget.email_input.setText("user@example.com")
+        widget._on_get_code()
+        assert widget.email_box.button.isEnabled() is False
+
+        # Simulate closing the dialog and opening a brand new one, which creates a
+        # brand new LoginWithCodeWidget with no memory of the previous instance.
+        new_widget = self._widget(qtbot)
+        new_widget.email_input.setText("user@example.com")
+
+        assert new_widget.email_box.button.isEnabled() is False
+        assert new_widget.code_input.isEnabled() is True
+        assert "Resend available in" in new_widget.status_label.text()
+
+    def test_get_code_cooldown_does_not_apply_to_a_different_email(self, qtbot: QtBot, mocker: MockerFixture):
+        mocker.patch.object(
+            AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(resend_cooldown_secs=120)
+        )
+        mocker.patch.object(aqt.mw.taskman, "run_in_background", side_effect=_run_in_background_synchronously)
+
+        widget = self._widget(qtbot)
+        widget.email_input.setText("user@example.com")
+        widget._on_get_code()
+
+        new_widget = self._widget(qtbot)
+        new_widget.email_input.setText("someone-else@example.com")
+
+        assert new_widget.email_box.button.isEnabled() is True
+
 
 @pytest.mark.skipif(using_qt5(), reason="AnkiWeb signup screens are not supported on Qt5")
 class TestAnkiwebLoginAndSignupSubmission:
@@ -1201,7 +1241,9 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert "unknown error" in widget.form_widget.error_label.status.text()
 
     def test_signup_with_code_success_shows_code_verification_widget(self, qtbot: QtBot, mocker: MockerFixture):
-        mocker.patch.object(AddonAnkiHubClient, "ankiweb_request_signup_code", return_value=Mock(resend_cooldown_secs=300))
+        mocker.patch.object(
+            AddonAnkiHubClient, "ankiweb_request_signup_code", return_value=Mock(resend_cooldown_secs=300)
+        )
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
         widget = cast(SignupWithCodeWidget, dialog._widget)

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1062,7 +1062,7 @@ class TestAnkiwebLoginWithCodeWidget:
         assert state == expected_state
 
     def test_get_code_disables_button_until_countdown_reaches_zero(self, qtbot: QtBot, mocker: MockerFixture):
-        mocker.patch.object(AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(code_ttl_secs=5))
+        mocker.patch.object(AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(resend_cooldown_secs=5))
         mocker.patch.object(aqt.mw.taskman, "run_in_background", side_effect=_run_in_background_synchronously)
 
         widget = self._widget(qtbot)
@@ -1201,7 +1201,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert "unknown error" in widget.form_widget.error_label.status.text()
 
     def test_signup_with_code_success_shows_code_verification_widget(self, qtbot: QtBot, mocker: MockerFixture):
-        mocker.patch.object(AddonAnkiHubClient, "ankiweb_request_signup_code", return_value=Mock(code_ttl_secs=300))
+        mocker.patch.object(AddonAnkiHubClient, "ankiweb_request_signup_code", return_value=Mock(resend_cooldown_secs=300))
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
         widget = cast(SignupWithCodeWidget, dialog._widget)
@@ -1258,19 +1258,21 @@ class TestAnkiwebLoginAndSignupSubmission:
         persist_mock.assert_called_once_with(email="other@example.com", host_key="hostkey123")
 
     def test_signup_code_verification_reuses_timer(self, qtbot: QtBot, mocker: MockerFixture):
-        code_ttl_secs = 300
+        resend_cooldown_secs = 300
         elapsed_secs = 5
         mocker.patch.object(AddonAnkiHubClient, "ankiweb_verify_signup_code", side_effect=Exception("some error"))
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
-        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=code_ttl_secs, dialog=dialog)
+        widget = SignupCodeVerificationWidget(
+            email="user@example.com", remaining_seconds=resend_cooldown_secs, dialog=dialog
+        )
         dialog.replace_widget(widget)
         # Simulate the countdown having run for a few seconds, so the time left is
         # distinguishable from the full TTL. `Countdown` also counts down once on
         # construction, hence the extra second.
         for _ in range(elapsed_secs):
             widget._timer._on_timeout()
-        remaining_seconds = code_ttl_secs - elapsed_secs - 1
+        remaining_seconds = resend_cooldown_secs - elapsed_secs - 1
         assert widget._timer.remaining_seconds == remaining_seconds
 
         widget.code_input.setText("123456")
@@ -1284,15 +1286,17 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert retry_widget.remaining_seconds == remaining_seconds
 
     def test_signup_code_verification_restarts_timer_when_it_ran_out(self, qtbot: QtBot, mocker: MockerFixture):
-        code_ttl_secs = 3
+        resend_cooldown_secs = 3
         mocker.patch.object(AddonAnkiHubClient, "ankiweb_verify_signup_code", side_effect=Exception("some error"))
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
-        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=code_ttl_secs, dialog=dialog)
+        widget = SignupCodeVerificationWidget(
+            email="user@example.com", remaining_seconds=resend_cooldown_secs, dialog=dialog
+        )
         dialog.replace_widget(widget)
         # Let the countdown run out. `Countdown` counts down once on construction,
         # hence one tick less than the TTL.
-        for _ in range(code_ttl_secs - 1):
+        for _ in range(resend_cooldown_secs - 1):
             widget._timer._on_timeout()
         assert widget._timer.remaining_seconds == 0
 
@@ -1304,8 +1308,8 @@ class TestAnkiwebLoginAndSignupSubmission:
         retry_widget = dialog._widget
         assert retry_widget is not widget
         assert isinstance(retry_widget, SignupCodeVerificationWidget)
-        assert retry_widget.remaining_seconds == code_ttl_secs
-        assert retry_widget._timer.remaining_seconds == code_ttl_secs - 1
+        assert retry_widget.remaining_seconds == resend_cooldown_secs
+        assert retry_widget._timer.remaining_seconds == resend_cooldown_secs - 1
 
     def test_signup_with_password_success_shows_email_verification_widget(self, qtbot: QtBot, mocker: MockerFixture):
         from ankihub.gui.ankiweb import SignupEmailVerificationWidget


### PR DESCRIPTION
## Summary
Renames the magic-code response field `code_ttl_secs` to `resend_cooldown_secs` across the proto and the AnkiWeb signup/login UI. The old name described a code TTL, but the value the server returns is the per-email resend spacing (the seconds the client must wait before offering to resend). The new name matches the server contract in ankiweb.

- Rename `code_ttl_secs` → `resend_cooldown_secs` in `proto/user_backend/magic_code.proto` (signup and login responses).
- Wire `SignupCodeVerificationWidget` to seed its countdown from the server's `resend_cooldown_secs`, keeping a single internal `remaining_seconds` field for the timer (initial open, resend, and retry all share it).
- Update `_on_sign_up` and the retry call site to pass `remaining_seconds` consistently.
- Update unit tests to the new field/param names.

Pairs with the AnkiWeb PR that renames the field server-side and enforces the per-email resend cooldown.

## Related PR
https://github.com/ankitects/ankiweb/pull/30

## Test plan
- [ ] `pytest tests/addon/test_unit.py -k signup_code_verification`
- [ ] Manual: request a signup code, confirm the "Resend available in Ns" countdown starts from the server cooldown and the button re-enables at 0.
- [ ] Manual: fail a verification and confirm the retry screen resumes the remaining countdown instead of restarting.