### PR TITLE
[KNW-216] Gate media sync progress dialog/button behind a feature flag

### DIFF
--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -50,6 +50,9 @@ from .utils import (
 
 SHOW_MEDIA_PROGRESS_PYCMD = "ankihub_show_media_progress"
 TOOLBAR_BUTTON_ID = "ankihub_media_sync"
+# Gates the media sync progress UI, i.e. the progress dialog and the toolbar button.
+# While it's off, the media sync only reports its status as text on the menu action.
+MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG = "media_sync_progress_ui"
 
 
 class MediaSyncStatus(Enum):
@@ -58,6 +61,10 @@ class MediaSyncStatus(Enum):
     ERROR = "Error"
     CANCELING = "Canceling..."
     IDLE = "Idle"
+
+
+def _progress_ui_enabled() -> bool:
+    return config.get_feature_flags().get(MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG, False)
 
 
 def _is_collection_error(exc: Exception) -> bool:
@@ -156,7 +163,7 @@ class _AnkiHubMediaSync:
         self._last_op_callback = lambda: self.start_media_upload(media_names, ankihub_did, on_success, is_retry=True)
 
         media_paths = self._media_paths_for_media_names(media_names)
-        self._dialog.reset_progress(len(media_paths))
+        self._reset_dialog_progress(len(media_paths))
 
         def on_failure(exception: Exception) -> None:
             self._amount_uploads_in_progress -= 1
@@ -175,7 +182,7 @@ class _AnkiHubMediaSync:
     def _on_media_chunk_uploaded(self, future: Future) -> None:
         try:
             count = future.result()
-            aqt.mw.taskman.run_on_main(lambda: self._dialog.increment_progress(count))
+            aqt.mw.taskman.run_on_main(lambda: self._increment_dialog_progress(count))
         except Exception as exc:
             self._errors.append(exc)
 
@@ -198,7 +205,7 @@ class _AnkiHubMediaSync:
 
     def close_for_profile(self):
         self.stop_background_threads()
-        self._dialog.reset_progress(0)
+        self._reset_dialog_progress(0)
 
     def refresh_sync_status(self, is_retry: bool):
         """Refresh the status text on the status action and the toolbar button."""
@@ -213,6 +220,32 @@ class _AnkiHubMediaSync:
     @cached_property
     def _dialog(self) -> "MediaSyncProgressDialog":
         return MediaSyncProgressDialog()
+
+    def _dialog_if_enabled(self) -> Optional["MediaSyncProgressDialog"]:
+        """The progress dialog, or None while the progress UI feature flag is off.
+
+        All dialog access goes through here, so that the dialog is never created for users
+        who shouldn't see it.
+        """
+        if not _progress_ui_enabled():
+            return None
+        return self._dialog
+
+    def _show_dialog(self) -> None:
+        if (dialog := self._dialog_if_enabled()) is not None:
+            dialog.show()
+
+    def _update_dialog_status(self, status: MediaSyncStatus, is_retry: bool) -> None:
+        if (dialog := self._dialog_if_enabled()) is not None:
+            dialog.update_status(status, is_retry=is_retry)
+
+    def _reset_dialog_progress(self, maximum: int) -> None:
+        if (dialog := self._dialog_if_enabled()) is not None:
+            dialog.reset_progress(maximum)
+
+    def _increment_dialog_progress(self, increment: int = 1) -> None:
+        if (dialog := self._dialog_if_enabled()) is not None:
+            dialog.increment_progress(increment)
 
     def _media_paths_for_media_names(self, media_names: Iterable[str]) -> Set[Path]:
         media_dir_path = Path(collection_or_error().media.dir())
@@ -238,7 +271,8 @@ class _AnkiHubMediaSync:
             self._update_deck_media(ankihub_did=ah_did)
             all_missing.append((ah_did, self._missing_media_for_ah_deck(ah_did)))
 
-        aqt.mw.taskman.run_on_main(lambda: self._dialog.reset_progress(sum(len(m[1]) for m in all_missing)))
+        missing_media_count = sum(len(m[1]) for m in all_missing)
+        aqt.mw.taskman.run_on_main(lambda: self._reset_dialog_progress(missing_media_count))
 
         for ah_did, missing_media_names in all_missing:
             if self._stop_background_threads:
@@ -260,7 +294,7 @@ class _AnkiHubMediaSync:
             future.result()
         except Exception as exc:
             self._errors.append(exc)
-        aqt.mw.taskman.run_on_main(lambda: self._dialog.increment_progress())
+        aqt.mw.taskman.run_on_main(lambda: self._increment_dialog_progress())
 
     def _update_deck_media(self, ankihub_did: uuid.UUID) -> None:
         """Fetch deck media updates from AnkiHub and update the database and the config.
@@ -364,7 +398,7 @@ class _AnkiHubMediaSync:
         status = self._get_status()
         self._set_status_text(status)
         self._set_toolbar_button_status(status)
-        self._dialog.update_status(status, is_retry=is_retry)
+        self._update_dialog_status(status, is_retry=is_retry)
 
     def _set_status_text(self, status: MediaSyncStatus):
         if self._status_action is None:
@@ -378,7 +412,9 @@ class _AnkiHubMediaSync:
     def _set_toolbar_button_status(self, status: MediaSyncStatus) -> None:
         elem_js = f"document.getElementById({json.dumps(TOOLBAR_BUTTON_ID)})"
         icon = media_sync_error_svg() if status == MediaSyncStatus.ERROR else media_sync_svg()
-        if status == MediaSyncStatus.IDLE:
+        # The button is also removed when the feature flag is off, so that it disappears
+        # for users who lose access to the feature while Anki is running.
+        if status == MediaSyncStatus.IDLE or not _progress_ui_enabled():
             js = """(() => {
                 const toolbarButton = %(elem_js)s;
                 if(toolbarButton) {
@@ -405,11 +441,11 @@ class _AnkiHubMediaSync:
         aqt.mw.toolbar.web.eval(js)
 
     def _on_toolbar_button_clicked(self) -> None:
-        self._dialog.show()
+        self._show_dialog()
 
     def _on_status_action_triggered(self) -> None:
         if self._get_status() != MediaSyncStatus.IDLE:
-            self._dialog.show()
+            self._show_dialog()
 
 
 class FixedDialogLayout(QVBoxLayout):

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -475,7 +475,12 @@ class _Config:
         self._private_config.show_enable_fsrs_reminder = show_remind
         self._update_private_config()
 
-    def get_feature_flags(self) -> Optional[dict]:
+    def get_feature_flags(self) -> dict:
+        # Feature flags are read from hooks which can run before the private config is set up
+        # for the profile, e.g. while the toolbar is drawn during Anki's startup. Treat flags
+        # as unset in that case instead of raising.
+        if self._private_config is None:
+            return {}
         return self._private_config.feature_flags
 
     def set_user_details(self, user_details: Optional[dict]):

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -179,7 +179,7 @@ from ankihub.gui.js_message_handling import (
     UNSUSPEND_NOTES_PYCMD,
     _post_message_to_ankihub_js,
 )
-from ankihub.gui.media_sync import media_sync
+from ankihub.gui.media_sync import MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG, media_sync
 from ankihub.gui.menu import (
     AnkiHubLogin,
     _maybe_show_onboarding_tutorial_after_login,
@@ -8298,7 +8298,10 @@ class TestSuggestionsWithMedia:
         mock_client_media_upload: Mock,
         mocker: MockerFixture,
         qtbot: QtBot,
+        set_feature_flag_state: SetFeatureFlagState,
     ):
+        set_feature_flag_state(MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG)
+
         entry_point.run()
 
         with anki_session_with_addon_data.profile_loaded():

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -141,6 +141,8 @@ from ankihub.gui.errors import (
 )
 from ankihub.gui.exceptions import DeckDownloadAndInstallError
 from ankihub.gui.media_sync import (
+    MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG,
+    TOOLBAR_BUTTON_ID,
     MediaSyncProgressDialog,
     MediaSyncStatus,
     media_sync,
@@ -495,21 +497,38 @@ class TestMediaSyncProgressDialog:
         assert dialog.isHidden() is True
 
 
+@pytest.fixture
+def media_sync_dialog_mock() -> Generator[Mock, None, None]:
+    # Assigning into __dict__ instead of using mocker.patch.object, because reading the
+    # _dialog cached_property would construct a real dialog and cache it on the singleton.
+    previous = media_sync.__dict__.get("_dialog")
+    mock = Mock()
+    media_sync.__dict__["_dialog"] = mock
+    yield mock
+    if previous is None:
+        del media_sync.__dict__["_dialog"]
+    else:
+        media_sync.__dict__["_dialog"] = previous
+
+
+def set_media_sync_progress_ui_flag(mocker: MockerFixture, is_active: bool) -> None:
+    mocker.patch.object(
+        config,
+        "get_feature_flags",
+        return_value={MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG: is_active},
+    )
+
+
 class TestMediaSyncProgressDialogUpdates:
     """Covers that the media sync keeps its progress dialog up to date."""
 
     @pytest.fixture
-    def dialog_mock(self) -> Generator[Mock, None, None]:
-        # Assigning into __dict__ instead of using mocker.patch.object, because reading the
-        # _dialog cached_property would construct a real dialog and cache it on the singleton.
-        previous = media_sync.__dict__.get("_dialog")
-        mock = Mock()
-        media_sync.__dict__["_dialog"] = mock
-        yield mock
-        if previous is None:
-            del media_sync.__dict__["_dialog"]
-        else:
-            media_sync.__dict__["_dialog"] = previous
+    def dialog_mock(self, media_sync_dialog_mock: Mock) -> Mock:
+        return media_sync_dialog_mock
+
+    @pytest.fixture(autouse=True)
+    def _enable_progress_ui(self, mocker: MockerFixture) -> None:
+        set_media_sync_progress_ui_flag(mocker, is_active=True)
 
     @pytest.fixture(autouse=True)
     def _mock_toolbar_button_status(self, mocker: MockerFixture) -> None:
@@ -561,7 +580,7 @@ class TestMediaSyncProgressDialogUpdates:
 
         media_sync._on_downloaded_file(future_with_result(None))
 
-        dialog_mock.increment_progress.assert_called_once_with()
+        dialog_mock.increment_progress.assert_called_once_with(1)
         assert media_sync._errors == []
 
     def test_failed_download_advances_the_progress_and_records_the_error(
@@ -573,7 +592,7 @@ class TestMediaSyncProgressDialogUpdates:
         media_sync._on_downloaded_file(future_with_exception(exception))
 
         # The file is done, even though it failed, so the progress has to move on.
-        dialog_mock.increment_progress.assert_called_once_with()
+        dialog_mock.increment_progress.assert_called_once_with(1)
         assert media_sync._errors == [exception]
 
     def test_uploaded_chunk_advances_the_progress_by_the_amount_of_files(
@@ -607,6 +626,95 @@ class TestMediaSyncProgressDialogUpdates:
         dialog_mock.reset_progress.assert_called_once_with(0)
         assert media_sync._canceling is True
         refresh_sync_status_mock.assert_called_once_with(False)
+
+
+class TestMediaSyncProgressUIFeatureFlag:
+    """Covers that the progress dialog and the toolbar button are gated by the feature flag."""
+
+    def test_dialog_is_not_created_while_the_flag_is_off(self, mocker: MockerFixture):
+        set_media_sync_progress_ui_flag(mocker, is_active=False)
+
+        assert media_sync._dialog_if_enabled() is None
+
+    def test_dialog_is_not_updated_while_the_flag_is_off(self, media_sync_dialog_mock: Mock, mocker: MockerFixture):
+        set_media_sync_progress_ui_flag(mocker, is_active=False)
+        mocker.patch.object(media_sync, "_set_toolbar_button_status")
+        mocker.patch.object(media_sync, "_errors", [])
+
+        media_sync._refresh_media_download_status_inner(is_retry=False)
+        media_sync._on_downloaded_file(future_with_result(None))
+        media_sync._on_media_chunk_uploaded(future_with_result(3))
+
+        assert media_sync_dialog_mock.method_calls == []
+
+    def test_toolbar_button_click_shows_the_dialog_while_the_flag_is_on(
+        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
+    ):
+        set_media_sync_progress_ui_flag(mocker, is_active=True)
+
+        media_sync._on_toolbar_button_clicked()
+
+        media_sync_dialog_mock.show.assert_called_once_with()
+
+    def test_toolbar_button_click_does_not_show_the_dialog_while_the_flag_is_off(
+        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
+    ):
+        set_media_sync_progress_ui_flag(mocker, is_active=False)
+
+        media_sync._on_toolbar_button_clicked()
+
+        media_sync_dialog_mock.show.assert_not_called()
+
+    def test_status_action_does_not_show_the_dialog_while_the_flag_is_off(
+        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
+    ):
+        set_media_sync_progress_ui_flag(mocker, is_active=False)
+        # A sync has to be in progress, otherwise the action doesn't show the dialog anyway.
+        mocker.patch.object(media_sync, "_canceling", False)
+        mocker.patch.object(media_sync, "_download_in_progress", True)
+
+        media_sync._on_status_action_triggered()
+
+        media_sync_dialog_mock.show.assert_not_called()
+
+    def test_toolbar_button_is_added_while_the_flag_is_on(self, mocker: MockerFixture):
+        set_media_sync_progress_ui_flag(mocker, is_active=True)
+        mocker.patch.object(media_sync, "_toolbar_link", f'<a id="{TOOLBAR_BUTTON_ID}"></a>', create=True)
+        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
+
+        media_sync._set_toolbar_button_status(MediaSyncStatus.DOWNLOAD)
+
+        js = toolbar_mock.web.eval.call_args.args[0]
+        assert "insertAdjacentHTML" in js
+        assert TOOLBAR_BUTTON_ID in js
+
+    def test_toolbar_button_is_removed_while_the_flag_is_off(self, mocker: MockerFixture):
+        set_media_sync_progress_ui_flag(mocker, is_active=False)
+        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
+
+        media_sync._set_toolbar_button_status(MediaSyncStatus.DOWNLOAD)
+
+        # The button is removed instead of inserted, so that it also disappears for users who
+        # lose access to the feature while Anki is running.
+        js = toolbar_mock.web.eval.call_args.args[0]
+        assert "insertAdjacentHTML" not in js
+        assert ".remove()" in js
+
+    def test_status_refresh_before_the_private_config_is_set_up(
+        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
+    ):
+        # The toolbar is drawn - and with it the status refreshed - before the private config
+        # of the profile exists, so the flag check must not raise there.
+        mocker.patch.object(config, "_private_config", None)
+        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
+        mocker.patch.object(media_sync, "_canceling", False)
+        mocker.patch.object(media_sync, "_download_in_progress", True)
+
+        media_sync._refresh_media_download_status_inner(is_retry=False)
+
+        # Without feature flags, the progress UI stays hidden.
+        assert media_sync_dialog_mock.method_calls == []
+        assert "insertAdjacentHTML" not in toolbar_mock.web.eval.call_args.args[0]
 
 
 def test_lowest_level_common_ancestor_deck_name():
@@ -3826,6 +3934,13 @@ class TestFeatureFlags:
         callback = MagicMock()
         add_user_state_refreshed_callback(callback)
         assert callback in _state.user_state_refreshed_callbacks
+
+    def test_feature_flags_are_empty_before_the_private_config_is_set_up(self, mocker: MockerFixture):
+        # Hooks can read feature flags while Anki is still starting up, before the private
+        # config of the profile exists.
+        mocker.patch.object(config, "_private_config", None)
+
+        assert config.get_feature_flags() == {}
 
     def test_offline_scenario_preserves_cached_feature_flags(self, mocker: MockerFixture, qtbot: QtBot):
         """Test that cached feature flags are preserved when server is unreachable."""


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-216


## Proposed changes

Put the new UI improvements for media sync (KNW-173) behind a feature flag named `media_sync_progress_ui`.

## How to reproduce

- Sync or install a deck with media.
- Confirm the toolbar button does not appear now as the feature flag is off by default.
- Set the flag manually in ankihub/gui/media_sync.py:_progress_ui_enabled or on staging and confirm the toolbar button is active and clicking it shows the progress dialog.

