### PR TITLE
[NRT-866] Log which local content an import overwrites

### DIFF
--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -137,6 +137,8 @@ class _AnkiHubDeckUpdater:
             LOGGER.info("User cancelled deck update.")
             return False
 
+        _log_if_protected_fields_shrank(ankihub_did, deck_updates.protected_fields)
+
         note_types = cast(
             Dict[NotetypeId, NotetypeDict],
             self._client.get_note_types_dict_for_deck(ankihub_did),
@@ -293,6 +295,31 @@ class _AnkiHubDeckUpdater:
 
 
 ah_deck_updater = _AnkiHubDeckUpdater()
+
+
+def _log_if_protected_fields_shrank(ah_did: uuid.UUID, protected_fields: Dict[int, List[str]]) -> None:
+    """Warns when the deck updates carry less field protection than the previous sync did.
+
+    Whatever this response contains is what the import protects, so a response that drops
+    protection lets the import overwrite the user's personal content (TRIAGE-36). Users also
+    unprotect fields on the website deliberately, so this is a lead to correlate against the
+    overwrite summary, not proof of a bug. Must run before `set_globally_protected_fields`
+    replaces the stored value this compares against.
+    """
+    missing_by_mid = {
+        mid: sorted(missing)
+        for mid, names in config.globally_protected_fields(ah_did).items()
+        if (missing := set(names) - set(protected_fields.get(mid, [])))
+    }
+    if not missing_by_mid:
+        return
+
+    LOGGER.warning(
+        "Fields protected during the last sync are missing from the deck updates.",
+        ah_did=ah_did,
+        missing_protected_fields=missing_by_mid,
+        protected_fields=protected_fields,
+    )
 
 
 def show_tooltip_about_last_deck_updates_results() -> None:

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -301,10 +301,10 @@ def _log_if_protected_fields_shrank(ah_did: uuid.UUID, protected_fields: Dict[in
     """Warns when the deck updates carry less field protection than the previous sync did.
 
     Whatever this response contains is what the import protects, so a response that drops
-    protection lets the import overwrite the user's personal content (TRIAGE-36). Users also
-    unprotect fields on the website deliberately, so this is a lead to correlate against the
-    overwrite summary, not proof of a bug. Must run before `set_globally_protected_fields`
-    replaces the stored value this compares against.
+    protection lets the import overwrite the user's personal content. Users also unprotect
+    fields on the website deliberately, so this is a lead to correlate against the overwrite
+    summary, not proof of a bug. Must run before `set_globally_protected_fields` replaces the
+    stored value this compares against.
     """
     missing_by_mid = {
         mid: sorted(missing)

--- a/ankihub/gui/deck_updater.py
+++ b/ankihub/gui/deck_updater.py
@@ -297,7 +297,7 @@ class _AnkiHubDeckUpdater:
 ah_deck_updater = _AnkiHubDeckUpdater()
 
 
-def _log_if_protected_fields_shrank(ah_did: uuid.UUID, protected_fields: Dict[int, List[str]]) -> None:
+def _log_if_protected_fields_shrank(ah_did: uuid.UUID, new_protected_fields: Dict[int, List[str]]) -> None:
     """Warns when the deck updates carry less field protection than the previous sync did.
 
     Whatever this response contains is what the import protects, so a response that drops
@@ -306,10 +306,11 @@ def _log_if_protected_fields_shrank(ah_did: uuid.UUID, protected_fields: Dict[in
     summary, not proof of a bug. Must run before `set_globally_protected_fields` replaces the
     stored value this compares against.
     """
+    old_protected_fields = config.globally_protected_fields(ah_did)
     missing_by_mid = {
         mid: sorted(missing)
-        for mid, names in config.globally_protected_fields(ah_did).items()
-        if (missing := set(names) - set(protected_fields.get(mid, [])))
+        for mid, old_names in old_protected_fields.items()
+        if (missing := set(old_names) - set(new_protected_fields.get(mid, [])))
     }
     if not missing_by_mid:
         return
@@ -318,7 +319,7 @@ def _log_if_protected_fields_shrank(ah_did: uuid.UUID, protected_fields: Dict[in
         "Fields protected during the last sync are missing from the deck updates.",
         ah_did=ah_did,
         missing_protected_fields=missing_by_mid,
-        protected_fields=protected_fields,
+        protected_fields=new_protected_fields,
     )
 
 

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -60,20 +60,30 @@ MIN_ANKING_CARDS_FOR_PREVIOUS_DECK = 1000
 # How many note ids to keep per key in the summaries of overwritten content
 OVERWRITE_SAMPLE_LIMIT = 10
 
+# How many distinct keys a summary of overwritten content reports on
+OVERWRITE_KEY_LIMIT = 50
+
 
 class _OverwriteTally:
-    """Counts overwrites per key (field name or tag root) with a bounded sample of note ids.
+    """Counts overwrites per key (a field name or a tag) with a bounded sample of note ids.
 
-    A single import can overwrite content on tens of thousands of notes. The add-on log file
-    is size-capped and rotates, so keeping every note id here would push out the older log
-    history that these summaries exist to preserve.
+    A single import can overwrite content on tens of thousands of notes, and a deck-wide tag
+    reorganisation removes as many distinct tags. The add-on log file is size-capped and
+    rotates, so recording all of that would push out the older log history that these
+    summaries exist to preserve. Records beyond the key limit are counted in `omitted_count`
+    rather than dropped silently.
     """
 
     def __init__(self) -> None:
         self._counts: Dict[str, int] = {}
         self._sample_nids: Dict[str, List[NoteId]] = {}
+        self._omitted_count = 0
 
     def record(self, key: str, nid: NoteId) -> None:
+        if key not in self._counts and len(self._counts) >= OVERWRITE_KEY_LIMIT:
+            self._omitted_count += 1
+            return
+
         self._counts[key] = self._counts.get(key, 0) + 1
         sample = self._sample_nids.setdefault(key, [])
         if len(sample) < OVERWRITE_SAMPLE_LIMIT:
@@ -89,6 +99,11 @@ class _OverwriteTally:
     @property
     def sample_nids(self) -> Dict[str, List[NoteId]]:
         return self._sample_nids
+
+    @property
+    def omitted_count(self) -> int:
+        """How many records fell outside the key limit and aren't represented in `counts`."""
+        return self._omitted_count
 
 
 class NoteOperation(Enum):
@@ -462,8 +477,9 @@ class AnkiHubImporter:
             overwritten_fields_sample_nids=self._overwritten_fields.sample_nids,
             cleared_fields=self._cleared_fields.counts,
             cleared_fields_sample_nids=self._cleared_fields.sample_nids,
-            removed_tag_roots=self._removed_tags.counts,
-            removed_tag_roots_sample_nids=self._removed_tags.sample_nids,
+            removed_tags=self._removed_tags.counts,
+            removed_tags_sample_nids=self._removed_tags.sample_nids,
+            removed_tags_omitted_count=self._removed_tags.omitted_count,
             protected_fields=self._protected_fields,
             protected_tags=self._protected_tags,
             overwritten_mids_without_protection=sorted(self._overwritten_mids_without_protection),
@@ -925,14 +941,16 @@ class AnkiHubImporter:
         return changed
 
     def _record_removed_tags(self, note: Note, removed_tags: Set[str]) -> None:
-        """Records tags the import took off a note, grouped by their top-level component.
+        """Records the tags the import took off a note.
 
-        Grouping keeps the tally bounded: protection is configured per top-level tag, and
-        decks like AnKing carry thousands of distinct full tag paths.
+        Whole tags, not a prefix of them: a protected tag matches any "::"-separated component
+        of a tag, so no single component tells you why a tag went unprotected. Tags that share
+        a top-level component would collapse into one entry as well, hiding which of them the
+        note actually lost.
         """
         nid = NoteId(note.id)
-        for tag_root in {tag.split("::")[0] for tag in removed_tags}:
-            self._removed_tags.record(tag_root, nid)
+        for tag in removed_tags:
+            self._removed_tags.record(tag, nid)
 
 
 def _adjust_deck(deck_name: str, local_did: Optional[DeckId] = None) -> DeckId:

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -464,13 +464,15 @@ class AnkiHubImporter:
         nor which protection was in effect when it happened - so the protection settings are
         repeated here to keep an excerpt of this line self-contained.
         Field values are deliberately not logged; note ids are enough to inspect a report.
+
+        Logged at INFO even when content was emptied: a deck maintainer clearing a field is a
+        normal update, so this reports what happened rather than that something went wrong.
+        `cleared_fields` marks the destructive case for whoever reads the line.
         """
         if not (self._overwritten_fields or self._removed_tags):
             return
 
-        # Emptying a field the user had content in is the destructive case these reports describe.
-        log = LOGGER.warning if self._cleared_fields else LOGGER.info
-        log(
+        LOGGER.info(
             "Overwrote local content during import.",
             ah_did=self._ankihub_did,
             overwritten_fields=self._overwritten_fields.counts,

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -126,7 +126,7 @@ class AnkiHubImporter:
         self._overwritten_fields = _OverwriteTally()
         self._cleared_fields = _OverwriteTally()
         self._removed_tags = _OverwriteTally()
-        self._mids_without_protected_fields: Set[int] = set()
+        self._overwritten_mids_without_protection: Set[int] = set()
 
         self._ankihub_did: Optional[uuid.UUID] = None
         self._is_first_import_of_deck: Optional[bool] = None
@@ -185,7 +185,7 @@ class AnkiHubImporter:
         self._overwritten_fields = _OverwriteTally()
         self._cleared_fields = _OverwriteTally()
         self._removed_tags = _OverwriteTally()
-        self._mids_without_protected_fields = set()
+        self._overwritten_mids_without_protection = set()
 
         self._ankihub_did = ankihub_did
         self._is_first_import_of_deck = is_first_import_of_deck
@@ -466,7 +466,7 @@ class AnkiHubImporter:
             removed_tag_roots_sample_nids=self._removed_tags.sample_nids,
             protected_fields=self._protected_fields,
             protected_tags=self._protected_tags,
-            mids_without_protected_fields=sorted(self._mids_without_protected_fields),
+            overwritten_mids_without_protection=sorted(self._overwritten_mids_without_protection),
         )
 
     def _prepare_notes(
@@ -870,11 +870,6 @@ class AnkiHubImporter:
         changed = False
         fields_protected_by_tags = get_fields_protected_by_tags(note)
         protected_fields_for_model = protected_fields.get(aqt.mw.col.models.get(note.mid)["id"], [])
-        if protected_fields and not protected_fields_for_model:
-            # The deck has protected fields, but none for this note's note type. Recorded
-            # because a note type id that isn't a key of protected_fields silently disables
-            # global protection for the note.
-            self._mids_without_protected_fields.add(note.mid)
 
         for field_name in note.keys():
             if field_name == settings.ANKIHUB_NOTE_TYPE_FIELD_NAME:
@@ -891,17 +886,28 @@ class AnkiHubImporter:
 
             if note[field.name] != field.value:
                 if note[field.name]:
-                    self._record_field_overwrite(note, field)
+                    self._record_field_overwrite(note, field, protects_any_field=bool(protected_fields_for_model))
                 note[field.name] = field.value
                 changed = True
         return changed
 
-    def _record_field_overwrite(self, note: Note, field: Field) -> None:
-        """Records that existing local content in a field was replaced by the remote value."""
+    def _record_field_overwrite(self, note: Note, field: Field, protects_any_field: bool) -> None:
+        """Notes that a prepared change replaces existing local content in a field.
+
+        Recorded during preparation because that is the last point that still has the old
+        value, but only reported once the prepared notes have been written. The two can't
+        disagree: a note without changes has nothing to record, a new note has no local
+        content to lose, and notes to delete never get their fields prepared.
+        """
         nid = NoteId(note.id)
         self._overwritten_fields.record(field.name, nid)
         if not field.value:
             self._cleared_fields.record(field.name, nid)
+        if self._protected_fields and not protects_any_field:
+            # The deck protects fields, but none for this note's note type, and content was
+            # lost on it. A note type id that isn't a key of protected_fields silently
+            # disables global protection for the note, which looks exactly like this.
+            self._overwritten_mids_without_protection.add(note.mid)
 
     def _prepare_tags(
         self,

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -57,6 +57,39 @@ from .utils import (
 # How many cards the previous AnKing deck should at least have to be considered the previous deck
 MIN_ANKING_CARDS_FOR_PREVIOUS_DECK = 1000
 
+# How many note ids to keep per key in the summaries of overwritten content
+OVERWRITE_SAMPLE_LIMIT = 10
+
+
+class _OverwriteTally:
+    """Counts overwrites per key (field name or tag root) with a bounded sample of note ids.
+
+    A single import can overwrite content on tens of thousands of notes. The add-on log file
+    is size-capped and rotates, so keeping every note id here would push out the older log
+    history that these summaries exist to preserve.
+    """
+
+    def __init__(self) -> None:
+        self._counts: Dict[str, int] = {}
+        self._sample_nids: Dict[str, List[NoteId]] = {}
+
+    def record(self, key: str, nid: NoteId) -> None:
+        self._counts[key] = self._counts.get(key, 0) + 1
+        sample = self._sample_nids.setdefault(key, [])
+        if len(sample) < OVERWRITE_SAMPLE_LIMIT:
+            sample.append(nid)
+
+    def __bool__(self) -> bool:
+        return bool(self._counts)
+
+    @property
+    def counts(self) -> Dict[str, int]:
+        return dict(sorted(self._counts.items(), key=lambda item: item[1], reverse=True))
+
+    @property
+    def sample_nids(self) -> Dict[str, List[NoteId]]:
+        return self._sample_nids
+
 
 class NoteOperation(Enum):
     CREATE = "create"
@@ -89,6 +122,11 @@ class AnkiHubImporter:
         self._deleted_nids: List[NoteId] = []
         self._marked_as_deleted_nids: List[NoteId] = []
         self._skipped_nids: List[NoteId] = []
+
+        self._overwritten_fields = _OverwriteTally()
+        self._cleared_fields = _OverwriteTally()
+        self._removed_tags = _OverwriteTally()
+        self._mids_without_protected_fields: Set[int] = set()
 
         self._ankihub_did: Optional[uuid.UUID] = None
         self._is_first_import_of_deck: Optional[bool] = None
@@ -144,6 +182,10 @@ class AnkiHubImporter:
         self._nids_without_changes = []
         self._deleted_nids = []
         self._skipped_nids = []
+        self._overwritten_fields = _OverwriteTally()
+        self._cleared_fields = _OverwriteTally()
+        self._removed_tags = _OverwriteTally()
+        self._mids_without_protected_fields = set()
 
         self._ankihub_did = ankihub_did
         self._is_first_import_of_deck = is_first_import_of_deck
@@ -377,6 +419,7 @@ class AnkiHubImporter:
         aqt.mw.col.save()
 
         self._log_note_import_summary()
+        self._log_overwritten_content_summary()
 
     def _reset_note_types_of_notes_based_on_notes_data(self, notes_data: Sequence[NoteInfo]) -> None:
         """Set the note type of notes back to the note type they have in the remote deck if they have a different one"""
@@ -396,6 +439,34 @@ class AnkiHubImporter:
             marked_as_deleted_notes_truncated=truncated_list(self._marked_as_deleted_nids, limit=3),
             skipped_notes_count=len(self._skipped_nids),
             skipped_notes_list=truncated_list(self._skipped_nids, limit=3),
+        )
+
+    def _log_overwritten_content_summary(self) -> None:
+        """Logs which local field content and tags this import replaced.
+
+        Users report personal content vanishing after a sync and we have never been able to
+        reproduce it (TRIAGE-36). Without this, the log shows how many notes changed but not
+        what was lost, nor which protection was in effect when it happened - so the protection
+        settings are repeated here to keep an excerpt of this line self-contained.
+        Field values are deliberately not logged; note ids are enough to inspect a report.
+        """
+        if not (self._overwritten_fields or self._removed_tags):
+            return
+
+        # Emptying a field the user had content in is the destructive case these reports describe.
+        log = LOGGER.warning if self._cleared_fields else LOGGER.info
+        log(
+            "Overwrote local content during import.",
+            ah_did=self._ankihub_did,
+            overwritten_fields=self._overwritten_fields.counts,
+            overwritten_fields_sample_nids=self._overwritten_fields.sample_nids,
+            cleared_fields=self._cleared_fields.counts,
+            cleared_fields_sample_nids=self._cleared_fields.sample_nids,
+            removed_tag_roots=self._removed_tags.counts,
+            removed_tag_roots_sample_nids=self._removed_tags.sample_nids,
+            protected_fields=self._protected_fields,
+            protected_tags=self._protected_tags,
+            mids_without_protected_fields=sorted(self._mids_without_protected_fields),
         )
 
     def _prepare_notes(
@@ -798,6 +869,13 @@ class AnkiHubImporter:
 
         changed = False
         fields_protected_by_tags = get_fields_protected_by_tags(note)
+        protected_fields_for_model = protected_fields.get(aqt.mw.col.models.get(note.mid)["id"], [])
+        if protected_fields and not protected_fields_for_model:
+            # The deck has protected fields, but none for this note's note type. Recorded
+            # because a note type id that isn't a key of protected_fields silently disables
+            # global protection for the note (see TRIAGE-36).
+            self._mids_without_protected_fields.add(note.mid)
+
         for field_name in note.keys():
             if field_name == settings.ANKIHUB_NOTE_TYPE_FIELD_NAME:
                 continue
@@ -805,7 +883,6 @@ class AnkiHubImporter:
                 (f for f in fields if f.name == field_name),
                 Field(name=field_name, value=""),
             )
-            protected_fields_for_model = protected_fields.get(aqt.mw.col.models.get(note.mid)["id"], [])
             if field.name in protected_fields_for_model:
                 continue
 
@@ -813,9 +890,18 @@ class AnkiHubImporter:
                 continue
 
             if note[field.name] != field.value:
+                if note[field.name]:
+                    self._record_field_overwrite(note, field)
                 note[field.name] = field.value
                 changed = True
         return changed
+
+    def _record_field_overwrite(self, note: Note, field: Field) -> None:
+        """Records that existing local content in a field was replaced by the remote value."""
+        nid = NoteId(note.id)
+        self._overwritten_fields.record(field.name, nid)
+        if not field.value:
+            self._cleared_fields.record(field.name, nid)
 
     def _prepare_tags(
         self,
@@ -828,8 +914,19 @@ class AnkiHubImporter:
         note.tags = _updated_tags(cur_tags=note.tags, incoming_tags=tags, protected_tags=protected_tags)
         if set(prev_tags) != set(note.tags):
             changed = True
+            self._record_removed_tags(note, removed_tags=set(prev_tags) - set(note.tags))
 
         return changed
+
+    def _record_removed_tags(self, note: Note, removed_tags: Set[str]) -> None:
+        """Records tags the import took off a note, grouped by their top-level component.
+
+        Grouping keeps the tally bounded: protection is configured per top-level tag, and
+        decks like AnKing carry thousands of distinct full tag paths.
+        """
+        nid = NoteId(note.id)
+        for tag_root in {tag.split("::")[0] for tag in removed_tags}:
+            self._removed_tags.record(tag_root, nid)
 
 
 def _adjust_deck(deck_name: str, local_did: Optional[DeckId] = None) -> DeckId:

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -445,9 +445,9 @@ class AnkiHubImporter:
         """Logs which local field content and tags this import replaced.
 
         Users report personal content vanishing after a sync and we have never been able to
-        reproduce it (TRIAGE-36). Without this, the log shows how many notes changed but not
-        what was lost, nor which protection was in effect when it happened - so the protection
-        settings are repeated here to keep an excerpt of this line self-contained.
+        reproduce it. Without this, the log shows how many notes changed but not what was lost,
+        nor which protection was in effect when it happened - so the protection settings are
+        repeated here to keep an excerpt of this line self-contained.
         Field values are deliberately not logged; note ids are enough to inspect a report.
         """
         if not (self._overwritten_fields or self._removed_tags):
@@ -873,7 +873,7 @@ class AnkiHubImporter:
         if protected_fields and not protected_fields_for_model:
             # The deck has protected fields, but none for this note's note type. Recorded
             # because a note type id that isn't a key of protected_fields silently disables
-            # global protection for the note (see TRIAGE-36).
+            # global protection for the note.
             self._mids_without_protected_fields.add(note.mid)
 
         for field_name in note.keys():

--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -900,8 +900,9 @@ class AnkiHubImporter:
             if field.name in fields_protected_by_tags:
                 continue
 
-            if note[field.name] != field.value:
-                if note[field.name]:
+            current_value = note[field.name]
+            if current_value != field.value:
+                if current_value:
                     self._record_field_overwrite(note, field, protects_any_field=bool(protected_fields_for_model))
                 note[field.name] = field.value
                 changed = True
@@ -932,11 +933,12 @@ class AnkiHubImporter:
         protected_tags: List[str],
     ) -> bool:
         changed = False
-        prev_tags = note.tags
+        prev_tags = set(note.tags)
         note.tags = _updated_tags(cur_tags=note.tags, incoming_tags=tags, protected_tags=protected_tags)
-        if set(prev_tags) != set(note.tags):
+        new_tags = set(note.tags)
+        if prev_tags != new_tags:
             changed = True
-            self._record_removed_tags(note, removed_tags=set(prev_tags) - set(note.tags))
+            self._record_removed_tags(note, removed_tags=prev_tags - new_tags)
 
         return changed
 

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -30,8 +30,8 @@ def reset_local_changes_to_notes(
     protected_tags = client.get_protected_tags(ah_did=ah_did)
 
     # A reset discards local field content and tags, so support needs to be able to tell it
-    # apart from a regular sync when a user reports content loss (TRIAGE-36). It is reachable
-    # from the browser, the tutorial and the startup database check.
+    # apart from a regular sync when a user reports content loss. It is reachable from the
+    # browser, the tutorial and the startup database check.
     LOGGER.info(
         "Resetting local changes to notes...",
         ah_did=ah_did,

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -9,6 +9,7 @@ import aqt
 from anki.errors import NotFoundError
 from anki.notes import NoteId
 
+from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
@@ -27,6 +28,17 @@ def reset_local_changes_to_notes(
     client = AnkiHubClient()
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
+
+    # A reset discards local field content and tags, so support needs to be able to tell it
+    # apart from a regular sync when a user reports content loss (TRIAGE-36). It is reachable
+    # from the browser, the tutorial and the startup database check.
+    LOGGER.info(
+        "Resetting local changes to notes...",
+        ah_did=ah_did,
+        nids_count=len(nids),
+        protected_fields=protected_fields,
+        protected_tags=protected_tags,
+    )
 
     # Personal-protect tags (AnkiHub_Protect::*) block the importer's
     # `_prepare_fields` from resetting their field. Strip them so Reset actually
@@ -73,6 +85,7 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
     # so preservation and the importer's reset decisions stay in lockstep even if
     # the cached config is stale.
     changed = []
+    stripped_tag_counts: Dict[str, int] = {}
     for nid in nids:
         try:
             note = aqt.mw.col.get_note(nid)
@@ -81,7 +94,15 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
         preserved = {protection_tag_for_field(f).lower() for f in protected_fields.get(note.mid, [])}
         new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
+            for tag in set(note.tags) - set(new_tags):
+                stripped_tag_counts[tag] = stripped_tag_counts.get(tag, 0) + 1
             note.tags = new_tags
             changed.append(note)
     if changed:
         aqt.mw.col.update_notes(changed)
+
+    LOGGER.info(
+        "Stripped personal-protect tags before reset.",
+        notes_count=len(changed),
+        stripped_tags=dict(sorted(stripped_tag_counts.items(), key=lambda item: item[1], reverse=True)),
+    )

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -9,7 +9,6 @@ import aqt
 from anki.errors import NotFoundError
 from anki.notes import NoteId
 
-from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
@@ -28,17 +27,6 @@ def reset_local_changes_to_notes(
     client = AnkiHubClient()
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
-
-    # A reset discards local field content and tags, so support needs to be able to tell it
-    # apart from a regular sync when a user reports content loss. It is reachable from the
-    # browser, the tutorial and the startup database check.
-    LOGGER.info(
-        "Resetting local changes to notes...",
-        ah_did=ah_did,
-        nids_count=len(nids),
-        protected_fields=protected_fields,
-        protected_tags=protected_tags,
-    )
 
     # Personal-protect tags (AnkiHub_Protect::*) block the importer's
     # `_prepare_fields` from resetting their field. Strip them so Reset actually
@@ -85,7 +73,6 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
     # so preservation and the importer's reset decisions stay in lockstep even if
     # the cached config is stale.
     changed = []
-    stripped_tag_counts: Dict[str, int] = {}
     for nid in nids:
         try:
             note = aqt.mw.col.get_note(nid)
@@ -94,15 +81,7 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
         preserved = {protection_tag_for_field(f).lower() for f in protected_fields.get(note.mid, [])}
         new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
-            for tag in set(note.tags) - set(new_tags):
-                stripped_tag_counts[tag] = stripped_tag_counts.get(tag, 0) + 1
             note.tags = new_tags
             changed.append(note)
     if changed:
         aqt.mw.col.update_notes(changed)
-
-    LOGGER.info(
-        "Stripped personal-protect tags before reset.",
-        notes_count=len(changed),
-        stripped_tags=dict(sorted(stripped_tag_counts.items(), key=lambda item: item[1], reverse=True)),
-    )

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3596,7 +3596,7 @@ class TestAnkiHubImporter:
             assert ankihub_importer._overwritten_fields.sample_nids["Back"] == [note.id]
             # Only Back had its content emptied; Front was replaced by other content.
             assert ankihub_importer._cleared_fields.counts == {"Back": 1}
-            assert ankihub_importer._removed_tags.counts == {"Semester-1": 1}
+            assert ankihub_importer._removed_tags.counts == {"Semester-1::Week-1": 1}
 
     def test_protected_field_content_is_not_overwritten_or_tracked(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3552,23 +3552,44 @@ class TestAnkiHubImporter:
             for card in note.cards():
                 assert card.did == mw.col.decks.id_for_name("Testdeck::A::B")
 
+    def _import_updated_note(
+        self,
+        ah_did: uuid.UUID,
+        note_data: NoteInfo,
+        protected_fields: Dict[int, List[str]],
+    ) -> AnkiHubImporter:
+        """Imports note_data as an update to an existing note and returns the importer."""
+        importer = AnkiHubImporter()
+        importer.import_ankihub_deck(
+            ankihub_did=ah_did,
+            notes=[note_data],
+            deck_name="test",
+            is_first_import_of_deck=False,
+            behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+            note_types={NotetypeId(note_data.mid): ankihub_db.note_type_dict(NotetypeId(note_data.mid))},
+            protected_fields=protected_fields,
+            protected_tags=[],
+            suspend_new_cards_of_new_notes=DeckConfig.suspend_new_cards_of_new_notes_default(ah_did),
+            suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
+        )
+        return importer
+
     def test_overwritten_local_content_is_tracked(
         self,
         anki_session_with_addon_data: AnkiSession,
-        install_sample_ah_deck: InstallSampleAHDeck,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
     ):
         """The tallies behind the overwrite summary log make reports of personal content
         disappearing after a sync diagnosable from an uploaded log file."""
         with anki_session_with_addon_data.profile_loaded():
-            mw = anki_session_with_addon_data.mw
-            anki_did, ah_did = install_sample_ah_deck()
+            ah_did = install_ah_deck()
+            note_data = import_ah_note(ah_did=ah_did)
 
-            notes_data = ankihub_sample_deck_notes_data()
-            note_data = notes_data[0]
-            note = mw.col.get_note(NoteId(note_data.anki_nid))
+            note = aqt.mw.col.get_note(ankihub_db.anki_nid_for_ankihub_nid(note_data.ah_nid))
             note["Back"] = "personal content"
             note.tags = ["Semester-1::Week-1"]
-            mw.col.update_note(note)
+            aqt.mw.col.update_note(note)
 
             # The remote version changes Front, has nothing in Back and lacks the personal tag.
             note_data.fields = [
@@ -3577,65 +3598,38 @@ class TestAnkiHubImporter:
             ]
             note_data.tags = []
 
-            ankihub_importer = AnkiHubImporter()
-            ankihub_importer.import_ankihub_deck(
-                ankihub_did=ah_did,
-                notes=notes_data,
-                deck_name="test",
-                is_first_import_of_deck=False,
-                behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
-                note_types=SAMPLE_NOTE_TYPES,
-                protected_fields={},
-                protected_tags=[],
-                anki_did=anki_did,
-                suspend_new_cards_of_new_notes=DeckConfig.suspend_new_cards_of_new_notes_default(ah_did),
-                suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
-            )
+            importer = self._import_updated_note(ah_did, note_data, protected_fields={})
 
-            assert ankihub_importer._overwritten_fields.counts == {"Front": 1, "Back": 1}
-            assert ankihub_importer._overwritten_fields.sample_nids["Back"] == [note.id]
+            assert importer._overwritten_fields.counts == {"Front": 1, "Back": 1}
+            assert importer._overwritten_fields.sample_nids["Back"] == [note.id]
             # Only Back had its content emptied; Front was replaced by other content.
-            assert ankihub_importer._cleared_fields.counts == {"Back": 1}
-            assert ankihub_importer._removed_tags.counts == {"Semester-1::Week-1": 1}
+            assert importer._cleared_fields.counts == {"Back": 1}
+            assert importer._removed_tags.counts == {"Semester-1::Week-1": 1}
 
     def test_protected_field_content_is_not_overwritten_or_tracked(
         self,
         anki_session_with_addon_data: AnkiSession,
-        install_sample_ah_deck: InstallSampleAHDeck,
+        install_ah_deck: InstallAHDeck,
+        import_ah_note: ImportAHNote,
     ):
         with anki_session_with_addon_data.profile_loaded():
-            mw = anki_session_with_addon_data.mw
-            anki_did, ah_did = install_sample_ah_deck()
+            ah_did = install_ah_deck()
+            note_data = import_ah_note(ah_did=ah_did)
 
-            notes_data = ankihub_sample_deck_notes_data()
-            note_data = notes_data[0]
-            note = mw.col.get_note(NoteId(note_data.anki_nid))
+            note = aqt.mw.col.get_note(ankihub_db.anki_nid_for_ankihub_nid(note_data.ah_nid))
             note["Back"] = "personal content"
-            mw.col.update_note(note)
+            aqt.mw.col.update_note(note)
 
             note_data.fields = [
                 Field(name="Front", value="remote front"),
                 Field(name="Back", value=""),
             ]
 
-            ankihub_importer = AnkiHubImporter()
-            ankihub_importer.import_ankihub_deck(
-                ankihub_did=ah_did,
-                notes=notes_data,
-                deck_name="test",
-                is_first_import_of_deck=False,
-                behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
-                note_types=SAMPLE_NOTE_TYPES,
-                protected_fields={note.mid: ["Back"]},
-                protected_tags=[],
-                anki_did=anki_did,
-                suspend_new_cards_of_new_notes=DeckConfig.suspend_new_cards_of_new_notes_default(ah_did),
-                suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
-            )
+            importer = self._import_updated_note(ah_did, note_data, protected_fields={note.mid: ["Back"]})
 
-            assert mw.col.get_note(note.id)["Back"] == "personal content"
-            assert "Back" not in ankihub_importer._overwritten_fields.counts
-            assert note.mid not in ankihub_importer._overwritten_mids_without_protection
+            assert aqt.mw.col.get_note(note.id)["Back"] == "personal content"
+            assert "Back" not in importer._overwritten_fields.counts
+            assert note.mid not in importer._overwritten_mids_without_protection
 
     def test_import_deck_and_check_that_values_are_saved_to_databases(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3552,6 +3552,91 @@ class TestAnkiHubImporter:
             for card in note.cards():
                 assert card.did == mw.col.decks.id_for_name("Testdeck::A::B")
 
+    def test_overwritten_local_content_is_tracked(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+    ):
+        """The tallies behind the overwrite summary log make reports of personal content
+        disappearing after a sync (TRIAGE-36) diagnosable from an uploaded log file."""
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+            anki_did, ah_did = install_sample_ah_deck()
+
+            notes_data = ankihub_sample_deck_notes_data()
+            note_data = notes_data[0]
+            note = mw.col.get_note(NoteId(note_data.anki_nid))
+            note["Back"] = "personal content"
+            note.tags = ["Semester-1::Week-1"]
+            mw.col.update_note(note)
+
+            # The remote version changes Front, has nothing in Back and lacks the personal tag.
+            note_data.fields = [
+                Field(name="Front", value="remote front"),
+                Field(name="Back", value=""),
+            ]
+            note_data.tags = []
+
+            ankihub_importer = AnkiHubImporter()
+            ankihub_importer.import_ankihub_deck(
+                ankihub_did=ah_did,
+                notes=notes_data,
+                deck_name="test",
+                is_first_import_of_deck=False,
+                behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+                note_types=SAMPLE_NOTE_TYPES,
+                protected_fields={},
+                protected_tags=[],
+                anki_did=anki_did,
+                suspend_new_cards_of_new_notes=DeckConfig.suspend_new_cards_of_new_notes_default(ah_did),
+                suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
+            )
+
+            assert ankihub_importer._overwritten_fields.counts == {"Front": 1, "Back": 1}
+            assert ankihub_importer._overwritten_fields.sample_nids["Back"] == [note.id]
+            # Only Back had its content emptied; Front was replaced by other content.
+            assert ankihub_importer._cleared_fields.counts == {"Back": 1}
+            assert ankihub_importer._removed_tags.counts == {"Semester-1": 1}
+
+    def test_protected_field_content_is_not_overwritten_or_tracked(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_sample_ah_deck: InstallSampleAHDeck,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+            anki_did, ah_did = install_sample_ah_deck()
+
+            notes_data = ankihub_sample_deck_notes_data()
+            note_data = notes_data[0]
+            note = mw.col.get_note(NoteId(note_data.anki_nid))
+            note["Back"] = "personal content"
+            mw.col.update_note(note)
+
+            note_data.fields = [
+                Field(name="Front", value="remote front"),
+                Field(name="Back", value=""),
+            ]
+
+            ankihub_importer = AnkiHubImporter()
+            ankihub_importer.import_ankihub_deck(
+                ankihub_did=ah_did,
+                notes=notes_data,
+                deck_name="test",
+                is_first_import_of_deck=False,
+                behavior_on_remote_note_deleted=BehaviorOnRemoteNoteDeleted.NEVER_DELETE,
+                note_types=SAMPLE_NOTE_TYPES,
+                protected_fields={note.mid: ["Back"]},
+                protected_tags=[],
+                anki_did=anki_did,
+                suspend_new_cards_of_new_notes=DeckConfig.suspend_new_cards_of_new_notes_default(ah_did),
+                suspend_new_cards_of_existing_notes=DeckConfig.suspend_new_cards_of_existing_notes_default(),
+            )
+
+            assert mw.col.get_note(note.id)["Back"] == "personal content"
+            assert "Back" not in ankihub_importer._overwritten_fields.counts
+            assert note.mid not in ankihub_importer._mids_without_protected_fields
+
     def test_import_deck_and_check_that_values_are_saved_to_databases(
         self,
         anki_session_with_addon_data: AnkiSession,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3635,7 +3635,7 @@ class TestAnkiHubImporter:
 
             assert mw.col.get_note(note.id)["Back"] == "personal content"
             assert "Back" not in ankihub_importer._overwritten_fields.counts
-            assert note.mid not in ankihub_importer._mids_without_protected_fields
+            assert note.mid not in ankihub_importer._overwritten_mids_without_protection
 
     def test_import_deck_and_check_that_values_are_saved_to_databases(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -3558,7 +3558,7 @@ class TestAnkiHubImporter:
         install_sample_ah_deck: InstallSampleAHDeck,
     ):
         """The tallies behind the overwrite summary log make reports of personal content
-        disappearing after a sync (TRIAGE-36) diagnosable from an uploaded log file."""
+        disappearing after a sync diagnosable from an uploaded log file."""
         with anki_session_with_addon_data.profile_loaded():
             mw = anki_session_with_addon_data.mw
             anki_did, ah_did = install_sample_ah_deck()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -184,6 +184,7 @@ from ankihub.main import suggestions
 from ankihub.main.deck_creation import DeckCreationResult
 from ankihub.main.exporting import _prepared_field_html
 from ankihub.main.importing import (
+    OVERWRITE_KEY_LIMIT,
     OVERWRITE_SAMPLE_LIMIT,
     _OverwriteTally,
     _updated_tags,
@@ -739,6 +740,21 @@ class TestOverwriteTally:
 
         assert tally.counts == {"Front": len(nids)}
         assert tally.sample_nids["Front"] == nids[:OVERWRITE_SAMPLE_LIMIT]
+
+    def test_records_beyond_the_key_limit_are_counted_as_omitted(self):
+        tally = _OverwriteTally()
+        for key in range(OVERWRITE_KEY_LIMIT):
+            tally.record(f"tag_{key}", NoteId(1))
+
+        # A key already being tracked keeps counting; a new one past the limit does not.
+        tally.record("tag_0", NoteId(2))
+        tally.record("one_tag_too_many", NoteId(3))
+        tally.record("another_tag_too_many", NoteId(4))
+
+        assert len(tally.counts) == OVERWRITE_KEY_LIMIT
+        assert tally.counts["tag_0"] == 2
+        assert "one_tag_too_many" not in tally.counts
+        assert tally.omitted_count == 2
 
     def test_empty_tally_is_falsy(self):
         tally = _OverwriteTally()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -183,7 +183,11 @@ from ankihub.gui.utils import (
 from ankihub.main import suggestions
 from ankihub.main.deck_creation import DeckCreationResult
 from ankihub.main.exporting import _prepared_field_html
-from ankihub.main.importing import _updated_tags
+from ankihub.main.importing import (
+    OVERWRITE_SAMPLE_LIMIT,
+    _OverwriteTally,
+    _updated_tags,
+)
 from ankihub.main.note_conversion import (
     ADDON_INTERNAL_TAGS,
     TAG_FOR_OPTIONAL_TAGS,
@@ -715,6 +719,33 @@ def test_updated_tags():
             protected_tags=[],
         )
     ) == set([optional_tag])
+
+
+class TestOverwriteTally:
+    def test_counts_are_sorted_by_frequency(self):
+        tally = _OverwriteTally()
+        tally.record("Front", NoteId(1))
+        tally.record("Back", NoteId(2))
+        tally.record("Back", NoteId(3))
+
+        assert list(tally.counts.items()) == [("Back", 2), ("Front", 1)]
+        assert tally.sample_nids == {"Front": [1], "Back": [2, 3]}
+
+    def test_sample_nids_are_capped_but_counts_are_not(self):
+        tally = _OverwriteTally()
+        nids = [NoteId(nid) for nid in range(OVERWRITE_SAMPLE_LIMIT + 5)]
+        for nid in nids:
+            tally.record("Front", nid)
+
+        assert tally.counts == {"Front": len(nids)}
+        assert tally.sample_nids["Front"] == nids[:OVERWRITE_SAMPLE_LIMIT]
+
+    def test_empty_tally_is_falsy(self):
+        tally = _OverwriteTally()
+        assert not tally
+
+        tally.record("Front", NoteId(1))
+        assert tally
 
 
 def test_mids_of_notes(anki_session: AnkiSession):

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3940,6 +3940,9 @@ class TestFeatureFlags:
         # Assert user details kept cached value (fetch failed)
         assert config.get_user_details() == cached_user_details
 
+    # The background refresh can still be writing the private config when the test ends, which
+    # raises in the Qt event loop once pytest has removed the profile directory.
+    @pytest.mark.qt_no_exception_capture
     def test_logout_clears_caches(self, mocker: MockerFixture, qtbot: QtBot):
         """Test that logging out clears both feature flags and user details caches."""
         # Set up initial cached values (simulating previous login)


### PR DESCRIPTION
## Related issues

- [NRT-866](https://ankihub.atlassian.net/browse/NRT-866)
- [TRIAGE-36](https://ankihub.atlassian.net/browse/TRIAGE-36) (archived) — "Personal tags & Lecture notes getting deleted even after protecting the tag/field". This PR **does not close it**: it adds the diagnostics needed to find the cause the next time it's reported. Most recent report: [Missed questions protected field is deleted with updates](https://community.ankihub.net/t/missed-questions-protected-field-is-deleted-with-updates/604516)
- Companion PR: #1357 — a separate fix from the same investigation, which also carries the logging for the `reset_local_changes` path. The two are independent and can be merged in either order.

## Proposed changes

Reports of protected tags and personal field content disappearing after a sync go back to Dec 2024 and have never been reproducible. The logs today show *how many* notes an import changed, but not **which** content was replaced or **which protection was in effect** at the time, so every report dead-ends. This adds the missing signals so the next one can be diagnosed from an uploaded log instead of guesswork. Add-on behaviour is unchanged.

Everything is aggregated: an import can touch tens of thousands of notes and the log file is size-capped (3 MB × 5) and rotates, so per-note logging would push out the older history these summaries exist to preserve. **Field values are never logged** — note ids are enough to inspect a specific report.

**`ankihub/main/importing.py`** — one summary line per import of what local content it replaced:

```
Overwrote local content during import. ah_did=...
  overwritten_fields={'Front': 1, 'Back': 1} overwritten_fields_sample_nids={'Back': [1608240057545]}
  cleared_fields={'Back': 1} cleared_fields_sample_nids={'Back': [1608240057545]}
  removed_tags={'Semester-1::Week-1': 1} removed_tags_sample_nids={...} removed_tags_omitted_count=0
  protected_fields={1657023668893: ['Back']} protected_tags=[] overwritten_mids_without_protection=[]
```

- Only *destructive* changes are recorded: a field counts only if the local value was non-empty, so new notes and fills of empty fields add no noise. `cleared_fields` narrows that to content that was emptied outright.
- The protection in effect is repeated on this line so an excerpt stays self-contained even if the earlier `Importing ankihub deck...` line has rotated away.
- `overwritten_mids_without_protection` — note types that lost content while having **no entry** in `protected_fields`. A note type id that isn't a key of that dict silently disables global protection for its notes, which is one of the candidate explanations for these reports.
- Bounded by `_OverwriteTally`: at most 10 sample note ids and 50 distinct keys per tally, with anything past the key limit counted in `removed_tags_omitted_count` rather than dropped silently.

**`ankihub/gui/deck_updater.py`** — warns when deck updates carry less field protection than the previous sync stored. Whatever the response contains is *all* the import protects, so a response that silently drops protection is today indistinguishable from "the user unprotected the field". A lead to correlate against the summary above, not proof of a bug.

## How to reproduce

Covered by tests:

```
pytest tests/addon/test_unit.py -k "OverwriteTally"
pytest tests/addon/test_integration.py -k "overwritten_local_content or protected_field_content_is_not"
```

**Unrelated drive-by:** `TestFeatureFlags::test_logout_clears_caches` gets `@pytest.mark.qt_no_exception_capture`. Its background user-state refresh can still be writing the private config when the test ends, which raises in the Qt event loop after pytest has removed the temp profile and fails the run at teardown (it flaked on this branch). Same marker the suite already uses in ~17 places for this.

## Further comments

**Why aggregate instead of per-note.** A log line per overwritten field would be more useful per note but is self-defeating: a full AnKing sync would emit tens of thousands of lines into a 3 MB rotating file and evict the history we actually need, since these wipes are usually noticed days or weeks later.

**Why INFO and not WARNING.** A maintainer clearing a field is a normal deck update, so this reports what happened rather than claiming something went wrong. Nothing filters on the level anyway — the file handler is at DEBUG and Sentry's `LoggingIntegration` treats INFO and WARNING alike as breadcrumbs — while a warning that fires on ordinary syncs would train people to ignore it.

**Why no root cause is fixed here.** The investigation turned up several mechanisms that can produce this outcome (an empty protection response, a note type id missing from `protected_fields`, the reset path), but nothing in the existing logs can tell them apart after the fact — which is the whole problem. These signals are chosen to discriminate between them on the next report.

**Not a candidate for the original reports:** the auto-protect-on-edit hook. It's behind `AUTO_PROTECT_FEATURE_FLAG` and landed in NRT-748 (#1259) this year, while the reports start Dec 2024. The reset path and the database-check prompt (both 2023) do predate them.


[NRT-866]: https://ankihub.atlassian.net/browse/NRT-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRIAGE-36]: https://ankihub.atlassian.net/browse/TRIAGE-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ