### PR TITLE
[NRT-867] Don't discard personally protected content in the database check's reset

### DIFF
--- a/ankihub/gui/browser/browser.py
+++ b/ankihub/gui/browser/browser.py
@@ -510,7 +510,7 @@ def _on_reset_local_changes_action(browser: Browser, nids: Sequence[NoteId]) -> 
         tooltip("Reset local changes for selected notes.", parent=browser)
 
     aqt.mw.taskman.with_progress(
-        task=lambda: reset_local_changes_to_notes(filtered_nids, ah_did=ankihub_did),
+        task=lambda: reset_local_changes_to_notes(filtered_nids, ah_did=ankihub_did, strip_personal_protect_tags=True),
         on_done=on_done,
         label="Resetting local changes...",
         parent=browser,
@@ -597,7 +597,7 @@ def _on_reset_deck_action(browser: Browser):
         tooltip(f"Reset local changes to deck <b>{deck_config.name}</b>")
 
     aqt.mw.taskman.with_progress(
-        lambda: reset_local_changes_to_notes(nids, ah_did=ah_did),
+        lambda: reset_local_changes_to_notes(nids, ah_did=ah_did, strip_personal_protect_tags=True),
         on_done=on_done,
         label="Resetting local changes...",
         parent=browser,

--- a/ankihub/gui/operations/db_check/anki_db_check.py
+++ b/ankihub/gui/operations/db_check/anki_db_check.py
@@ -45,8 +45,7 @@ def _check_missing_ankihub_nids() -> None:
         text=(
             "AnkiHub has detected that the following deck(s) have missing values:<br>"
             f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
-            "The add-on needs to reset local changes to these decks, which reverts your edits "
-            "to fields and tags you haven't protected.<br><br>"
+            "The add-on needs to reset local changes to these decks. This may take a while.<br><br>"
             "Protected fields and tags will not be affected.<br><br>"
             "A full sync with AnkiWeb might be necessary after the reset, so it's recommended "
             "to sync changes from other devices before doing this.<br><br>"

--- a/ankihub/gui/operations/db_check/anki_db_check.py
+++ b/ankihub/gui/operations/db_check/anki_db_check.py
@@ -46,7 +46,7 @@ def _check_missing_ankihub_nids() -> None:
             "AnkiHub has detected that the following deck(s) have missing values:<br>"
             f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
             "The add-on needs to reset local changes to these decks, which reverts your edits "
-            "to fields and tags you haven't protected. This may take a while.<br><br>"
+            "to fields and tags you haven't protected.<br><br>"
             "Protected fields and tags will not be affected.<br><br>"
             "A full sync with AnkiWeb might be necessary after the reset, so it's recommended "
             "to sync changes from other devices before doing this.<br><br>"

--- a/ankihub/gui/operations/db_check/anki_db_check.py
+++ b/ankihub/gui/operations/db_check/anki_db_check.py
@@ -46,7 +46,7 @@ def _check_missing_ankihub_nids() -> None:
             "AnkiHub has detected that the following deck(s) have missing values:<br>"
             f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
             "The add-on needs to reset local changes to these decks, which reverts your edits "
-            "to fields you haven't protected. This may take a while.<br><br>"
+            "to fields and tags you haven't protected. This may take a while.<br><br>"
             "Protected fields and tags will not be affected.<br><br>"
             "A full sync with AnkiWeb might be necessary after the reset, so it's recommended "
             "to sync changes from other devices before doing this.<br><br>"

--- a/ankihub/gui/operations/db_check/anki_db_check.py
+++ b/ankihub/gui/operations/db_check/anki_db_check.py
@@ -45,7 +45,8 @@ def _check_missing_ankihub_nids() -> None:
         text=(
             "AnkiHub has detected that the following deck(s) have missing values:<br>"
             f"{'<br>'.join('<b>' + deck_name + '</b>' for deck_name in deck_names)}<br><br>"
-            "The add-on needs to reset local changes to these decks. This may take a while.<br><br>"
+            "The add-on needs to reset local changes to these decks, which reverts your edits "
+            "to fields you haven't protected. This may take a while.<br><br>"
             "Protected fields and tags will not be affected.<br><br>"
             "A full sync with AnkiWeb might be necessary after the reset, so it's recommended "
             "to sync changes from other devices before doing this.<br><br>"
@@ -119,7 +120,10 @@ def _decks_with_missing_ankihub_nids() -> List[uuid.UUID]:
 def _reset_decks(ah_dids: List[uuid.UUID]):
     for ah_did in ah_dids:
         nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-        reset_local_changes_to_notes(nids, ah_did=ah_did)
+        # The importer restores the AnkiHub ID field regardless of any protection, so this
+        # repair doesn't need the personal-protect tags stripped — and stripping them would
+        # break the promise the dialog above makes about protected fields.
+        reset_local_changes_to_notes(nids, ah_did=ah_did, strip_personal_protect_tags=False)
 
 
 def _check_ankihub_update_tags() -> None:

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1006,7 +1006,9 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
         if not self._has_cards_to_review():
             nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-            reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
+            # The tutorial resets the intro deck to have cards to show, not because the user
+            # asked to discard their edits, so their protected content stays untouched.
+            reset_local_changes_to_notes(nids=nids, ah_did=ah_did, strip_personal_protect_tags=False)
 
         self._move_to_intro_deck_overview(on_done)
 

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1006,8 +1006,9 @@ class OnboardingTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
         if not self._has_cards_to_review():
             nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-            # The tutorial resets the intro deck to have cards to show, not because the user
-            # asked to discard their edits, so their protected content stays untouched.
+            # Only reached when notes were deleted locally, since unsuspending and lifting the
+            # daily limits didn't yield enough cards. The importer recreates them, which
+            # doesn't involve protect tags.
             reset_local_changes_to_notes(nids=nids, ah_did=ah_did, strip_personal_protect_tags=False)
 
         self._move_to_intro_deck_overview(on_done)

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -101,11 +101,17 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
         new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
             for tag in set(note.tags) - set(new_tags):
-                stripped_tag_counts[tag] = stripped_tag_counts.get(tag, 0) + 1
+                # Whether a tag protects a field is decided case-insensitively, so case
+                # variants of one tag have to count as one here too.
+                key = tag.lower()
+                stripped_tag_counts[key] = stripped_tag_counts.get(key, 0) + 1
             note.tags = new_tags
             changed.append(note)
-    if changed:
-        aqt.mw.col.update_notes(changed)
+
+    if not changed:
+        return
+
+    aqt.mw.col.update_notes(changed)
 
     # Deleting a protect tag discards a user setting that nothing else records.
     LOGGER.info(

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -36,9 +36,6 @@ def reset_local_changes_to_notes(
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
 
-    # A reset discards local field content and tags, and reverts every note passed in rather
-    # than only the ones that changed remotely, so support needs to be able to tell it apart
-    # from a regular sync when a user reports content loss.
     LOGGER.info(
         "Resetting local changes to notes...",
         ah_did=ah_did,

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -9,6 +9,7 @@ import aqt
 from anki.errors import NotFoundError
 from anki.notes import NoteId
 
+from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..db import ankihub_db
 from ..settings import config
@@ -32,6 +33,18 @@ def reset_local_changes_to_notes(
     client = AnkiHubClient()
     protected_fields = client.get_protected_fields(ah_did=ah_did)
     protected_tags = client.get_protected_tags(ah_did=ah_did)
+
+    # A reset discards local field content and tags, and reverts every note passed in rather
+    # than only the ones that changed remotely, so support needs to be able to tell it apart
+    # from a regular sync when a user reports content loss.
+    LOGGER.info(
+        "Resetting local changes to notes...",
+        ah_did=ah_did,
+        nids_count=len(nids),
+        strip_personal_protect_tags=strip_personal_protect_tags,
+        protected_fields=protected_fields,
+        protected_tags=protected_tags,
+    )
 
     # Personal-protect tags (AnkiHub_Protect::*) block the importer's
     # `_prepare_fields` from resetting their field. Strip them so Reset actually
@@ -79,6 +92,7 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
     # so preservation and the importer's reset decisions stay in lockstep even if
     # the cached config is stale.
     changed = []
+    stripped_tag_counts: Dict[str, int] = {}
     for nid in nids:
         try:
             note = aqt.mw.col.get_note(nid)
@@ -87,7 +101,16 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
         preserved = {protection_tag_for_field(f).lower() for f in protected_fields.get(note.mid, [])}
         new_tags = [t for t in note.tags if not is_protect_tag(t) or t.lower() in preserved]
         if new_tags != note.tags:
+            for tag in set(note.tags) - set(new_tags):
+                stripped_tag_counts[tag] = stripped_tag_counts.get(tag, 0) + 1
             note.tags = new_tags
             changed.append(note)
     if changed:
         aqt.mw.col.update_notes(changed)
+
+    # Deleting a protect tag discards a user setting that nothing else records.
+    LOGGER.info(
+        "Stripped personal-protect tags before reset.",
+        notes_count=len(changed),
+        stripped_tags=dict(sorted(stripped_tag_counts.items(), key=lambda item: item[1], reverse=True)),
+    )

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -90,7 +90,7 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
     # `protected_fields` is the same freshly-fetched dict passed to the importer,
     # so preservation and the importer's reset decisions stay in lockstep even if
     # the cached config is stale.
-    changed = []
+    notes_with_stripped_tags = []
     stripped_tag_counts: Dict[str, int] = {}
     for nid in nids:
         try:
@@ -106,16 +106,16 @@ def _strip_personal_protect_tags(nids: Sequence[NoteId], protected_fields: Dict[
                 key = tag.lower()
                 stripped_tag_counts[key] = stripped_tag_counts.get(key, 0) + 1
             note.tags = new_tags
-            changed.append(note)
+            notes_with_stripped_tags.append(note)
 
-    if not changed:
+    if not notes_with_stripped_tags:
         return
 
-    aqt.mw.col.update_notes(changed)
+    aqt.mw.col.update_notes(notes_with_stripped_tags)
 
     # Deleting a protect tag discards a user setting that nothing else records.
     LOGGER.info(
         "Stripped personal-protect tags before reset.",
-        notes_count=len(changed),
+        notes_count=len(notes_with_stripped_tags),
         stripped_tags=dict(sorted(stripped_tag_counts.items(), key=lambda item: item[1], reverse=True)),
     )

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -20,13 +20,15 @@ from .note_conversion import is_protect_tag, protection_tag_for_field
 def reset_local_changes_to_notes(
     nids: Sequence[NoteId],
     ah_did: uuid.UUID,
-    strip_personal_protect_tags: bool = True,
+    *,
+    strip_personal_protect_tags: bool,
 ) -> None:
     # all notes have to be from the ankihub deck with the given uuid
     #
-    # Pass strip_personal_protect_tags=False for callers that reset notes to repair add-on
-    # data rather than because the user asked to discard their edits. Those callers must not
-    # touch personally protected content.
+    # strip_personal_protect_tags has no default on purpose: only a reset the user explicitly
+    # asked for may discard their protection settings. A caller that resets notes to repair
+    # add-on data or to drive an add-on flow must pass False, and inheriting either behaviour
+    # by silence is how personally protected content got discarded on startup before.
 
     deck_config = config.deck_config(ah_did)
 

--- a/ankihub/main/reset_local_changes.py
+++ b/ankihub/main/reset_local_changes.py
@@ -19,8 +19,13 @@ from .note_conversion import is_protect_tag, protection_tag_for_field
 def reset_local_changes_to_notes(
     nids: Sequence[NoteId],
     ah_did: uuid.UUID,
+    strip_personal_protect_tags: bool = True,
 ) -> None:
     # all notes have to be from the ankihub deck with the given uuid
+    #
+    # Pass strip_personal_protect_tags=False for callers that reset notes to repair add-on
+    # data rather than because the user asked to discard their edits. Those callers must not
+    # touch personally protected content.
 
     deck_config = config.deck_config(ah_did)
 
@@ -36,7 +41,8 @@ def reset_local_changes_to_notes(
     # are preserved — those fields are typically the user's personal content
     # (e.g. Lecture Notes) that should outlive a later removal of global
     # protection; same convention as the browser "Protect Fields" dialog.
-    _strip_personal_protect_tags(nids, protected_fields)
+    if strip_personal_protect_tags:
+        _strip_personal_protect_tags(nids, protected_fields)
 
     notes_data = ankihub_db.notes_data_for_anki_nids(nids)
     note_types = {

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6682,47 +6682,46 @@ def test_reset_local_changes_to_notes(
 
 def test_reset_local_changes_to_notes_without_stripping_personal_protect_tags(
     anki_session_with_addon_data: AnkiSession,
-    install_sample_ah_deck: InstallSampleAHDeck,
+    install_ah_deck: InstallAHDeck,
+    import_ah_note: ImportAHNote,
     mock_client_get_note_type: MockClientGetNoteType,
     mocker: MockerFixture,
 ):
     """The database check resets decks to repair add-on data, not because the user asked to
     discard edits, so it must leave personally protected content alone."""
     with anki_session_with_addon_data.profile_loaded():
-        mw = anki_session_with_addon_data.mw
+        ah_did = install_ah_deck()
+        note_info = import_ah_note(ah_did=ah_did)
 
-        _, ah_did = install_sample_ah_deck()
-
-        note = mw.col.get_note(NoteId(1608240029527))
+        note = aqt.mw.col.get_note(ankihub_db.anki_nid_for_ankihub_nid(note_info.ah_nid))
         note["Front"] = "changed front"
         note["Back"] = "personal content"
-        note.tags = ["AnkiHub_Protect::Back"]
-        note.flush()
+        note.tags = [f"{TAG_FOR_PROTECTING_FIELDS}::Back"]
+        aqt.mw.col.update_note(note)
 
         mocker.patch.object(AnkiHubClient, "get_protected_fields", return_value={})
         mocker.patch.object(AnkiHubClient, "get_protected_tags")
-        mock_client_get_note_type([note_type for note_type in mw.col.models.all()])
+        mock_client_get_note_type([note_type for note_type in aqt.mw.col.models.all()])
 
-        nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-        reset_local_changes_to_notes(nids=nids, ah_did=ah_did, strip_personal_protect_tags=False)
+        reset_local_changes_to_notes(nids=[note.id], ah_did=ah_did, strip_personal_protect_tags=False)
 
         # Back is personally protected: content and tag both survive, even though the field
         # is not globally protected. Front is unprotected and gets reset as usual.
         note.load()
         assert note["Back"] == "personal content"
-        assert "AnkiHub_Protect::Back" in note.tags
-        assert note["Front"] == "This is the front 1"
+        assert f"{TAG_FOR_PROTECTING_FIELDS}::Back" in note.tags
+        assert note["Front"] == note_info.fields[0].value
 
 
 def test_db_check_resets_decks_without_stripping_personal_protect_tags(
     anki_session_with_addon_data: AnkiSession,
-    install_sample_ah_deck: InstallSampleAHDeck,
+    install_ah_deck: InstallAHDeck,
     mocker: MockerFixture,
 ):
     """Pins the wiring the dialog's "Protected fields and tags will not be affected" promise
     depends on; the reset itself is covered by the test above."""
     with anki_session_with_addon_data.profile_loaded():
-        _, ah_did = install_sample_ah_deck()
+        ah_did = install_ah_deck()
 
         reset_mock = mocker.patch("ankihub.gui.operations.db_check.anki_db_check.reset_local_changes_to_notes")
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -189,6 +189,7 @@ from ankihub.gui.menu import (
 from ankihub.gui.operations import ankihub_sync
 from ankihub.gui.operations.db_check import ah_db_check
 from ankihub.gui.operations.db_check.ah_db_check import check_ankihub_db
+from ankihub.gui.operations.db_check.anki_db_check import _reset_decks
 from ankihub.gui.operations.deck_installation import download_and_install_decks
 from ankihub.gui.operations.new_deck_subscriptions import check_and_install_new_deck_subscriptions
 from ankihub.gui.operations.utils import future_with_result
@@ -6677,6 +6678,57 @@ def test_reset_local_changes_to_notes(
         assert basic_note_2.cards()
         for card in basic_note_2.cards():
             assert mw.col.decks.name(card.did) == "Testdeck"
+
+
+def test_reset_local_changes_to_notes_without_stripping_personal_protect_tags(
+    anki_session_with_addon_data: AnkiSession,
+    install_sample_ah_deck: InstallSampleAHDeck,
+    mock_client_get_note_type: MockClientGetNoteType,
+    mocker: MockerFixture,
+):
+    """The database check resets decks to repair add-on data, not because the user asked to
+    discard edits, so it must leave personally protected content alone (TRIAGE-36)."""
+    with anki_session_with_addon_data.profile_loaded():
+        mw = anki_session_with_addon_data.mw
+
+        _, ah_did = install_sample_ah_deck()
+
+        note = mw.col.get_note(NoteId(1608240029527))
+        note["Front"] = "changed front"
+        note["Back"] = "personal content"
+        note.tags = ["AnkiHub_Protect::Back"]
+        note.flush()
+
+        mocker.patch.object(AnkiHubClient, "get_protected_fields", return_value={})
+        mocker.patch.object(AnkiHubClient, "get_protected_tags")
+        mock_client_get_note_type([note_type for note_type in mw.col.models.all()])
+
+        nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+        reset_local_changes_to_notes(nids=nids, ah_did=ah_did, strip_personal_protect_tags=False)
+
+        # Back is personally protected: content and tag both survive, even though the field
+        # is not globally protected. Front is unprotected and gets reset as usual.
+        note.load()
+        assert note["Back"] == "personal content"
+        assert "AnkiHub_Protect::Back" in note.tags
+        assert note["Front"] == "This is the front 1"
+
+
+def test_db_check_resets_decks_without_stripping_personal_protect_tags(
+    anki_session_with_addon_data: AnkiSession,
+    install_sample_ah_deck: InstallSampleAHDeck,
+    mocker: MockerFixture,
+):
+    """Pins the wiring the dialog's "Protected fields and tags will not be affected" promise
+    depends on; the reset itself is covered by the test above."""
+    with anki_session_with_addon_data.profile_loaded():
+        _, ah_did = install_sample_ah_deck()
+
+        reset_mock = mocker.patch("ankihub.gui.operations.db_check.anki_db_check.reset_local_changes_to_notes")
+
+        _reset_decks([ah_did])
+
+        assert reset_mock.call_args.kwargs["strip_personal_protect_tags"] is False
 
 
 def test_migrate_profile_data_from_old_location(

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6700,7 +6700,7 @@ def test_reset_local_changes_to_notes_without_stripping_personal_protect_tags(
         aqt.mw.col.update_note(note)
 
         mocker.patch.object(AnkiHubClient, "get_protected_fields", return_value={})
-        mocker.patch.object(AnkiHubClient, "get_protected_tags")
+        mocker.patch.object(AnkiHubClient, "get_protected_tags", return_value=[])
         mock_client_get_note_type([note_type for note_type in aqt.mw.col.models.all()])
 
         reset_local_changes_to_notes(nids=[note.id], ah_did=ah_did, strip_personal_protect_tags=False)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6657,7 +6657,7 @@ def test_reset_local_changes_to_notes(
 
         # reset local changes
         nids = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-        reset_local_changes_to_notes(nids=nids, ah_did=ah_did)
+        reset_local_changes_to_notes(nids=nids, ah_did=ah_did, strip_personal_protect_tags=True)
 
         # Front: not globally protected → personal-protect tag stripped, field reset.
         # Back: globally protected → field stays edited (importer respects protected_fields)

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -6687,7 +6687,7 @@ def test_reset_local_changes_to_notes_without_stripping_personal_protect_tags(
     mocker: MockerFixture,
 ):
     """The database check resets decks to repair add-on data, not because the user asked to
-    discard edits, so it must leave personally protected content alone (TRIAGE-36)."""
+    discard edits, so it must leave personally protected content alone."""
     with anki_session_with_addon_data.profile_loaded():
         mw = anki_session_with_addon_data.mw
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3794,6 +3794,10 @@ class TestTutorialProductMetrics:
         mock_web.return_value.eval.assert_called_once()
 
 
+# These tests kick off refresh_user_state_in_background, which can still be writing the private
+# config when the test ends and then raises in the Qt event loop once pytest has removed the
+# profile directory.
+@pytest.mark.qt_no_exception_capture
 class TestFeatureFlags:
     @pytest.fixture(autouse=True)
     def setup(self):


### PR DESCRIPTION
## Related issues

- [NRT-867](https://ankihub.atlassian.net/browse/NRT-867) — found while investigating [TRIAGE-36](https://ankihub.atlassian.net/browse/TRIAGE-36), which it does **not** close (it isn't the cause of the 2024 reports — see below).
- Introduced by [NRT-769](https://ankihub.atlassian.net/browse/NRT-769) / #1292.
- Companion PR: #1356 — import-side logging from the same investigation. Independent; either order.

## Proposed changes

`_check_missing_ankihub_nids` runs on **every startup**. When a deck has notes with a missing AnkiHub ID, it offers to reset local changes for **every note in that deck**, reassuring the user that *"Protected fields and tags will not be affected"*. That stopped being true in #1292, which made `reset_local_changes_to_notes` strip personal `AnkiHub_Protect::*` tags before resetting — and those tags are what protect personal fields like Lecture Notes.

Stripping is right for the browser's **Reset local changes**: #1292's rationale is that the user deliberately overrode protection by clicking Reset and can re-add it. A reset the add-on starts by itself meets none of that, and the importer restores the AnkiHub ID field regardless of protection, so the repair never needed the tags gone.

- `reset_local_changes_to_notes` takes a keyword-only `strip_personal_protect_tags` with **no default**, so each caller states its intent. Inheriting the destructive behaviour by silence is how this bug happened; a default would rebuild that trap.
- Database check and tutorial pass `False` (the tutorial resets the intro deck to have cards to show, not because the user asked to discard edits). Both browser call sites pass `True`.
- Adds logging to the reset path, which was previously indistinguishable from a normal sync in the logs: an entry line, and a line recording which protect tags were stripped.
- **No copy changes** — with the fix, the dialog's existing promise is true again.

## How to reproduce

On `main`: protect a field locally via Browser → AnkiHub → **Protect Fields** (adds `AnkiHub_Protect::<Field>`), put personal content in it, then make the database check fire for that deck — it triggers when the AnkiHub ID field is missing or empty — and accept the dialog on restart. The tag is gone and the field is reset. With this PR both survive, while unprotected fields are still reset and the AnkiHub ID is still restored.

```
pytest tests/addon/test_integration.py -k "reset_local_changes or db_check_resets_decks"
```

Two new tests: the repair path preserves a personally protected field's content and its tag while still resetting an unprotected field; and the database check passes the flag (that module had no coverage, and the wiring is the defect). `test_reset_local_changes_to_notes` is untouched and still pins #1292's stripping for the user-triggered reset.

## Further comments

**Why a flag rather than removing the stripping.** #1292 added it for a real reason: with auto-protect-on-edit tagging every edited field, "Reset local changes" would otherwise leave exactly those fields untouched. That holds for a reset the user asked for and doesn't transfer to one the add-on starts itself, so the call sites have to differ.

**Why this isn't the root cause of TRIAGE-36.** The reports start Dec 2024; the stripping is from May 2026. The database check and `reset_local_changes` both date to 2023, so a user accepting this dialog before 2026 would still have lost unprotected edits and unprotected personal tags — just not tag-protected ones. #1356 adds the logging needed to tell whether this path is what users have been hitting.


[NRT-867]: https://ankihub.atlassian.net/browse/NRT-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRIAGE-36]: https://ankihub.atlassian.net/browse/TRIAGE-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NRT-769]: https://ankihub.atlassian.net/browse/NRT-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ