### PR TITLE
[KNW-177] Catch collection errors while media sync is active

### DIFF
--- a/ankihub/addon_ankihub_client.py
+++ b/ankihub/addon_ankihub_client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import aqt
+from anki.collection import Collection
 from requests import Response
 
 from . import LOGGER
@@ -64,6 +65,20 @@ DEFAULT_RESPONSE_HOOKS = [
 ]
 
 
+class CollectionNotAvailableError(Exception):
+    """
+    Raised when the Anki collection is unavailable (profile switched or full sync running)\
+    while a media sync is active.
+    """
+
+
+def collection_or_error() -> Collection:
+    if col := getattr(aqt.mw, "col", None):
+        return col
+    else:
+        raise CollectionNotAvailableError()
+
+
 class AddonAnkiHubClient(AnkiHubClient):
     def __init__(self, hooks=None) -> None:
         super().__init__(
@@ -72,7 +87,7 @@ class AddonAnkiHubClient(AnkiHubClient):
             ankiweb_url=config.ankiweb_url,
             response_hooks=hooks if hooks is not None else DEFAULT_RESPONSE_HOOKS,
             get_token=lambda: config.token(),
-            local_media_dir_path_cb=lambda: (Path(aqt.mw.col.media.dir()) if aqt.mw.col else None),
+            local_media_dir_path_cb=lambda: (Path(collection_or_error().media.dir())),
         )
 
     def upload_logs(self, file: Path, key: str) -> None:

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -34,13 +34,19 @@ from aqt.qt import (
 )
 
 from .. import LOGGER
-from ..addon_ankihub_client import AddonAnkiHubClient
+from ..addon_ankihub_client import AddonAnkiHubClient, CollectionNotAvailableError, collection_or_error
 from ..ankihub_client.models import DeckMedia
 from ..common_utils import get_media_names_from_note_field, get_media_names_from_note_type
 from ..db import ankihub_db
 from ..settings import config, get_anki_profile_id
 from .operations import AddonQueryOp
-from .utils import error_icon, media_download_icon, media_sync_error_svg, media_sync_svg, media_upload_icon
+from .utils import (
+    error_icon,
+    media_download_icon,
+    media_sync_error_svg,
+    media_sync_svg,
+    media_upload_icon,
+)
 
 SHOW_MEDIA_PROGRESS_PYCMD = "ankihub_show_media_progress"
 TOOLBAR_BUTTON_ID = "ankihub_media_sync"
@@ -51,6 +57,17 @@ class MediaSyncStatus(Enum):
     UPLOAD = "Uploading..."
     ERROR = "Error"
     IDLE = "Idle"
+
+
+def _is_collection_error(exc: Exception) -> bool:
+    return isinstance(exc, CollectionNotAvailableError) or "CollectionNotOpen" in str(exc)
+
+
+def _format_error(exc: Exception) -> str:
+    if _is_collection_error(exc):
+        return "Collection is unavailable."
+    else:
+        return str(exc)
 
 
 class _AnkiHubMediaSync:
@@ -111,7 +128,8 @@ class _AnkiHubMediaSync:
             self._errors = [exception]
             self.refresh_sync_status()
             self._dialog.update_status(self._get_status())
-            raise exception
+            if not _is_collection_error(exception):
+                raise exception
 
         AddonQueryOp(
             parent=aqt.mw,
@@ -146,7 +164,8 @@ class _AnkiHubMediaSync:
             self._errors = [exception]
             self.refresh_sync_status()
             self._dialog.update_status(self._get_status())
-            raise exception
+            if not _is_collection_error(exception):
+                raise exception
 
         AddonQueryOp(
             parent=aqt.mw,
@@ -192,7 +211,7 @@ class _AnkiHubMediaSync:
         return MediaSyncProgressDialog()
 
     def _media_paths_for_media_names(self, media_names: Iterable[str]) -> Set[Path]:
-        media_dir_path = Path(aqt.mw.col.media.dir())
+        media_dir_path = Path(collection_or_error().media.dir())
         return {media_dir_path / media_name for media_name in media_names}
 
     def _on_upload_finished(
@@ -287,7 +306,7 @@ class _AnkiHubMediaSync:
         note_type_ids: Set[int] = set()
         for nid in anki_nids:
             try:
-                note = aqt.mw.col.get_note(nid)
+                note = collection_or_error().get_note(nid)
             except NotFoundError:
                 continue
             note_type_ids.add(note.mid)
@@ -310,7 +329,7 @@ class _AnkiHubMediaSync:
         # Filter to only media that is both downloadable AND referenced by notes
         media_list = [m for m in media_list if m.name in referenced_media]
 
-        media_dir_path = Path(aqt.mw.col.media.dir())
+        media_dir_path = Path(collection_or_error().media.dir())
         result = [
             media.name
             for media in media_list
@@ -493,9 +512,9 @@ class MediaSyncProgressDialog(QDialog):
             toggle_log = len(media_sync._errors) > 1
             if toggle_log:
                 error_text = "Some errors found. See full log for details."
-                self.error_log_browser.setPlainText("\n".join(str(error) for error in media_sync._errors))
+                self.error_log_browser.setPlainText("\n".join(_format_error(error) for error in media_sync._errors))
             else:
-                error_text = str(media_sync._errors[0])
+                error_text = _format_error(media_sync._errors[0])
             self.error_label.setText(error_text)
         elif status == MediaSyncStatus.IDLE:
             label = "Finished"

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -56,6 +56,7 @@ from pytestqt.qtbot import QtBot  # type: ignore
 from requests import Response  # type: ignore
 from requests_mock import Mocker
 
+from ankihub.addon_ankihub_client import CollectionNotAvailableError
 from ankihub.gui.block_exam_dialog import BlockExamSubdeckDialog
 from ankihub.gui.enable_fsrs_dialog import ENABLE_FSRS_REMINDER_INTERVAL_DAYS, maybe_show_enable_fsrs_reminder
 from ankihub.gui.optimize_fsrs_dialog import (
@@ -7958,6 +7959,41 @@ class TestMediaSyncMediaDownload:
             assert len(db_media) == 2
             media_names = {m.name for m in db_media}
             assert media_names == {"referenced_image.png", "unreferenced_image.png"}
+
+    def test_collection_not_available_exception_is_recorded(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        entry_point.run()
+
+        with anki_session_with_addon_data.profile_loaded():
+            _, _ = install_sample_ah_deck()
+            latest_media_update = datetime.now()
+            media = DeckMediaFactory.create(
+                name="test.png",
+                modified=latest_media_update,
+                referenced_on_accepted_note=True,
+                exists_on_s3=True,
+                download_enabled=True,
+            )
+            mocker.patch.object(
+                AnkiHubClient,
+                "get_deck_media_updates",
+                return_value=[
+                    DeckMediaUpdateChunk(media=[media], latest_update=latest_media_update),
+                ],
+            )
+            # Simulate closed collection
+            mocker.patch("aqt.mw.col", None)
+            with qtbot.captureExceptions() as exceptions:
+                media_sync.start_media_download()
+                qtbot.wait_until(lambda: media_sync._download_in_progress is False)
+            # Exception is reported by the dialog but not raised
+            assert len(exceptions) == 0
+            assert isinstance(media_sync._errors[0], CollectionNotAvailableError)
 
 
 @fixture

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -8291,6 +8291,42 @@ class TestSuggestionsWithMedia:
 
         assert name_of_uploaded_media == expected_media_name
 
+    def test_collection_not_available_exception_is_recorded(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+        mock_client_media_upload: Mock,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        entry_point.run()
+
+        with anki_session_with_addon_data.profile_loaded():
+            _, ah_did = install_sample_ah_deck()
+
+            # Simulate closed collection
+            def close_collection(*args, **kwargs):
+                mocker.patch("aqt.mw.col", None)
+                return {}
+
+            mocker.patch.object(
+                AnkiHubClient,
+                "_get_presigned_url_for_multiple_uploads",
+                side_effect=close_collection,
+            )
+
+            with qtbot.captureExceptions() as exceptions:
+                media_sync.start_media_upload(["testfile_1.jpeg"], ah_did)
+                qtbot.wait_until(lambda: media_sync._amount_uploads_in_progress == 0)
+
+            # Exception is reported by the dialog but not raised
+            assert len(exceptions) == 0
+            assert isinstance(media_sync._errors[0], CollectionNotAvailableError)
+            assert media_sync._dialog.error_label.text() == "Collection is unavailable."
+
+            # Nothing was uploaded to S3
+            assert mock_client_media_upload.call_count == 0
+
 
 class TestAddonInstallAndUpdate:
     def test_install_and_update_addon(


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-177

<details>

<summary>Jira description for people with no access</summary>

Problem: The background sync does not cancel immediately when the user’s collection becomes unavailable in some cases (e.g. profile switched).

Solution: Review usage of mw.col in the sync logic and ensure there are checks to prevent errors.

</details>

## Proposed changes

Media sync runs in the background and relies on the existence of `aqt.mw.col` to get the media folder (which can be None when the profile is switched or a full sync is running). While the background task is canceled when the profile is switched, it takes time for cancellation to take effect and any access of `aqt.mw.col` there results in spurious errors. This is one of the most common error reports on [Discourse](https://community.ankihub.net/t/idk-this-is-annoying/596352)/[Sentry](https://ankihub.sentry.io/issues/6725784266/?project=6546414&query=TypeError&referrer=issue-stream&sort=recommended).

#1339 improved the situation by showing all kinds of errors in a dialog instead of throwing errors visibly at the user. This PR just adds a custom error message for that instead of showing TypeError/CollectionNotOpen exception messages.

## How to reproduce

1. Start a media sync (by downloading a large deck for example).
2. Open the media sync dialog from the toolbar button.
3. Switch the Anki profile quickly from _File>Switch Profile_ while the sync is starting (before the file count is displayed).
4. Depending on the timing, you should see "Collection is unavailable." displayed in the dialog.

## Screenshots and videos

<img width="502" height="128" alt="image" src="https://github.com/user-attachments/assets/db5985e3-9011-4dc7-93a3-af104299de9f" />

