### PR TITLE
[KNW-215] Show a custom error message for AnkiWeb connection errors

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -172,7 +172,7 @@ class LabelWithLink(QLabel):
             widget_type = widget_for_link(AnkiwebLinkIds(link))
             widget = widget_type(self._dialog)
             self._dialog.replace_widget(widget)
-        elif not self._link_handler(link):
+        elif not (self._link_handler and self._link_handler(link)):
             openLink(link)
 
 

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -829,7 +829,8 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
         form_widget = FormWidget(
             description=description, rows=rows, dialog=self._dialog, back_to=AnkiwebLinkIds.SIGNUP_CODE
         )
-        form_widget.error_label.set_exception(exc)
+        if exc:
+            form_widget.error_label.set_exception(exc)
 
         return form_widget
 

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -35,6 +35,7 @@ from aqt.utils import openLink, tooltip
 
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
+from ..ankihub_client import AnkiHubRequestException
 from ..settings import config
 from ..user_state import add_user_state_refreshed_callback
 from .operations import AddonQueryOp
@@ -89,6 +90,17 @@ def widget_for_link(link: AnkiwebLinkIds) -> Callable[[AnkiwebDialog], BaseAnkiw
         return SignupWithPasswordWidget
     else:
         assert_exhaustive(link)
+
+
+def _format_error(exc: Exception) -> str:
+    print("_format_error", exc)
+    if isinstance(exc, AnkiHubRequestException):
+        return (
+            "Can't reach AnkiWeb. "
+            "Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down."
+        )
+    else:
+        return str(exc)
 
 
 def destroy_timer(timer: QTimer | None) -> None:
@@ -565,7 +577,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(str(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
 
     def _on_sign_in(self) -> None:
         def task() -> str:
@@ -580,7 +592,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
-                self.form_widget.error_label.set_error(str(exc))
+                self.form_widget.error_label.set_error(_format_error(exc))
                 self.code_input.clear()
 
         run_with_progress(dialog=self._dialog, heading=self.title, status="Signing you in", task=task, on_done=on_done)
@@ -635,7 +647,7 @@ class LoginWithPasswordWidget(BaseLoginWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
-                self.form_widget.error_label.set_error(str(exc))
+                self.form_widget.error_label.set_error(_format_error(exc))
 
         run_with_progress(dialog=self._dialog, heading=self.title, status="Signing you in", task=task, on_done=on_done)
 
@@ -740,7 +752,7 @@ class SignupEmailVerificationWidget(BaseSignupWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_resend_verification(self.host_key).throttled,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(str(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
 
     def _on_login(self) -> None:
         self._dialog.replace_widget(LoginWithPasswordWidget(self._dialog))
@@ -841,7 +853,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(str(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
 
     def _get_email(self) -> str:
         return self.email_input.text() if self._is_retry else self.email
@@ -870,7 +882,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                     SignupCodeVerificationWidget(
                         email=self._get_email(),
                         dialog=self._dialog,
-                        error=str(exc),
+                        error=_format_error(exc),
                         remaining_seconds=remaining_seconds,
                     )
                 )
@@ -988,7 +1000,7 @@ class BaseSignupFirstPageWidget(BaseSignupWidget):
                 if "An account with this email already exists" in str(exc):
                     self._dialog.replace_widget(SignupErrorWidget(str(exc), self._dialog, self.is_code_signup))
                 else:
-                    self.form_widget.error_label.set_error(str(exc))
+                    self.form_widget.error_label.set_error(_format_error(exc))
 
         run_with_progress(
             dialog=self._dialog, heading=self.title, status="Creating account", task=task, on_done=on_done

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -38,6 +38,7 @@ from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..ankihub_client import AnkiHubRequestException
 from ..settings import config
 from ..user_state import add_user_state_refreshed_callback
+from .errors import _error_reporting_enabled, _show_feedback_dialog, report_exception_and_upload_logs
 from .operations import AddonQueryOp
 from .utils import error_icon, is_email
 
@@ -45,6 +46,7 @@ EMAIL_INSTRUCTIONS = (
     "Didn't receive an email?<ul><li>Check your spam folder. "
     "Emails can end up there.</li><li>Resend the email when the countdown ends.</li></ul>"
 )
+ERROR_DIALOG_LINK = "#error-dialog"
 
 
 class AnkiwebLinkIds(Enum):
@@ -92,16 +94,17 @@ def widget_for_link(link: AnkiwebLinkIds) -> Callable[[AnkiwebDialog], BaseAnkiw
         assert_exhaustive(link)
 
 
-def _format_error(exc: Exception) -> str:
-    print("_format_error", exc)
+def _report_and_format_exception(exc: Exception) -> tuple[str, str | None]:
     if isinstance(exc, AnkiHubRequestException):
         LOGGER.info("AnkiWeb request exception", exc_info=exc.original_exception)
+        sentry_event_id = report_exception_and_upload_logs(exc) if _error_reporting_enabled() else None
         return (
             "Can't reach AnkiWeb. "
-            "Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down."
-        )
+            "Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down. "
+            + html_link(ERROR_DIALOG_LINK, "See error details.", False)
+        ), sentry_event_id
     else:
-        return str(exc)
+        return str(exc), None
 
 
 def destroy_timer(timer: QTimer | None) -> None:
@@ -152,8 +155,15 @@ class CancelButton(Button):
 
 
 class LabelWithLink(QLabel):
-    def __init__(self, text: str, dialog: AnkiwebDialog, parent: QWidget | None = None):
+    def __init__(
+        self,
+        text: str,
+        dialog: AnkiwebDialog,
+        link_handler: Callable[[str], bool] | None = None,
+        parent: QWidget | None = None,
+    ):
         self._dialog = dialog
+        self._link_handler = link_handler
         super().__init__(text=text, parent=parent)
         qconnect(self.linkActivated, self._on_link_activated)
 
@@ -162,7 +172,7 @@ class LabelWithLink(QLabel):
             widget_type = widget_for_link(AnkiwebLinkIds(link))
             widget = widget_type(self._dialog)
             self._dialog.replace_widget(widget)
-        else:
+        elif not self._link_handler(link):
             openLink(link)
 
 
@@ -171,16 +181,19 @@ class ErrorLabel(QWidget):
     # FormWidget's inner content width, given the dialog's fixed 525px width and margins.
     _FALLBACK_MAX_WIDTH = 461
 
-    def __init__(self, parent: QWidget | None = None):
+    def __init__(self, dialog: AnkiwebDialog, parent: QWidget | None = None):
+        self._dialog = dialog
         super().__init__(parent)
         self._setup_ui()
+        self._exc: Exception | None = None
+        self._sentry_event_id: str | None = None
 
     def _setup_ui(self) -> None:
         self.setVisible(False)
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
         hbox.setSpacing(4)
-        self.status = status = QLabel("")
+        self.status = status = LabelWithLink("", dialog=self._dialog, link_handler=self._link_handler)
         status.setWordWrap(True)
         status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         font = self.font()
@@ -197,10 +210,25 @@ class ErrorLabel(QWidget):
         hbox.addWidget(status)
         self.setLayout(hbox)
 
-    def set_error(self, text: str) -> None:
+    def set_error(self, text: str, clear_exception: bool = True) -> None:
         self.setVisible(bool(text))
         self.status.setText(text)
         self._update_status_width()
+        if clear_exception:
+            self._exc = None
+            self._sentry_event_id = None
+
+    def set_exception(self, exc: Exception) -> None:
+        self._exc = exc
+        error, self._sentry_event_id = _report_and_format_exception(exc)
+        self.set_error(error, clear_exception=False)
+
+    def _link_handler(self, link: str) -> bool:
+        if link == ERROR_DIALOG_LINK:
+            if self._exc:
+                _show_feedback_dialog(self._exc, self._sentry_event_id)
+            return True
+        return False
 
     def _update_status_width(self) -> None:
         # Measure the label's own sizeHint with word wrap temporarily disabled. This
@@ -281,7 +309,7 @@ class FormWidget(QGroupBox):
         vbox.setContentsMargins(12, 12, 12, 12)
         vbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.error_label = error_label = ErrorLabel(self)
+        self.error_label = error_label = ErrorLabel(self._dialog, self)
         vbox.addWidget(error_label)
 
         if description:
@@ -578,7 +606,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_exception(exc)).run_in_background()
 
     def _on_sign_in(self) -> None:
         def task() -> str:
@@ -593,7 +621,7 @@ class LoginWithCodeWidget(BaseLoginWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
-                self.form_widget.error_label.set_error(_format_error(exc))
+                self.form_widget.error_label.set_exception(exc)
                 self.code_input.clear()
 
         run_with_progress(dialog=self._dialog, heading=self.title, status="Signing you in", task=task, on_done=on_done)
@@ -648,7 +676,7 @@ class LoginWithPasswordWidget(BaseLoginWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
-                self.form_widget.error_label.set_error(_format_error(exc))
+                self.form_widget.error_label.set_exception(exc)
 
         run_with_progress(dialog=self._dialog, heading=self.title, status="Signing you in", task=task, on_done=on_done)
 
@@ -753,22 +781,22 @@ class SignupEmailVerificationWidget(BaseSignupWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_resend_verification(self.host_key).throttled,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_exception(exc)).run_in_background()
 
     def _on_login(self) -> None:
         self._dialog.replace_widget(LoginWithPasswordWidget(self._dialog))
 
 
 class SignupCodeVerificationWidget(BaseSignupWidget):
-    def __init__(self, email: str, dialog: AnkiwebDialog, error: str = "", remaining_seconds: int = 0):
+    def __init__(self, email: str, dialog: AnkiwebDialog, exc: Exception | None = None, remaining_seconds: int = 0):
         self.email = email
         self._dialog = dialog
         self.remaining_seconds = remaining_seconds
-        self._is_retry = bool(error)
+        self._is_retry = bool(exc)
         super().__init__(
             heading="Email confirmation",
             main_description="",
-            form_widget=self._create_form_widget(error),
+            form_widget=self._create_form_widget(exc),
             bottom_label=f"{html_link(AnkiwebLinkIds.LOGIN_CODE.value, 'Have an account? Sign in.')}",
             dialog=dialog,
         )
@@ -777,7 +805,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
         else:
             self._update_code_button_state()
 
-    def _create_form_widget(self, error: str = "") -> FormWidget:
+    def _create_form_widget(self, exc: Exception | None = None) -> FormWidget:
         self.code_input = code_input = CodeInput()
         qconnect(code_input.textChanged, self._on_code_changed)
         self.code_box = code_box = InputWithButtonHbox(code_input, "Verify code")
@@ -801,7 +829,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
         form_widget = FormWidget(
             description=description, rows=rows, dialog=self._dialog, back_to=AnkiwebLinkIds.SIGNUP_CODE
         )
-        form_widget.error_label.set_error(error)
+        form_widget.error_label.set_exception(exc)
 
         return form_widget
 
@@ -854,7 +882,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
             parent=self,
             op=lambda _: AnkiHubClient().ankiweb_request_login_code(email).code_ttl_secs,
             success=on_success,
-        ).failure(lambda exc: self.form_widget.error_label.set_error(_format_error(exc))).run_in_background()
+        ).failure(lambda exc: self.form_widget.error_label.set_exception(exc)).run_in_background()
 
     def _get_email(self) -> str:
         return self.email_input.text() if self._is_retry else self.email
@@ -883,7 +911,7 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                     SignupCodeVerificationWidget(
                         email=self._get_email(),
                         dialog=self._dialog,
-                        error=_format_error(exc),
+                        exc=exc,
                         remaining_seconds=remaining_seconds,
                     )
                 )
@@ -1001,7 +1029,7 @@ class BaseSignupFirstPageWidget(BaseSignupWidget):
                 if "An account with this email already exists" in str(exc):
                     self._dialog.replace_widget(SignupErrorWidget(str(exc), self._dialog, self.is_code_signup))
                 else:
-                    self.form_widget.error_label.set_error(_format_error(exc))
+                    self.form_widget.error_label.set_exception(exc)
 
         run_with_progress(
             dialog=self._dialog, heading=self.title, status="Creating account", task=task, on_done=on_done

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -95,6 +95,7 @@ def widget_for_link(link: AnkiwebLinkIds) -> Callable[[AnkiwebDialog], BaseAnkiw
 def _format_error(exc: Exception) -> str:
     print("_format_error", exc)
     if isinstance(exc, AnkiHubRequestException):
+        LOGGER.info("AnkiWeb request exception", exc_info=exc.original_exception)
         return (
             "Can't reach AnkiWeb. "
             "Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down."

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1246,7 +1246,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         # Passing an error makes this a retry widget, which shows an editable
         # email field instead of the original read-only `self.email`.
         widget = SignupCodeVerificationWidget(
-            email="user@example.com", remaining_seconds=300, dialog=dialog, error="Some unknown error"
+            email="user@example.com", remaining_seconds=300, dialog=dialog, exc=Exception("Some unknown error")
         )
         dialog.replace_widget(widget)
         widget.email_input.setText("other@example.com")

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -109,8 +109,12 @@ from ankihub.db.exceptions import IntegrityError, MissingValueError
 from ankihub.db.models import AnkiHubNote, DeckMedia, get_peewee_database
 from ankihub.gui import menu
 from ankihub.gui.ankiweb import (
+    ERROR_DIALOG_LINK,
+    AnkiwebLinkIds,
     AnkiwebLoginDialog,
     AnkiwebSignupDialog,
+    ErrorLabel,
+    LabelWithLink,
     LoginWithCodeWidget,
     LoginWithPasswordWidget,
     SignupCodeVerificationWidget,
@@ -1331,6 +1335,247 @@ class TestAnkiwebLoginAndSignupSubmission:
         signup_mock.assert_called_once_with("user@example.com", "password123", True)
         assert isinstance(dialog._widget, SignupEmailVerificationWidget)
         assert dialog._widget.host_key == "hostkey123"
+
+    def test_login_with_code_request_exception_shows_generic_message(self, qtbot: QtBot, mocker: MockerFixture):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_verify_login_code",
+            side_effect=AnkiHubRequestException(original_exception=ConnectionError("connection refused")),
+        )
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        widget = cast(LoginWithCodeWidget, dialog._widget)
+        widget.email_input.setText("user@example.com")
+        widget.code_input.setText("123456")
+
+        widget._on_sign_in()
+
+        assert "Can't reach AnkiWeb" in widget.form_widget.error_label.status.text()
+
+    def test_get_code_request_exception_shows_generic_message(self, qtbot: QtBot, mocker: MockerFixture):
+        # Unlike the sign-in handlers, requesting a code runs as an AddonQueryOp, whose
+        # failure callback feeds the exception into the error label.
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_request_login_code",
+            side_effect=AnkiHubRequestException(original_exception=ConnectionError("connection refused")),
+        )
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        widget = cast(LoginWithCodeWidget, dialog._widget)
+        widget.email_input.setText("user@example.com")
+
+        widget._on_get_code()
+
+        qtbot.wait_until(lambda: "Can't reach AnkiWeb" in widget.form_widget.error_label.status.text())
+
+    def test_login_with_password_request_exception_shows_generic_message(self, qtbot: QtBot, mocker: MockerFixture):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_login",
+            side_effect=AnkiHubRequestException(original_exception=ConnectionError("connection refused")),
+        )
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        widget = LoginWithPasswordWidget(dialog)
+        qtbot.addWidget(widget)
+        widget.email_input.setText("user@example.com")
+        widget.password_input.setText("hunter2")
+
+        widget._on_sign_in()
+
+        error_text = widget.form_widget.error_label.status.text()
+        assert "Can't reach AnkiWeb" in error_text
+        # The raw exception isn't surfaced inline, only behind the error details link.
+        assert "connection refused" not in error_text
+
+    def test_signup_with_code_request_exception_shows_generic_message(self, qtbot: QtBot, mocker: MockerFixture):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_request_signup_code",
+            side_effect=AnkiHubRequestException(original_exception=ConnectionError("connection refused")),
+        )
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = cast(SignupWithCodeWidget, dialog._widget)
+        widget.terms_checkbox.setChecked(True)
+        widget.email_input.setText("user@example.com")
+
+        widget._on_sign_up()
+
+        assert dialog._widget is widget
+        assert "Can't reach AnkiWeb" in widget.form_widget.error_label.status.text()
+
+    def test_fresh_signup_code_verification_shows_no_error(self, qtbot: QtBot):
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=300, dialog=dialog)
+        dialog.replace_widget(widget)
+
+        # No exception is passed for a freshly created widget, so the error label stays
+        # empty and hidden instead of showing a placeholder for the missing exception.
+        assert widget.form_widget.error_label.status.text() == ""
+        assert widget.form_widget.error_label.isHidden() is True
+
+    def test_signup_code_verification_retry_shows_generic_message_for_request_exception(
+        self, qtbot: QtBot, mocker: MockerFixture
+    ):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_verify_signup_code",
+            side_effect=AnkiHubRequestException(original_exception=ConnectionError("connection refused")),
+        )
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(email="user@example.com", remaining_seconds=300, dialog=dialog)
+        dialog.replace_widget(widget)
+        widget.code_input.setText("123456")
+
+        widget._on_verify_or_resend()
+
+        # The exception is carried over to the retry widget, which renders it as the
+        # generic connection error message.
+        retry_widget = dialog._widget
+        assert isinstance(retry_widget, SignupCodeVerificationWidget)
+        assert "Can't reach AnkiWeb" in retry_widget.form_widget.error_label.status.text()
+
+
+@pytest.mark.skipif(using_qt5(), reason="AnkiWeb signup screens are not supported on Qt5")
+class TestAnkiwebErrorLabel:
+    """Tests for the inline error label of the AnkiWeb dialogs. Errors reported by AnkiWeb
+    itself are shown as-is, while failures to reach it get a generic message plus a link
+    to the error details dialog.
+    """
+
+    @pytest.fixture
+    def error_label(self, qtbot: QtBot) -> ErrorLabel:
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        error_label = ErrorLabel(dialog)
+        qtbot.addWidget(error_label)
+        return error_label
+
+    def test_generic_exception_is_shown_as_is_and_not_reported(self, error_label: ErrorLabel, mocker: MockerFixture):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=True)
+        report_mock = mocker.patch("ankihub.gui.ankiweb.report_exception_and_upload_logs")
+
+        error_label.set_exception(Exception("This code has expired. Request another."))
+
+        # Errors AnkiWeb responded with are expected, so they are neither rephrased nor
+        # sent to Sentry.
+        assert error_label.status.text() == "This code has expired. Request another."
+        assert error_label.isHidden() is False
+        report_mock.assert_not_called()
+
+    def test_request_exception_shows_generic_message_with_details_link(
+        self, error_label: ErrorLabel, mocker: MockerFixture
+    ):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=True)
+        report_mock = mocker.patch("ankihub.gui.ankiweb.report_exception_and_upload_logs", return_value="event-id")
+        exc = AnkiHubRequestException(original_exception=ConnectionError("connection refused"))
+
+        error_label.set_exception(exc)
+
+        error_text = error_label.status.text()
+        assert "Can't reach AnkiWeb" in error_text
+        assert ERROR_DIALOG_LINK in error_text
+        assert "connection refused" not in error_text
+        report_mock.assert_called_once_with(exc)
+
+    def test_request_exception_is_not_reported_when_error_reporting_is_disabled(
+        self, error_label: ErrorLabel, mocker: MockerFixture
+    ):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        report_mock = mocker.patch("ankihub.gui.ankiweb.report_exception_and_upload_logs")
+        show_dialog_mock = mocker.patch("ankihub.gui.ankiweb._show_feedback_dialog")
+        exc = AnkiHubRequestException(original_exception=ConnectionError())
+
+        error_label.set_exception(exc)
+        error_label.status.linkActivated.emit(ERROR_DIALOG_LINK)
+
+        report_mock.assert_not_called()
+        assert "Can't reach AnkiWeb" in error_label.status.text()
+        # The details are still available, just without a Sentry event ID.
+        show_dialog_mock.assert_called_once_with(exc, None)
+
+    def test_details_link_opens_error_dialog_with_sentry_event_id(self, error_label: ErrorLabel, mocker: MockerFixture):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=True)
+        mocker.patch("ankihub.gui.ankiweb.report_exception_and_upload_logs", return_value="event-id")
+        show_dialog_mock = mocker.patch("ankihub.gui.ankiweb._show_feedback_dialog")
+        open_link_mock = mocker.patch("ankihub.gui.ankiweb.openLink")
+        exc = AnkiHubRequestException(original_exception=ConnectionError())
+
+        error_label.set_exception(exc)
+        error_label.status.linkActivated.emit(ERROR_DIALOG_LINK)
+
+        show_dialog_mock.assert_called_once_with(exc, "event-id")
+        # The link is a pseudo link handled by the label itself, so it must not be
+        # opened in a browser.
+        open_link_mock.assert_not_called()
+
+    def test_details_link_does_nothing_after_the_error_was_replaced(
+        self, error_label: ErrorLabel, mocker: MockerFixture
+    ):
+        mocker.patch("ankihub.gui.ankiweb._error_reporting_enabled", return_value=False)
+        show_dialog_mock = mocker.patch("ankihub.gui.ankiweb._show_feedback_dialog")
+        error_label.set_exception(AnkiHubRequestException(original_exception=ConnectionError()))
+
+        # set_error() drops the exception the details dialog would have been about.
+        error_label.set_error("Sorry, no more emails can be sent to that address today.")
+        error_label.status.linkActivated.emit(ERROR_DIALOG_LINK)
+
+        show_dialog_mock.assert_not_called()
+
+    def test_set_error_with_empty_text_hides_the_label(self, error_label: ErrorLabel):
+        error_label.set_error("some error")
+        assert error_label.isHidden() is False
+
+        error_label.set_error("")
+        assert error_label.isHidden() is True
+
+
+@pytest.mark.skipif(using_qt5(), reason="AnkiWeb signup screens are not supported on Qt5")
+class TestAnkiwebLabelWithLink:
+    def test_widget_link_replaces_the_dialog_widget(self, qtbot: QtBot, mocker: MockerFixture):
+        open_link_mock = mocker.patch("ankihub.gui.ankiweb.openLink")
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        label = LabelWithLink("", dialog)
+        qtbot.addWidget(label)
+
+        label.linkActivated.emit(AnkiwebLinkIds.LOGIN_PASSWORD.value)
+
+        assert isinstance(dialog._widget, LoginWithPasswordWidget)
+        open_link_mock.assert_not_called()
+
+    def test_external_link_is_opened_without_a_link_handler(self, qtbot: QtBot, mocker: MockerFixture):
+        # Most labels (e.g. "Forgot password?", the terms & conditions) are created
+        # without a link handler, which used to make link activation raise.
+        open_link_mock = mocker.patch("ankihub.gui.ankiweb.openLink")
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        label = LabelWithLink("", dialog)
+        qtbot.addWidget(label)
+
+        label.linkActivated.emit("https://ankiweb.net/account/reset-password")
+
+        open_link_mock.assert_called_once_with("https://ankiweb.net/account/reset-password")
+
+    def test_external_link_is_opened_when_the_link_handler_declines(self, qtbot: QtBot, mocker: MockerFixture):
+        open_link_mock = mocker.patch("ankihub.gui.ankiweb.openLink")
+        dialog = AnkiwebLoginDialog()
+        qtbot.addWidget(dialog)
+        label = LabelWithLink("", dialog, link_handler=lambda link: False)
+        qtbot.addWidget(label)
+
+        label.linkActivated.emit("https://ankiweb.net/account/reset-password")
+
+        open_link_mock.assert_called_once_with("https://ankiweb.net/account/reset-password")
 
 
 @pytest.mark.skipif(using_qt5(), reason="AnkiWeb signup screens are not supported on Qt5")


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-215

<details>

<summary>Jira text</summary>

### Description

When the "Get code" request fails at the network layer, the sign-in dialog surfaces the raw exception (AnkiHub request exception: HTTPConnectionPool(host='ankiweb.test', port=23536): Max retries exceeded...). This is unreadable for users and gives them no idea what to do. The failure happens before any server response, so the cause is unknown — the user may be offline, or our server may be unreachable. One generic connection error covers both.

### Steps to reproduce

- Open Anki → Sign into AnkiWeb
- Disconnect from the internet (or point the client at an unreachable host)
- Enter an email and click Get code

### Current behavior

The panel shows a raw Python connection exception, including internal hostname and port.

### Expected behavior

The panel shows user-facing copy:

> Can't reach AnkiWeb.
> 
> Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down.
> 

### Acceptance criteria

- Any network-layer failure on Get code (connection refused, DNS failure, host unreachable, timeout) renders the copy above — no exception text, hostname, or port in the primary message.
- The headline wraps rather than truncates at ~45 characters.
- Errors that do come back from the server (invalid email, rate limit, expired code) keep their existing specific messages — this change only covers failures with no server response.

### Nice to have

A Details button in the error panel that opens the raw exception in Anki's existing text dialog — showText(raw_error, copyBtn=True) from qt/aqt/utils.py, which already provides Copy to Clipboard. No new design needed; it reuses an established pattern. Appending supportText() (version, Qt, platform) would give support everything it needs in one paste.

</details>

## Proposed changes

- Display a custom error message for connection errors (`AnkiHubRequestException`) rather than showing the raw exception text to the user. 
- Report connection errors to Sentry if error reporting is enabled.
- Show a link to view the full exception traceback in a dialog.

## How to reproduce

1. Set `ANKIWEB_URL` to an unreachable link or disconnect from the internet.
2. Open the new sign-in screen.
3. Enter an email then click _Get code_
4. You should see the message "Can't reach AnkiWeb. Check your connection and retry. If it keeps failing, AnkiWeb may be temporarily down. See error details", with a link to view the full exception traceback (using the existing `ErrorDialog`).

## Screenshots and videos
<img width="527" height="416" alt="Screenshot 2026-07-31 165342" src="https://github.com/user-attachments/assets/6fe4daf3-08f5-4261-98e9-bc802cd0ce1e" />
<img width="502" height="432" alt="Screenshot 2026-07-31 165406" src="https://github.com/user-attachments/assets/e37bd2e6-6b1c-4893-bda4-e374c012e5bd" />
