### PR TITLE
fix: Pin asgiref and urllib3 to versions that still support Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,13 @@ bundle = [
   "structlog==24.1.0",
   "peewee==3.18.2",
   "mashumaro",
-  # We cannot use more recent versions because we still need to support Python 3.9
+  # We cannot use more recent versions because we still need to support Python 3.9.
+  # asgiref and urllib3 are transitive dependencies, but they have to be pinned here because
+  # the bundle is resolved with the build machine's Python, which is newer than 3.9.
   "django==4.2.27",
   "django-cotton>=2.5.1",
+  "asgiref<3.12",
+  "urllib3<2.7",
   "protobuf-py; python_version >= '3.10'",
 ]
 aqt = ["aqt[qt]==26.5; python_version >= '3.10'"]

--- a/uv.lock
+++ b/uv.lock
@@ -104,6 +104,7 @@ aqt-legacy = [
     { name = "pyqtwebengine" },
 ]
 bundle = [
+    { name = "asgiref" },
     { name = "django" },
     { name = "django-cotton" },
     { name = "mashumaro" },
@@ -112,6 +113,7 @@ bundle = [
     { name = "sentry-sdk" },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "urllib3" },
 ]
 dev = [
     { name = "approvaltests" },
@@ -152,6 +154,7 @@ aqt-legacy = [
     { name = "pyqtwebengine", specifier = "==5.15.2" },
 ]
 bundle = [
+    { name = "asgiref", specifier = "<3.12" },
     { name = "django", specifier = "==4.2.27" },
     { name = "django-cotton", specifier = ">=2.5.1" },
     { name = "mashumaro", git = "https://github.com/AnkiHubSoftware/mashumaro.git?branch=master" },
@@ -160,6 +163,7 @@ bundle = [
     { name = "sentry-sdk", specifier = "==1.6.0" },
     { name = "structlog", specifier = "==24.1.0" },
     { name = "tenacity", specifier = "==8.2.2" },
+    { name = "urllib3", specifier = "<2.7" },
 ]
 dev = [
     { name = "approvaltests", specifier = ">=12.2.0" },


### PR DESCRIPTION
## Problem

Users on Anki builds that run Python 3.9 cannot load the add-on at all after the `2026-08-03.1` release. It crashes during import:

```
File ".../addons21/1322529746/lib/asgiref/sync.py", line 13, in <module>
from typing import (
ImportError: cannot import name 'ParamSpec' from 'typing' (unknown location)
```

`entry_point` imports `gui/deckbrowser` → `gui/tutorial` → the bundled Django, so this is a hard failure rather than a degraded feature. The `(unknown location)` part is just an artifact of Anki's bundled stdlib, not a separate issue.

No code change in the release caused this. `scripts/build.py` vendors the `bundle` group with `uv pip install --target ankihub/lib --group bundle`, which resolves with the build machine's Python (3.13.5, from `.python-version`) and without the lockfile. `asgiref` is an unpinned transitive dependency of Django, and `asgiref` 3.12.0 (published 2026-07-14) raised its floor to Python 3.10 and dropped the `sys.version_info` guard around its `ParamSpec` import. So the release simply picked up a newer `asgiref` than the previous release did:

| Release | Bundled asgiref | `Requires-Python` |
| --- | --- | --- |
| `2026-07-01.3` | 3.11.1 | `>=3.9` |
| `2026-08-03.1` | 3.12.1 | `>=3.10` |

Verified by downloading both `.ankiaddon` artifacts, and reproduced by importing the shipped `lib/` under Python 3.9, which raises the exact error above.

CI did not catch it: the Python 3.9 test job runs `scripts/build.py` with its own 3.9 interpreter, so it vendors a 3.9-correct resolution and stays green. Only the release job (Python 3.13) produces the broken bundle.

`urllib3` has the same problem and was already latent before this release: the bundle ships 2.7.0, which also requires Python 3.10 and fails on 3.9 with `TypeError: unsupported operand type(s) for |`. It has not produced reports because `ankihub/__init__.py` inserts `lib/` at `sys.path[0]` only after Anki has already imported `requests`/`urllib3`, so the cached module wins. It is still a landmine.

## Solution

Pin both packages in the `bundle` group to the newest versions that support Python 3.9, and update `uv.lock` (the release job runs `uv sync --locked`).

Resolving the bundle group on Python 3.13 now yields `asgiref==3.11.1` and `urllib3==2.6.3` instead of `3.12.1` and `2.7.0`. Importing that bundle under Python 3.9 succeeds. `asgiref` 3.11.1 needs `typing_extensions` on Python < 3.11, which is already bundled unconditionally via `mashumaro`.

### Alternatives considered

- **Pass `--python-version 3.9` to the `uv pip install` in `scripts/build.py`** so the whole bundle resolves against the minimum supported Python. This is the most general fix, but it is not a drop-in: `uv` evaluates environment markers against that version, so `protobuf-py; python_version >= '3.10'` would be dropped and `ankihub_client/ankiweb_client.py` would lose the protobuf bundle it needs on 3.10+. It would work only if `protobuf-py` were installed in a separate step.
- **Vendor the bundle from the lockfile** (`uv sync`-style, or `uv pip install --locked`) instead of re-resolving. This removes the whole class of surprise upgrades, but the lock is resolved for the dev environment, so it needs the same marker handling as above and is a larger change to how `lib/` is produced.
- **Do nothing and pin only `asgiref`.** Rejected because the bundled `urllib3` is broken on 3.9 for the same reason and only avoids crashing by accident of import order.

Regardless of the approach, this class of bug can recur for any unpinned transitive dependency in the bundle, since the release job re-resolves on a newer Python while the Python 3.9 CI job vendors its own resolution. A follow-up guard would be a post-build assertion that every `*.dist-info/METADATA` in `ankihub/lib` declares a `Requires-Python` that admits 3.9.

## Test plan

- [x] `just lint` passes.
- [x] Resolving the `bundle` group on Python 3.13 yields `asgiref==3.11.1` and `urllib3==2.6.3`.
- [x] `from django.apps import apps`, `import asgiref`, and `import urllib3` all succeed under Python 3.9 against the pinned bundle.
- [x] Confirmed the shipped `2026-08-03.1` bundle reproduces the reported `ImportError` under Python 3.9, and that `2026-07-01.3` does not.
- [ ] After merge, cut a release and confirm the resulting `.ankiaddon` bundles `asgiref` 3.11.1 and loads on a Python 3.9 Anki build.

Made with [Cursor](https://cursor.com)