### PR TITLE
[NRT-873] Build the vendored bundle from uv.lock and guard Python 3.9 support

### DIFF
--- a/.github/actions/setup-addon/action.yml
+++ b/.github/actions/setup-addon/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Install dependencies and detect Qt version
       if: ${{ inputs.install_qt == 'true' }}
       run: |
-        uv sync --group ${{ inputs.aqt_dependency_group }}
+        uv sync --locked --group ${{ inputs.aqt_dependency_group }}
         QT_VERSION=$(uv pip show ${{ inputs.qt_package }} | sed -n 's/^Version: //p')
         echo "QT_VERSION=$QT_VERSION" >> $GITHUB_ENV
         echo "PYTEST_QT_API=${{ inputs.qt_package }}" >> $GITHUB_ENV
@@ -47,7 +47,9 @@ runs:
       run: |
         # force git to use ssh
         git config --global url."git@github.com:".insteadOf "https://github.com/"
-        uv run ./scripts/build.py
+        # --locked, or a stale lockfile is re-locked in passing and these jobs test a bundle built
+        # from a resolution nobody reviewed.
+        uv run --locked ./scripts/build.py
       shell: bash
       env:
         GOOGLE_API_KEY: ${{ inputs.google_api_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
           aqt_dependency_group: ${{ matrix.aqt_dependency_group }}
           qt_package: ${{ matrix.qt_package }}
 
+      # Only this lane has an Anki-on-3.9 environment. Its own process, because under pytest the
+      # bundle is shadowed by the development environment - see scripts/check_addon_import.py.
+      - name: Check the built add-on imports inside Anki on Python 3.9
+        if: ${{ matrix.python_version == '3.9' }}
+        run: |
+          xvfb-run -a uv run --exact --group ${{ matrix.aqt_dependency_group }} --python ${{ matrix.python_version }} python scripts/check_addon_import.py
+
       - name: Run pytest with coverage
         run: |
           xvfb-run uv run --exact --group ${{ matrix.aqt_dependency_group }} --python ${{ matrix.python_version }} pytest ./tests/addon -n 0 -m sequential --cov --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,9 @@ repos:
           - id: no_absolute_imports_from_ankihub
             name: no_absolute_imports_from_ankihub
             types: [python]
-            exclude: ^tests/
+            # Anki installs the add-on under its AnkiWeb id, so a module inside it cannot import
+            # itself as `ankihub`. Tests and build scripts are not shipped inside it and can.
+            exclude: ^(tests|scripts)/
             entry: "from ankihub([.]| import )"
             language: pygrep
           - id: no_anki_aqt_imports_in_client

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The devcontainer doesn't include the AnkiHub web app yet, so you have to use it 
 
 -   Install uv: https://docs.astral.sh/uv/getting-started/installation/
 -   Set up project environment and install dependencies:
-    -   **Default (most systems):** `uv sync --group dev --group aqt --group bundle` or `just install`
-    -   **Legacy Anki (2.1.56):** `uv sync --group dev --group aqt_legacy --group bundle` or `just install aqt_legacy`
+    -   **Default (most systems):** `uv sync --group dev --group aqt --group bundle --group bundle_modern` or `just install`
+    -   **Legacy Anki (2.1.56):** `uv sync --group dev --group aqt_legacy --group bundle --group bundle_modern` or `just install aqt_legacy`
 
     (Requires [just](https://github.com/casey/just) for the `just install` commands)
 -   Open VSCode in this repo: `code .`

--- a/ankihub/__init__.py
+++ b/ankihub/__init__.py
@@ -5,9 +5,6 @@ import sys
 lib = (pathlib.Path(__file__).parent / "lib").absolute()
 sys.path.insert(0, str(lib))
 
-lib_other = (pathlib.Path(__file__).parent / "lib/other").absolute()
-sys.path.insert(0, str(lib_other))
-
 
 import structlog
 

--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -221,6 +221,9 @@ class API(Enum):
     ANKIWEB = "ankiweb"
 
 
+# The AnkiWeb endpoints speak protobuf, and protobuf-py needs Python 3.10, so below that the
+# methods are absent and gui/ankiweb.py leaves Anki's own login dialog in place. Importing this
+# unconditionally would stop the add-on loading on the Anki versions that still ship 3.9.
 if TYPE_CHECKING or sys.version_info >= (3, 10):
     from .ankiweb_client import AnkiWebClientMixin
 else:

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ default:
 
 # Set up Python environment and install dependencies (aqt_version: aqt or aqt_legacy)
 install aqt_version="aqt":
-    uv sync --group dev --group bundle --group {{aqt_version}}
+    uv sync --group dev --group bundle --group bundle_modern --group {{aqt_version}}
 
 lint:
     uv run pre-commit run --all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,14 @@ dev = [
   "typeguard>=2.13.3",
   "types-factory-boy>=0.3.1",
   "types-requests>=2.28.9",
+  # One resolution covers every group, so this also caps the urllib3 that ships in the bundle, where
+  # sentry-sdk pulls it in as a transitive and nothing caps it.
   "urllib3>=1.26.14,<2",
   "vcrpy>=4.2.0",
   "protoc-gen-py; python_version >= '3.10'",
   "buf-bin; python_version >= '3.10'",
 ]
 bundle = [
-  # Brings urllib3, which ships too. What holds that at 1.x is the `dev` group's own
-  # `urllib3>=1.26.14,<2` - one resolution covers every group, and nothing here caps it.
   "sentry_sdk==1.6.0",
   "tenacity==8.2.2",
   "structlog==24.1.0",
@@ -50,17 +50,15 @@ bundle = [
   "django==4.2.30",
   "django-cotton>=2.5.1",
   "asgiref<3.12",
-  # Django declares tzdata only for win32, and Windows is the one platform with no system time
-  # zone database. The bundle is built on Linux and shipped to every platform, so that marker
-  # would drop it for exactly the users who need it.
+  # Django declares tzdata for win32 only, and Windows is the one platform with no system time zone
+  # database. Built on Linux and shipped everywhere, that marker drops it for the users who need it.
   "tzdata",
 ]
 # protobuf-py has required Python 3.10 since its first release, so it cannot join `bundle`, which
 # installs with 3.9. It has to ship anyway: above 3.10 ankihub_client imports the AnkiWeb client at
-# module level, so a missing copy stops the add-on loading, while below it the add-on falls back to
-# Anki's own login dialog. Anki's google.protobuf is not an alternative - its version spans 4.21 to
-# 7.x across the Anki versions supported here, and generated code cannot satisfy that whole range.
-# The marker is what lets this be locked at all, given the project supports 3.9.
+# module level, so a missing copy stops the add-on loading. Anki's own google.protobuf is no
+# alternative - it spans 4.21 to 7.x across the Anki versions supported here, and generated code
+# cannot satisfy that whole range. The marker is what lets this be locked at all.
 bundle_modern = ["protobuf-py; python_version >= '3.10'"]
 aqt = ["aqt[qt]==26.5; python_version >= '3.10'"]
 aqt_legacy = ["aqt==2.1.56", "pyqt5==5.15.2", "pyqtwebengine==5.15.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ dev = [
   "typeguard>=2.13.3",
   "types-factory-boy>=0.3.1",
   "types-requests>=2.28.9",
-  # One resolution covers every group, so this also caps the urllib3 that ships in the bundle, where
-  # sentry-sdk pulls it in as a transitive and nothing caps it.
   "urllib3>=1.26.14,<2",
   "vcrpy>=4.2.0",
   "protoc-gen-py; python_version >= '3.10'",
@@ -50,6 +48,9 @@ bundle = [
   "django==4.2.30",
   "django-cotton>=2.5.1",
   "asgiref<3.12",
+  # A transitive of sentry-sdk, which is from 2022 and predates urllib3 2.0's API changes. Not the
+  # Python floor the layers already enforce: urllib3 2.x still supports 3.9, so nothing else stops it.
+  "urllib3<2",
   # Django declares tzdata for win32 only, and Windows is the one platform with no system time zone
   # database. Built on Linux and shipped everywhere, that marker drops it for the users who need it.
   "tzdata",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
   "buf-bin; python_version >= '3.10'",
 ]
 bundle = [
+  # Brings urllib3, which ships too. What holds that at 1.x is the `dev` group's own
+  # `urllib3>=1.26.14,<2` - one resolution covers every group, and nothing here caps it.
   "sentry_sdk==1.6.0",
   "tenacity==8.2.2",
   "structlog==24.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,15 +43,23 @@ bundle = [
   "structlog==24.1.0",
   "peewee==3.18.2",
   "mashumaro",
-  # We cannot use more recent versions because we still need to support Python 3.9.
-  # asgiref and urllib3 are transitive dependencies, but they have to be pinned here because
-  # the bundle is resolved with the build machine's Python, which is newer than 3.9.
-  "django==4.2.27",
+  # Held below the releases that need Python 3.10: Anki bundles its own interpreter and the builds
+  # before 25.07 ship 3.9. asgiref is a transitive, capped here because nothing else caps it.
+  "django==4.2.30",
   "django-cotton>=2.5.1",
   "asgiref<3.12",
-  "urllib3<2.7",
-  "protobuf-py; python_version >= '3.10'",
+  # Django declares tzdata only for win32, and Windows is the one platform with no system time
+  # zone database. The bundle is built on Linux and shipped to every platform, so that marker
+  # would drop it for exactly the users who need it.
+  "tzdata",
 ]
+# protobuf-py has required Python 3.10 since its first release, so it cannot join `bundle`, which
+# installs with 3.9. It has to ship anyway: above 3.10 ankihub_client imports the AnkiWeb client at
+# module level, so a missing copy stops the add-on loading, while below it the add-on falls back to
+# Anki's own login dialog. Anki's google.protobuf is not an alternative - its version spans 4.21 to
+# 7.x across the Anki versions supported here, and generated code cannot satisfy that whole range.
+# The marker is what lets this be locked at all, given the project supports 3.9.
+bundle_modern = ["protobuf-py; python_version >= '3.10'"]
 aqt = ["aqt[qt]==26.5; python_version >= '3.10'"]
 aqt_legacy = ["aqt==2.1.56", "pyqt5==5.15.2", "pyqtwebengine==5.15.2"]
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -28,6 +28,55 @@ WEB_CSS_TARGET = PROJECT_ROOT / "tutorial" / "lib" / "vendor" / "tailwind.css"
 
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 
+OLDEST_ANKI_PYTHON = "3.9"
+
+# The oldest Python that any Anki version reaching the modern-only layer can be running.
+OLDEST_MODERN_PYTHON = "3.10"
+
+# Install each layer with the oldest Python that can reach it, so uv refuses a distribution that
+# has dropped support for it. Separate dependency groups, so routing never reads markers.
+BUNDLE_LAYERS = (("bundle", OLDEST_ANKI_PYTHON), ("bundle_modern", OLDEST_MODERN_PYTHON))
+
+
+def locked_group_requirements(group: str) -> str:
+    """A dependency group's exact contents, as recorded in uv.lock.
+
+    Resolving the group at build time instead would pick up whatever versions are current then.
+    """
+    return subprocess.run(
+        [
+            "uv",
+            "export",
+            # Without this, export re-resolves against PyPI and rewrites uv.lock. It also fails
+            # when the lockfile is out of date with pyproject.toml rather than preferring one.
+            "--locked",
+            # Without --color never the export carries ANSI escapes that uv cannot re-parse.
+            "--color",
+            "never",
+            "--only-group",
+            group,
+            "--no-emit-project",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,  # stderr stays on the console so uv explains its own failures
+        text=True,
+        cwd=PROJECT_ROOT,
+    ).stdout
+
+
+def canonical_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def requirement_names(requirements: str) -> "set[str]":
+    names = set()
+    for line in requirements.splitlines():
+        match = re.match(r"[A-Za-z0-9._-]+", line)  # continuation lines are indented
+        if match:
+            names.add(canonical_name(match.group()))
+    return names
+
+
 subprocess.run("git submodule update --init --recursive", shell=True, cwd=PROJECT_ROOT)
 
 subprocess.run(
@@ -43,18 +92,48 @@ subprocess.run(
     ],
     check=True,
 )
-subprocess.run(
-    [
-        "uv",
-        "pip",
-        "install",
-        "--target",
-        str(ANKIHUB_LIB_TARGET),
-        "--group",
-        "bundle",
-    ],
-    check=True,
-)
+layer_requirements = {group: locked_group_requirements(group) for group, _ in BUNDLE_LAYERS}
+
+# The layers install into one directory in sequence, so a distribution in both would be
+# overwritten by the later, newer-Python copy.
+shared = set.intersection(*(requirement_names(text) for text in layer_requirements.values()))
+if shared:
+    raise SystemExit(
+        f"{sorted(shared)} are in more than one bundle layer; the later install would overwrite "
+        "the copy resolved for the older Python"
+    )
+
+# uv installs over whatever the target already holds, so distributions removed since an
+# earlier build would otherwise survive into the artifact. Not ignore_errors: a partial delete
+# would leave exactly that behind.
+if ANKIHUB_LIB_TARGET.exists():
+    shutil.rmtree(ANKIHUB_LIB_TARGET)
+subprocess.run(["uv", "python", "install", *dict(BUNDLE_LAYERS).values()], check=True)
+for group, python_version in BUNDLE_LAYERS:
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            python_version,
+            "--no-deps",
+            "--target",
+            str(ANKIHUB_LIB_TARGET),
+            "-r",
+            "-",
+        ],
+        check=True,
+        input=layer_requirements[group],
+        text=True,
+    )
+
+# Drop playhouse's optional C extensions: compiled for whichever interpreter and platform ran this
+# script, so unloadable anywhere else. Nothing imports playhouse, and peewee works without them.
+for pattern in ("*.so", "*.pyd"):
+    for extension in (ANKIHUB_LIB_TARGET / "playhouse").glob(pattern):
+        extension.unlink()
+
 shutil.rmtree(ANKIHUB_LIB_TARGET / "bin", ignore_errors=True)
 # Remove large unused files from the Django package
 for path in DJANGO_TARGET.rglob("locale/*"):
@@ -62,6 +141,19 @@ for path in DJANGO_TARGET.rglob("locale/*"):
         shutil.rmtree(path, ignore_errors=True)
 shutil.rmtree(DJANGO_TARGET / "contrib" / "admin" / "static", ignore_errors=True)
 shutil.rmtree(DJANGO_TARGET / "contrib" / "gis", ignore_errors=True)
+
+# Every distribution the lock exported has to have arrived. A requirement whose marker was false for
+# the interpreter or platform building it installs nothing and reports nothing, so its absence here
+# is the only signal there is. This reads dist-info, so it catches a distribution that never
+# installed rather than one whose files a prune above removed while leaving its metadata. It does
+# mean the build host has to be one every exported requirement applies to, which for the current
+# lock means Linux, as every workflow producing an artifact uses.
+missing = set().union(*(requirement_names(text) for text in layer_requirements.values()))
+missing -= {
+    name for path in ANKIHUB_LIB_TARGET.glob("*.dist-info") for name in [canonical_name(path.name.split("-")[0])]
+}
+if missing:
+    raise SystemExit(f"{sorted(missing)} are in the lock but not in the finished bundle")
 
 
 shutil.rmtree(WEB_COMPONENTS_TARGET, ignore_errors=True)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -71,11 +71,16 @@ def canonical_name(name: str) -> str:
 def requirement_names(requirements: str) -> "set[str]":
     names = set()
     for line in requirements.splitlines():
-        # Continuation lines are indented; uv also emits option lines such as --index-url, which a
-        # leading dash would otherwise turn into a requirement named "-index-url".
+        if not line.strip() or line.startswith("#") or line[0].isspace():
+            continue  # blank, a comment, or an indented --hash continuation
+        if line.startswith("--"):
+            continue  # --index-url and friends configure the install; they add no distribution
         match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", line)
-        if match:
-            names.add(canonical_name(match.group()))
+        if not match:
+            # Skipping silently is what makes this worth raising over: an editable (-e ../pkg)
+            # installs something that every check below would then be blind to.
+            raise SystemExit(f"cannot read {line!r} as a requirement; check what uv export emitted")
+        names.add(canonical_name(match.group()))
     return names
 
 
@@ -134,27 +139,31 @@ for group, python_version in BUNDLE_LAYERS:
         text=True,
     )
 
-# One artifact ships to every interpreter and platform Anki runs on, so an extension compiled for
-# the one that installed it can only load by accident - and that is the layer's Python, 3.9 or 3.10,
-# not the build machine's. An abi3 extension is the exception: it declares an ABI stable across
-# CPython versions, which is how protobuf-py-ext ships. playhouse's are optional, so they are
-# dropped - peewee works without them and nothing imports playhouse. Anything else has to be looked
-# at before it reaches users rather than deleted quietly, since something may need it to import.
-DROPPABLE_EXTENSION_PACKAGES = ("playhouse",)
+# A compiled extension is built for one interpreter and one platform, and this one artifact ships to
+# every combination Anki runs on. abi3 answers only the first half: protobuf-py-ext's wheel is
+# cp310-abi3-manylinux_2_17_x86_64, so it still cannot load on Windows, macOS or ARM. What makes an
+# extension safe to vendor is therefore the package treating it as optional, not its tag - and both
+# of these do. protobuf-py catches the failed import and falls back to pure Python, confirmed on
+# macOS arm64, so its extension is kept for the platform it does load on. Nothing imports playhouse
+# at all, so its 2 MB are dropped. Anything else fails the build rather than being kept or deleted
+# on a guess: kept, it breaks every platform but the builder; deleted, it breaks whatever needed it.
+KEPT_EXTENSION_PACKAGES = ("protobuf_ext",)
+DROPPED_EXTENSION_PACKAGES = ("playhouse",)
 
-unloadable = []
+unaudited = []
 for pattern in ("*.so", "*.pyd"):
     for extension in ANKIHUB_LIB_TARGET.rglob(pattern):
-        if ".abi3." in extension.name:
+        package = extension.relative_to(ANKIHUB_LIB_TARGET).parts[0]
+        if package in KEPT_EXTENSION_PACKAGES:
             continue
-        if extension.relative_to(ANKIHUB_LIB_TARGET).parts[0] in DROPPABLE_EXTENSION_PACKAGES:
+        if package in DROPPED_EXTENSION_PACKAGES:
             extension.unlink()
         else:
-            unloadable.append(str(extension.relative_to(ANKIHUB_LIB_TARGET)))
-if unloadable:
+            unaudited.append(str(extension.relative_to(ANKIHUB_LIB_TARGET)))
+if unaudited:
     raise SystemExit(
-        f"{sorted(unloadable)} are compiled for one interpreter and platform, so they cannot load "
-        "on the ones this artifact ships to; vendor an abi3 wheel or drop the extension"
+        f"{sorted(unaudited)} are compiled extensions this artifact would ship to platforms they "
+        "cannot load on; confirm the package falls back without them, then list it above"
     )
 
 shutil.rmtree(ANKIHUB_LIB_TARGET / "bin", ignore_errors=True)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -71,7 +71,9 @@ def canonical_name(name: str) -> str:
 def requirement_names(requirements: str) -> "set[str]":
     names = set()
     for line in requirements.splitlines():
-        match = re.match(r"[A-Za-z0-9._-]+", line)  # continuation lines are indented
+        # Continuation lines are indented; uv also emits option lines such as --index-url, which a
+        # leading dash would otherwise turn into a requirement named "-index-url".
+        match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", line)
         if match:
             names.add(canonical_name(match.group()))
     return names
@@ -106,7 +108,11 @@ if shared:
 # uv installs over whatever the target already holds, so distributions removed since an
 # earlier build would otherwise survive into the artifact. Not ignore_errors: a partial delete
 # would leave exactly that behind.
-if ANKIHUB_LIB_TARGET.exists():
+if ANKIHUB_LIB_TARGET.is_symlink():
+    # Worktrees set up for running Anki point this at the main checkout's copy, and installing
+    # through it would write there instead. rmtree refuses a symlink with an errno-less OSError.
+    ANKIHUB_LIB_TARGET.unlink()
+elif ANKIHUB_LIB_TARGET.exists():
     shutil.rmtree(ANKIHUB_LIB_TARGET)
 subprocess.run(["uv", "python", "install", *dict(BUNDLE_LAYERS).values()], check=True)
 for group, python_version in BUNDLE_LAYERS:
@@ -128,11 +134,28 @@ for group, python_version in BUNDLE_LAYERS:
         text=True,
     )
 
-# Drop playhouse's optional C extensions: compiled for whichever interpreter and platform ran this
-# script, so unloadable anywhere else. Nothing imports playhouse, and peewee works without them.
+# One artifact ships to every interpreter and platform Anki runs on, so an extension compiled for
+# the one that installed it can only load by accident - and that is the layer's Python, 3.9 or 3.10,
+# not the build machine's. An abi3 extension is the exception: it declares an ABI stable across
+# CPython versions, which is how protobuf-py-ext ships. playhouse's are optional, so they are
+# dropped - peewee works without them and nothing imports playhouse. Anything else has to be looked
+# at before it reaches users rather than deleted quietly, since something may need it to import.
+DROPPABLE_EXTENSION_PACKAGES = ("playhouse",)
+
+unloadable = []
 for pattern in ("*.so", "*.pyd"):
-    for extension in (ANKIHUB_LIB_TARGET / "playhouse").glob(pattern):
-        extension.unlink()
+    for extension in ANKIHUB_LIB_TARGET.rglob(pattern):
+        if ".abi3." in extension.name:
+            continue
+        if extension.relative_to(ANKIHUB_LIB_TARGET).parts[0] in DROPPABLE_EXTENSION_PACKAGES:
+            extension.unlink()
+        else:
+            unloadable.append(str(extension.relative_to(ANKIHUB_LIB_TARGET)))
+if unloadable:
+    raise SystemExit(
+        f"{sorted(unloadable)} are compiled for one interpreter and platform, so they cannot load "
+        "on the ones this artifact ships to; vendor an abi3 wheel or drop the extension"
+    )
 
 shutil.rmtree(ANKIHUB_LIB_TARGET / "bin", ignore_errors=True)
 # Remove large unused files from the Django package

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -81,11 +81,17 @@ def requirement_names(requirements: str) -> "set[str]":
 
 subprocess.run("git submodule update --init --recursive", shell=True, cwd=PROJECT_ROOT)
 
+subprocess.run(["uv", "python", "install", *dict(BUNDLE_LAYERS).values()], check=True)
+
+# media_import's requirements are not in uv.lock - the submodule carries its own requirements.txt -
+# but they ship in the same artifact, so they install with the same oldest interpreter.
 subprocess.run(
     [
         "uv",
         "pip",
         "install",
+        "--python",
+        OLDEST_ANKI_PYTHON,
         "--no-deps",
         "--target",
         str(MEDIA_IMPORT_LIBS),
@@ -114,7 +120,6 @@ if ANKIHUB_LIB_TARGET.is_symlink():
     ANKIHUB_LIB_TARGET.unlink()
 elif ANKIHUB_LIB_TARGET.exists():
     shutil.rmtree(ANKIHUB_LIB_TARGET)
-subprocess.run(["uv", "python", "install", *dict(BUNDLE_LAYERS).values()], check=True)
 for group, python_version in BUNDLE_LAYERS:
     subprocess.run(
         [

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -29,28 +29,23 @@ WEB_CSS_TARGET = PROJECT_ROOT / "tutorial" / "lib" / "vendor" / "tailwind.css"
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 
 OLDEST_ANKI_PYTHON = "3.9"
-
-# The oldest Python that any Anki version reaching the modern-only layer can be running.
 OLDEST_MODERN_PYTHON = "3.10"
 
-# Install each layer with the oldest Python that can reach it, so uv refuses a distribution that
-# has dropped support for it. Separate dependency groups, so routing never reads markers.
+# Each layer installs with the oldest Python that can reach it, so uv refuses a distribution that has
+# dropped support for it. They are separate dependency groups so that routing never reads markers.
 BUNDLE_LAYERS = (("bundle", OLDEST_ANKI_PYTHON), ("bundle_modern", OLDEST_MODERN_PYTHON))
 
 
 def locked_group_requirements(group: str) -> str:
-    """A dependency group's exact contents, as recorded in uv.lock.
-
-    Resolving the group at build time instead would pick up whatever versions are current then.
-    """
+    """Resolving the group at build time instead would pick up whatever versions are current then."""
     return subprocess.run(
         [
             "uv",
             "export",
-            # Without this, export re-resolves against PyPI and rewrites uv.lock. It also fails
-            # when the lockfile is out of date with pyproject.toml rather than preferring one.
+            # Without this, export re-resolves against PyPI and rewrites uv.lock. It also fails on a
+            # lockfile out of date with pyproject.toml rather than silently preferring one.
             "--locked",
-            # Without --color never the export carries ANSI escapes that uv cannot re-parse.
+            # Without it the export carries ANSI escapes that uv cannot re-parse.
             "--color",
             "never",
             "--only-group",
@@ -58,7 +53,7 @@ def locked_group_requirements(group: str) -> str:
             "--no-emit-project",
         ],
         check=True,
-        stdout=subprocess.PIPE,  # stderr stays on the console so uv explains its own failures
+        stdout=subprocess.PIPE,
         text=True,
         cwd=PROJECT_ROOT,
     ).stdout
@@ -72,13 +67,13 @@ def requirement_names(requirements: str) -> "set[str]":
     names = set()
     for line in requirements.splitlines():
         if not line.strip() or line.startswith("#") or line[0].isspace():
-            continue  # blank, a comment, or an indented --hash continuation
+            continue  # an indented line continues the one above it, carrying --hash
         if line.startswith("--"):
-            continue  # --index-url and friends configure the install; they add no distribution
+            continue  # --index-url and friends install nothing of their own
         match = re.match(r"[A-Za-z0-9][A-Za-z0-9._-]*", line)
         if not match:
-            # Skipping silently is what makes this worth raising over: an editable (-e ../pkg)
-            # installs something that every check below would then be blind to.
+            # Skipped instead, an editable (-e ../pkg) would install something every check below
+            # is then blind to.
             raise SystemExit(f"cannot read {line!r} as a requirement; check what uv export emitted")
         names.add(canonical_name(match.group()))
     return names
@@ -114,8 +109,8 @@ if shared:
 # earlier build would otherwise survive into the artifact. Not ignore_errors: a partial delete
 # would leave exactly that behind.
 if ANKIHUB_LIB_TARGET.is_symlink():
-    # Worktrees set up for running Anki point this at the main checkout's copy, and installing
-    # through it would write there instead. rmtree refuses a symlink with an errno-less OSError.
+    # Worktrees set up for running Anki point this at the main checkout's copy, which installing
+    # through would write to. rmtree refuses a symlink with an errno-less OSError.
     ANKIHUB_LIB_TARGET.unlink()
 elif ANKIHUB_LIB_TARGET.exists():
     shutil.rmtree(ANKIHUB_LIB_TARGET)
@@ -139,14 +134,11 @@ for group, python_version in BUNDLE_LAYERS:
         text=True,
     )
 
-# A compiled extension is built for one interpreter and one platform, and this one artifact ships to
-# every combination Anki runs on. abi3 answers only the first half: protobuf-py-ext's wheel is
-# cp310-abi3-manylinux_2_17_x86_64, so it still cannot load on Windows, macOS or ARM. What makes an
-# extension safe to vendor is therefore the package treating it as optional, not its tag - and both
-# of these do. protobuf-py catches the failed import and falls back to pure Python, confirmed on
-# macOS arm64, so its extension is kept for the platform it does load on. Nothing imports playhouse
-# at all, so its 2 MB are dropped. Anything else fails the build rather than being kept or deleted
-# on a guess: kept, it breaks every platform but the builder; deleted, it breaks whatever needed it.
+# A compiled extension is built for one interpreter and one platform; this artifact ships to every
+# combination Anki runs on. abi3 covers only the interpreter half - protobuf-py-ext's wheel is
+# cp310-abi3-manylinux_2_17_x86_64, unloadable on Windows, macOS or ARM. So what earns a place is the
+# package falling back without it: protobuf-py catches the failed import, and nothing imports
+# playhouse at all, so its copies are dropped instead of kept.
 KEPT_EXTENSION_PACKAGES = ("protobuf_ext",)
 DROPPED_EXTENSION_PACKAGES = ("playhouse",)
 
@@ -174,12 +166,10 @@ for path in DJANGO_TARGET.rglob("locale/*"):
 shutil.rmtree(DJANGO_TARGET / "contrib" / "admin" / "static", ignore_errors=True)
 shutil.rmtree(DJANGO_TARGET / "contrib" / "gis", ignore_errors=True)
 
-# Every distribution the lock exported has to have arrived. A requirement whose marker was false for
-# the interpreter or platform building it installs nothing and reports nothing, so its absence here
-# is the only signal there is. This reads dist-info, so it catches a distribution that never
-# installed rather than one whose files a prune above removed while leaving its metadata. It does
-# mean the build host has to be one every exported requirement applies to, which for the current
-# lock means Linux, as every workflow producing an artifact uses.
+# A requirement whose marker was false for the interpreter or platform building it installs nothing
+# and reports nothing, so its absence here is the only signal there is. Reading dist-info rather than
+# files catches one that never installed, not one whose files a prune above removed. It does mean the
+# build host has to be one every exported requirement applies to - Linux, for the current lock.
 missing = set().union(*(requirement_names(text) for text in layer_requirements.values()))
 missing -= {
     name for path in ANKIHUB_LIB_TARGET.glob("*.dist-info") for name in [canonical_name(path.name.split("-")[0])]

--- a/scripts/check_addon_import.py
+++ b/scripts/check_addon_import.py
@@ -9,9 +9,8 @@ import django, asgiref and urllib3 from the development environment before `impo
 the bundle, so the bundled copies are shadowed there and never exercised.
 
 scripts/build.py installs each layer with the oldest Python that can reach it, so a distribution
-declaring a newer floor cannot be installed at all. What that cannot show is whether the result
-imports: a distribution can declare 3.9 and still use newer syntax, and peewee and sentry_sdk
-declare no floor to check.
+declaring a newer floor cannot be installed at all. That covers declared floors only: a distribution
+can declare 3.9 and still not import on it, and peewee and sentry_sdk declare no floor at all.
 """
 
 import os
@@ -22,10 +21,9 @@ PROJECT_ROOT = Path(__file__).parent.parent
 BUNDLE = PROJECT_ROOT / "ankihub" / "lib"
 TARGET_PYTHON = (3, 9)
 
-# Installed for Python 3.10 and above, which is also where the add-on gates its own use of them.
 # Written out rather than derived from the bundle_modern group, because neither way of drifting from
-# it is silent: a module missing from here is imported with the rest and fails, and one that does
-# not belong here is caught by importable_modern_only_modules().
+# it is silent: a module missing from here is imported with the rest and fails, and one that does not
+# belong here is caught by importable_modern_only_modules().
 MODERN_ONLY_MODULES = ("protobuf", "protobuf_ext")
 
 
@@ -34,7 +32,6 @@ def target_python() -> str:
 
 
 def bundle_top_level_modules():
-    """Every name the bundle offers to `import`."""
     for entry in sorted(BUNDLE.iterdir()):
         if entry.name.endswith(".dist-info") or entry.name in ("bin", "__pycache__"):
             continue
@@ -51,10 +48,9 @@ def loaded_top_level_names() -> set:
 def load_addon() -> None:
     """Import the add-on as Anki would, without starting it.
 
-    This is also what puts the bundle within reach: ankihub/__init__.py prepends ankihub/lib to
-    sys.path. Importing entry_point then pulls in the part of the bundle the add-on itself uses,
-    which is how asgiref.sync comes to be loaded. Nothing checked after this means anything
-    without it.
+    This is what puts the bundle within reach at all: ankihub/__init__.py prepends ankihub/lib to
+    sys.path, and importing entry_point pulls in the part of it the add-on uses, which is how
+    asgiref.sync comes to be loaded. Nothing checked after this means anything without it.
     """
     sys.path.insert(0, str(PROJECT_ROOT))
     os.environ["SKIP_INIT"] = "1"  # entry_point.run() needs a running Anki; importing is enough
@@ -80,11 +76,10 @@ def wrong_bundle_module_origins(vendored, from_anki) -> list:
 def unparsable_bundle_modules() -> list:
     """Bundle modules the target Python cannot even parse.
 
-    The checks around this one reach a module only if something imports it, which for most of the
-    bundle means the add-on's own import graph - `asgiref.sync` is covered because Django's template
-    stack happens to pull it in. Parsing reaches every file regardless. It is the weaker signal of
-    the two: it catches syntax a release started using, not the `from typing import ParamSpec` kind
-    of break, which parses on 3.9 and fails on import.
+    The checks around this one reach a module only if something imports it - asgiref.sync is covered
+    because Django's template stack pulls it in, not because asgiref is vendored. Parsing reaches
+    every file, but catches only syntax a release started using: `from typing import ParamSpec`, the
+    break this whole script exists for, parses on 3.9 and fails on import.
     """
     problems = []
     for path in sorted(BUNDLE.rglob("*.py")):
@@ -116,9 +111,8 @@ def importable_modern_only_modules() -> list:
 def django_rendering_problems() -> list:
     """Render through the add-on's own Django setup, rather than a copy of its configuration.
 
-    Importing entry_point configures the template engine, which is what pulls in Django's template
-    stack and with it asgiref.sync. Rendering as well runs django_cotton's compiler over the input.
-    It renders plain HTML, not a component, so the component loader itself is not covered.
+    Rendering runs django_cotton's compiler over the input. It renders plain HTML, not a component,
+    so the component loader itself is not covered.
     """
     from ankihub.django import render_template_from_string
 
@@ -147,7 +141,6 @@ def main() -> int:
 
     from_anki = vendored & loaded_top_level_names()
 
-    # Loads the bundle modules, which is what the checks below inspect.
     load_addon()
 
     failures = (

--- a/scripts/check_addon_import.py
+++ b/scripts/check_addon_import.py
@@ -1,0 +1,148 @@
+"""Import the built add-on the way Anki does, on the oldest Python Anki ships.
+
+Run from the repository root, in its own process, with Anki installed:
+
+    uv run --exact --group aqt_legacy --python 3.9 python scripts/check_addon_import.py
+
+The test suite cannot do this even though it runs the add-on on 3.9. Pytest plugins and factory-boy
+import django, asgiref and urllib3 from the development environment before `import ankihub` prepends
+the bundle, so the bundled copies are shadowed there and never exercised.
+
+scripts/build.py installs each layer with the oldest Python that can reach it, so a distribution
+declaring a newer floor cannot be installed at all. What that cannot show is whether the result
+imports: a distribution can declare 3.9 and still use newer syntax, and peewee and sentry_sdk
+declare no floor to check.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+BUNDLE = PROJECT_ROOT / "ankihub" / "lib"
+TARGET_PYTHON = (3, 9)
+
+# Installed for Python 3.10 and above, which is also where the add-on gates its own use of them.
+# Written out rather than derived from the bundle_modern group, because neither way of drifting from
+# it is silent: a module missing from here is imported with the rest and fails, and one that does
+# not belong here is caught by importable_modern_only_modules().
+MODERN_ONLY_MODULES = ("protobuf", "protobuf_ext")
+
+
+def target_python() -> str:
+    return ".".join(str(part) for part in TARGET_PYTHON)
+
+
+def bundle_top_level_modules():
+    """Every name the bundle offers to `import`."""
+    for entry in sorted(BUNDLE.iterdir()):
+        if entry.name.endswith(".dist-info") or entry.name in ("bin", "__pycache__"):
+            continue
+        if entry.is_dir() and (entry / "__init__.py").exists():
+            yield entry.name
+        elif entry.suffix == ".py":
+            yield entry.stem
+
+
+def loaded_top_level_names() -> set:
+    return {name.split(".")[0] for name in sys.modules}
+
+
+def load_addon() -> None:
+    """Import the add-on as Anki would, without starting it.
+
+    This is also what puts the bundle within reach: ankihub/__init__.py prepends ankihub/lib to
+    sys.path. Importing entry_point then pulls in the part of the bundle the add-on itself uses,
+    which is how asgiref.sync comes to be loaded. Nothing checked after this means anything
+    without it.
+    """
+    sys.path.insert(0, str(PROJECT_ROOT))
+    os.environ["SKIP_INIT"] = "1"  # entry_point.run() needs a running Anki; importing is enough
+
+    import ankihub  # noqa: F401
+    import ankihub.entry_point  # noqa: F401
+
+
+def wrong_bundle_module_origins(vendored, from_anki) -> list:
+    """Modules resolving from somewhere other than the copy that should win."""
+    bundle = str(BUNDLE.resolve())
+    problems = []
+    for name in sorted(vendored):
+        origin = str(Path(__import__(name, fromlist=["__file__"]).__file__).resolve())
+        if name in from_anki:
+            if origin.startswith(bundle):
+                problems.append(f"{name} came from the bundle even though Anki had already imported it")
+        elif not origin.startswith(bundle):
+            problems.append(f"{name} came from {origin}, not the bundle")
+    return problems
+
+
+def importable_modern_only_modules() -> list:
+    """Modern-only modules that turn out to import here after all.
+
+    Skipping something importable would quietly narrow every assertion above, so each skip has to
+    earn itself. Forgetting one needs no check: it gets imported with the rest and fails.
+    """
+    problems = []
+    for name in MODERN_ONLY_MODULES:
+        try:
+            __import__(name)
+        except Exception:  # noqa: BLE001 - any failure at all means the skip was warranted
+            continue
+        problems.append(f"{name} imports on Python {target_python()} after all, so it should not be skipped")
+    return problems
+
+
+def django_rendering_problems() -> list:
+    """Render through the add-on's own Django setup, rather than a copy of its configuration.
+
+    Importing entry_point configures the template engine, which is what pulls in Django's template
+    stack and with it asgiref.sync. Rendering as well runs django_cotton's compiler over the input.
+    It renders plain HTML, not a component, so the component loader itself is not covered.
+    """
+    from ankihub.django import render_template_from_string
+
+    rendered = render_template_from_string("<div>{{ value }}</div>", {"value": "rendered"})
+    if "rendered" not in rendered:
+        return [f"rendering a template produced unexpected output: {rendered!r}"]
+    return []
+
+
+def main() -> int:
+    if sys.version_info[:2] != TARGET_PYTHON:
+        sys.exit(f"must run on Python {target_python()}, got {'.'.join(str(p) for p in sys.version_info[:3])}")
+
+    if not BUNDLE.is_dir():
+        sys.exit(f"no vendored bundle at {BUNDLE}; run scripts/build.py first")
+
+    vendored = set(bundle_top_level_modules()) - set(MODERN_ONLY_MODULES)
+
+    already_loaded = vendored & loaded_top_level_names()
+    if already_loaded:
+        sys.exit(f"{sorted(already_loaded)} were imported before this check ran, so it would prove nothing")
+
+    # Anki imports its own HTTP stack while loading the add-on manager, before any add-on runs, and
+    # whatever it has loaded by then wins over the bundle for the rest of the process.
+    import aqt.addons  # noqa: F401
+
+    from_anki = vendored & loaded_top_level_names()
+
+    # Loads the bundle modules, which is what the checks below inspect.
+    load_addon()
+
+    failures = wrong_bundle_module_origins(vendored, from_anki) + importable_modern_only_modules()
+    if not failures:
+        failures += django_rendering_problems()  # only meaningful once the origins are right
+
+    if failures:
+        print("the built add-on did not load as expected:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"the built add-on imports and renders on Python {target_python()} under aqt {aqt.appVersion}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_addon_import.py
+++ b/scripts/check_addon_import.py
@@ -95,8 +95,7 @@ def unparsable_bundle_modules() -> list:
 def importable_modern_only_modules() -> list:
     """Modern-only modules that turn out to import here after all.
 
-    Skipping something importable would quietly narrow every assertion above, so each skip has to
-    earn itself. Forgetting one needs no check: it gets imported with the rest and fails.
+    A skip that was not warranted would quietly narrow every assertion above.
     """
     problems = []
     for name in MODERN_ONLY_MODULES:

--- a/scripts/check_addon_import.py
+++ b/scripts/check_addon_import.py
@@ -77,6 +77,26 @@ def wrong_bundle_module_origins(vendored, from_anki) -> list:
     return problems
 
 
+def unparsable_bundle_modules() -> list:
+    """Bundle modules the target Python cannot even parse.
+
+    The checks around this one reach a module only if something imports it, which for most of the
+    bundle means the add-on's own import graph - `asgiref.sync` is covered because Django's template
+    stack happens to pull it in. Parsing reaches every file regardless. It is the weaker signal of
+    the two: it catches syntax a release started using, not the `from typing import ParamSpec` kind
+    of break, which parses on 3.9 and fails on import.
+    """
+    problems = []
+    for path in sorted(BUNDLE.rglob("*.py")):
+        if path.relative_to(BUNDLE).parts[0] in MODERN_ONLY_MODULES:
+            continue
+        try:
+            compile(path.read_bytes(), str(path), "exec", dont_inherit=True)
+        except SyntaxError as error:
+            problems.append(f"{path.relative_to(BUNDLE)} does not parse on Python {target_python()}: {error}")
+    return problems
+
+
 def importable_modern_only_modules() -> list:
     """Modern-only modules that turn out to import here after all.
 
@@ -130,7 +150,11 @@ def main() -> int:
     # Loads the bundle modules, which is what the checks below inspect.
     load_addon()
 
-    failures = wrong_bundle_module_origins(vendored, from_anki) + importable_modern_only_modules()
+    failures = (
+        wrong_bundle_module_origins(vendored, from_anki)
+        + importable_modern_only_modules()
+        + unparsable_bundle_modules()
+    )
     if not failures:
         failures += django_rendering_problems()  # only meaningful once the origins are right
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,9 @@
 set -e
 
+# Every path below is relative to the repository root.
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
 uv run scripts/build.py
 
 mkdir -p dist
@@ -14,4 +18,33 @@ cd dist/release
 # remove temporary files
 find . -name __pycache__ -or -regex ".*.py[cod]" -or -name .DS_Store -or -name ".pytest_cache" -or -name ".mypy_cache" | xargs rm -rf
 
+# zip updates an existing archive in place and never drops entries whose files are gone, so a
+# leftover artifact would keep shipping packages that are no longer vendored.
+rm -f "$PROJECT_ROOT/ankihub.ankiaddon"
 zip -r "../../ankihub.ankiaddon" . -x ./tests\*
+
+cd "$PROJECT_ROOT"
+
+# Check the archive contains its required members. Read from the extracted zip rather than from
+# ankihub/lib, so a fault in assembling it just above is caught as well as one in what build.py
+# vendored. Lives here because every workflow that produces an artifact runs this script - the
+# GitHub release, the AnkiWeb and S3 uploads, the PR test builds.
+check_dir="$(mktemp -d)"
+trap 'rm -rf "$check_dir"' EXIT
+unzip -q ankihub.ankiaddon -d "$check_dir/addon"
+
+for member in manifest.json __init__.py lib/django lib/peewee.py; do
+  if [ ! -e "$check_dir/addon/$member" ]; then
+    echo "ankihub.ankiaddon is missing $member" >&2
+    exit 1
+  fi
+done
+
+# Import the 3.10-only layer on 3.10. Nothing else does: scripts/check_addon_import.py runs on 3.9,
+# where the add-on gates protobuf off. protobuf_ext is imported rather than just checked for, because
+# protobuf-py catches a failed import of it, which would leave a missing or broken extension silent.
+# Covers Linux only - the vendored extension is built for this host, and protobuf-py falls back to
+# pure Python on the platforms it cannot load on.
+"$(uv python find 3.10)" -I -S -c "import sys; sys.path.insert(0, '$check_dir/addon/lib'); import protobuf, protobuf_ext"
+
+echo "ankihub.ankiaddon is assembled and its Python 3.10 layer loads"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,9 +5,9 @@ set -o pipefail
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-# --locked, because a plain `uv run` syncs first and will re-lock a lockfile that has fallen behind
-# pyproject.toml - after which build.py's own `uv export --locked` sees the lock it just wrote and
-# is satisfied. The artifact would then be built from a resolution nobody reviewed.
+# --locked because a plain `uv run` syncs first, re-locking a lockfile that has fallen behind
+# pyproject.toml - after which build.py's own `uv export --locked` is satisfied by what it just
+# wrote, and the artifact is built from a resolution nobody reviewed.
 uv run --locked scripts/build.py
 
 mkdir -p dist
@@ -19,9 +19,9 @@ cd dist/release
 # update version file
 ../../scripts/calver.sh > VERSION
 
-# remove temporary files. -exec rather than a pipe into xargs, which splits on whitespace: a
-# vendored path containing a space would become two unrelated arguments to `rm -rf`. -depth so a
-# directory is removed only after find has already walked into it.
+# remove temporary files. -exec rather than xargs, which splits on whitespace: a vendored path
+# containing a space becomes two unrelated arguments to `rm -rf`. -depth so a directory goes only
+# after find has walked into it.
 find . -depth \( -name __pycache__ -o -regex ".*\.py[cod]" -o -name .DS_Store -o -name .pytest_cache -o -name .mypy_cache \) -exec rm -rf -- {} +
 
 # zip updates an existing archive in place and never drops entries whose files are gone, so a
@@ -31,10 +31,9 @@ zip -r "../../ankihub.ankiaddon" . -x ./tests\*
 
 cd "$PROJECT_ROOT"
 
-# Check the archive contains its required members. Read from the extracted zip rather than from
-# ankihub/lib, so a fault in assembling it just above is caught as well as one in what build.py
-# vendored. Lives here because every workflow that produces an artifact runs this script - the
-# GitHub release, the AnkiWeb and S3 uploads, the PR test builds.
+# The checks below read the extracted zip rather than ankihub/lib, so a fault in assembling it just
+# above is caught as well as one in what build.py vendored. They live here because every workflow
+# that produces an artifact runs this script, and so inherits them.
 check_dir="$(mktemp -d)"
 trap 'rm -rf "$check_dir"' EXIT
 unzip -q ankihub.ankiaddon -d "$check_dir/addon"
@@ -46,18 +45,16 @@ for member in manifest.json VERSION __init__.py lib/django lib/peewee.py; do
   fi
 done
 
-# Import the 3.10-only layer on 3.10. Nothing else does: scripts/check_addon_import.py runs on 3.9,
-# where the add-on gates protobuf off. protobuf_ext is imported rather than just checked for, because
-# protobuf-py catches a failed import of it, which would leave a missing or broken extension silent.
-# Covers Linux only - the vendored extension is built for this host, and protobuf-py falls back to
-# pure Python on the platforms it cannot load on.
+# Nothing else imports the 3.10-only layer: check_addon_import.py runs on 3.9, where the add-on
+# gates protobuf off. protobuf_ext is imported rather than just checked for, because protobuf-py
+# catches a failed import of it and would leave a missing or broken extension silent. Linux only -
+# the vendored extension is built for this host.
 "$(uv python find 3.10)" -I -S -c "import sys; sys.path.insert(0, '$check_dir/addon/lib'); import protobuf, protobuf_ext"
 
-# Parse the bundle under 3.9. scripts/check_addon_import.py does this and much more, but it needs an
-# Anki running on 3.9 and so exists only in the CI lane that has one - while the AnkiWeb and S3
-# uploads are dispatchable on their own and would otherwise publish with no 3.9 check at all. This
-# narrows that gap rather than closing it: it catches syntax a release started using, not a
-# 3.10-only import. The two modules the add-on itself gates off above 3.9 are excluded.
+# check_addon_import.py parses the bundle too, and much besides, but it needs an Anki running on 3.9
+# and so exists only in the CI lane that has one - while the AnkiWeb and S3 uploads are dispatchable
+# on their own. This narrows that gap rather than closing it: syntax a release started using is
+# caught here, a 3.10-only import is not.
 "$(uv python find 3.9)" -I -S -m compileall -q -x '/(protobuf|protobuf_ext)/' "$check_dir/addon/lib"
 
 echo "ankihub.ankiaddon is assembled, parses on Python 3.9, and its Python 3.10 layer loads"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,7 +33,7 @@ check_dir="$(mktemp -d)"
 trap 'rm -rf "$check_dir"' EXIT
 unzip -q ankihub.ankiaddon -d "$check_dir/addon"
 
-for member in manifest.json __init__.py lib/django lib/peewee.py; do
+for member in manifest.json VERSION __init__.py lib/django lib/peewee.py; do
   if [ ! -e "$check_dir/addon/$member" ]; then
     echo "ankihub.ankiaddon is missing $member" >&2
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,10 +1,14 @@
 set -e
+set -o pipefail
 
 # Every path below is relative to the repository root.
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-uv run scripts/build.py
+# --locked, because a plain `uv run` syncs first and will re-lock a lockfile that has fallen behind
+# pyproject.toml - after which build.py's own `uv export --locked` sees the lock it just wrote and
+# is satisfied. The artifact would then be built from a resolution nobody reviewed.
+uv run --locked scripts/build.py
 
 mkdir -p dist
 rm -rf dist/release
@@ -15,8 +19,10 @@ cd dist/release
 # update version file
 ../../scripts/calver.sh > VERSION
 
-# remove temporary files
-find . -name __pycache__ -or -regex ".*.py[cod]" -or -name .DS_Store -or -name ".pytest_cache" -or -name ".mypy_cache" | xargs rm -rf
+# remove temporary files. -exec rather than a pipe into xargs, which splits on whitespace: a
+# vendored path containing a space would become two unrelated arguments to `rm -rf`. -depth so a
+# directory is removed only after find has already walked into it.
+find . -depth \( -name __pycache__ -o -regex ".*\.py[cod]" -o -name .DS_Store -o -name .pytest_cache -o -name .mypy_cache \) -exec rm -rf -- {} +
 
 # zip updates an existing archive in place and never drops entries whose files are gone, so a
 # leftover artifact would keep shipping packages that are no longer vendored.
@@ -47,4 +53,11 @@ done
 # pure Python on the platforms it cannot load on.
 "$(uv python find 3.10)" -I -S -c "import sys; sys.path.insert(0, '$check_dir/addon/lib'); import protobuf, protobuf_ext"
 
-echo "ankihub.ankiaddon is assembled and its Python 3.10 layer loads"
+# Parse the bundle under 3.9. scripts/check_addon_import.py does this and much more, but it needs an
+# Anki running on 3.9 and so exists only in the CI lane that has one - while the AnkiWeb and S3
+# uploads are dispatchable on their own and would otherwise publish with no 3.9 check at all. This
+# narrows that gap rather than closing it: it catches syntax a release started using, not a
+# 3.10-only import. The two modules the add-on itself gates off above 3.9 are excluded.
+"$(uv python find 3.9)" -I -S -m compileall -q -x '/(protobuf|protobuf_ext)/' "$check_dir/addon/lib"
+
+echo "ankihub.ankiaddon is assembled, parses on Python 3.9, and its Python 3.10 layer loads"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 
-# Every path below is relative to the repository root.
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
@@ -35,7 +35,14 @@ cd "$PROJECT_ROOT"
 # above is caught as well as one in what build.py vendored. They live here because every workflow
 # that produces an artifact runs this script, and so inherits them.
 check_dir="$(mktemp -d)"
-trap 'rm -rf "$check_dir"' EXIT
+# The archive is written before it is checked, so without this a failure below leaves a
+# freshly-timestamped broken one at the repository root to be picked up and installed.
+cleanup() {
+  status=$?
+  rm -rf "$check_dir"
+  [ "$status" -eq 0 ] || rm -f "$PROJECT_ROOT/ankihub.ankiaddon"
+}
+trap cleanup EXIT
 unzip -q ankihub.ankiaddon -d "$check_dir/addon"
 
 for member in manifest.json VERSION __init__.py lib/django lib/peewee.py; do
@@ -51,10 +58,12 @@ done
 # the vendored extension is built for this host.
 "$(uv python find 3.10)" -I -S -c "import sys; sys.path.insert(0, '$check_dir/addon/lib'); import protobuf, protobuf_ext"
 
-# check_addon_import.py parses the bundle too, and much besides, but it needs an Anki running on 3.9
-# and so exists only in the CI lane that has one - while the AnkiWeb and S3 uploads are dispatchable
-# on their own. This narrows that gap rather than closing it: syntax a release started using is
-# caught here, a 3.10-only import is not.
-"$(uv python find 3.9)" -I -S -m compileall -q -x '/(protobuf|protobuf_ext)/' "$check_dir/addon/lib"
+# check_addon_import.py does this and much more, but needs an Anki on 3.9 and so runs only in the CI
+# lane that has one - while the AnkiWeb and S3 uploads are dispatchable on their own. Narrows that
+# gap without closing it: syntax a release started using is caught, a 3.10-only import is not. The
+# exclusion repeats MODERN_ONLY_MODULES; drift surfaces as a SyntaxError naming the package, not this
+# list. media_import/libs comes from the submodule's requirements.txt rather than uv.lock.
+"$(uv python find 3.9)" -I -S -m compileall -q -x '/(protobuf|protobuf_ext)/' \
+  "$check_dir/addon/lib" "$check_dir/addon/media_import/libs"
 
 echo "ankihub.ankiaddon is assembled, parses on Python 3.9, and its Python 3.10 layer loads"

--- a/uv.lock
+++ b/uv.lock
@@ -109,11 +109,13 @@ bundle = [
     { name = "django-cotton" },
     { name = "mashumaro" },
     { name = "peewee" },
-    { name = "protobuf-py", marker = "python_full_version >= '3.10' or (extra == 'group-13-ankihub-addon-aqt' and extra == 'group-13-ankihub-addon-aqt-legacy')" },
     { name = "sentry-sdk" },
     { name = "structlog" },
     { name = "tenacity" },
-    { name = "urllib3" },
+    { name = "tzdata" },
+]
+bundle-modern = [
+    { name = "protobuf-py", marker = "python_full_version >= '3.10' or (extra == 'group-13-ankihub-addon-aqt' and extra == 'group-13-ankihub-addon-aqt-legacy')" },
 ]
 dev = [
     { name = "approvaltests" },
@@ -155,16 +157,16 @@ aqt-legacy = [
 ]
 bundle = [
     { name = "asgiref", specifier = "<3.12" },
-    { name = "django", specifier = "==4.2.27" },
+    { name = "django", specifier = "==4.2.30" },
     { name = "django-cotton", specifier = ">=2.5.1" },
     { name = "mashumaro", git = "https://github.com/AnkiHubSoftware/mashumaro.git?branch=master" },
     { name = "peewee", specifier = "==3.18.2" },
-    { name = "protobuf-py", marker = "python_full_version >= '3.10'" },
     { name = "sentry-sdk", specifier = "==1.6.0" },
     { name = "structlog", specifier = "==24.1.0" },
     { name = "tenacity", specifier = "==8.2.2" },
-    { name = "urllib3", specifier = "<2.7" },
+    { name = "tzdata" },
 ]
+bundle-modern = [{ name = "protobuf-py", marker = "python_full_version >= '3.10'" }]
 dev = [
     { name = "approvaltests", specifier = ">=12.2.0" },
     { name = "buf-bin", marker = "python_full_version >= '3.10'" },
@@ -292,14 +294,14 @@ qt = [
 
 [[package]]
 name = "asgiref"
-version = "3.11.0"
+version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'group-13-ankihub-addon-aqt' and extra == 'group-13-ankihub-addon-aqt-legacy')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/b9/4db2509eabd14b4a8c71d1b24c8d5734c52b8560a7b1e1a8b56c8d25568b/asgiref-3.11.0.tar.gz", hash = "sha256:13acff32519542a1736223fb79a715acdebe24286d98e8b164a73085f40da2c4", size = 37969, upload-time = "2025-11-19T15:32:20.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/be/317c2c55b8bbec407257d45f5c8d1b6867abc76d12043f2d3d58c538a4ea/asgiref-3.11.0-py3-none-any.whl", hash = "sha256:1db9021efadb0d9512ce8ffaf72fcef601c7b73a8807a1bb2ef143dc6b14846d", size = 24096, upload-time = "2025-11-19T15:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
 ]
 
 [[package]]
@@ -352,11 +354,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.10.5"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -631,28 +633,28 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.27"
+version = "4.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'group-13-ankihub-addon-aqt' and extra == 'group-13-ankihub-addon-aqt-legacy')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/ff/6aa5a94b85837af893ca82227301ac6ddf4798afda86151fb2066d26ca0a/django-4.2.27.tar.gz", hash = "sha256:b865fbe0f4a3d1ee36594c5efa42b20db3c8bbb10dff0736face1c6e4bda5b92", size = 10432781, upload-time = "2025-12-02T14:01:49.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707, upload-time = "2026-04-07T14:05:45.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/f5/1a2319cc090870bfe8c62ef5ad881a6b73b5f4ce7330c5cf2cb4f9536b12/django-4.2.27-py3-none-any.whl", hash = "sha256:f393a394053713e7d213984555c5b7d3caeee78b2ccb729888a0774dff6c11a8", size = 7995090, upload-time = "2025-12-02T14:01:44.234Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231, upload-time = "2026-04-07T14:05:38.241Z" },
 ]
 
 [[package]]
 name = "django-cotton"
-version = "2.5.1"
+version = "2.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/a9/ec7c6172beb4adb67278df3b58ea4e9e3b21a1987b3a5b972d53dd7d3837/django_cotton-2.5.1.tar.gz", hash = "sha256:b2dbd346d0aced774de0c212d2f6c4e5f30cb8e14521379e60e16b448934af0e", size = 30284, upload-time = "2025-12-08T07:55:53.727Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/cd/5c467a1495b756f56246a6d8d36425517cd01bd3aa4bc6209a821f83ec74/django_cotton-2.7.2.tar.gz", hash = "sha256:7e050042873f724beaa5824e86d5034ced2f7de1c5478c3a9d8c053e05caa8ac", size = 33171, upload-time = "2026-06-01T22:52:00.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/b7/587d364f59543962e2e2540adc0e323174107bdba89ec073a5c9acbee7e9/django_cotton-2.5.1-py3-none-any.whl", hash = "sha256:b03fb57dde097e771aa47ee15f377d9b757b6a058ee8fcd9cef9914d1093c169", size = 29681, upload-time = "2025-12-08T07:55:52.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9b/d75158f6280906befada54f9cb17c10d5e0eac078d8d2e189e2f90da0fc1/django_cotton-2.7.2-py3-none-any.whl", hash = "sha256:1b293037ead54ab228362654da00ededc5ca52b2ff407b6087a81cfd9390850e", size = 32084, upload-time = "2026-06-01T22:52:01.238Z" },
 ]
 
 [[package]]
@@ -2393,11 +2395,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.4"
+version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
 ]
 
 [[package]]
@@ -2552,11 +2554,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,7 @@ bundle = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tzdata" },
+    { name = "urllib3" },
 ]
 bundle-modern = [
     { name = "protobuf-py", marker = "python_full_version >= '3.10' or (extra == 'group-13-ankihub-addon-aqt' and extra == 'group-13-ankihub-addon-aqt-legacy')" },
@@ -165,6 +166,7 @@ bundle = [
     { name = "structlog", specifier = "==24.1.0" },
     { name = "tenacity", specifier = "==8.2.2" },
     { name = "tzdata" },
+    { name = "urllib3", specifier = "<2" },
 ]
 bundle-modern = [{ name = "protobuf-py", marker = "python_full_version >= '3.10'" }]
 dev = [


### PR DESCRIPTION
## Related issues

- [NRT-873](https://ankihub.atlassian.net/browse/NRT-873)
- Follow-up to #1359, the emergency hotfix that pinned `asgiref<3.12`

## Proposed changes

`scripts/build.py` re-resolved the `bundle` group from `pyproject.toml` on every build. It never read `uv.lock`, and it evaluated markers against the build machine's Python (3.13) rather than the oldest interpreter the add-on has to run on — so any transitive that dropped Python 3.9 reached users unnoticed, which is what happened when `asgiref` 3.12 was released.

Anki bundles its own CPython. Official builds moved to 3.13 in 25.07, but the builds before that ship 3.9, and with a declared minimum Anki of 2.1.56 the add-on still has to run there. Roughly a quarter of active users are on an Anki predating 25.07.

**The fix makes the break impossible rather than merely detected.** The bundle now installs from the lockfile, in two layers, each with the oldest Python that can reach it: the `bundle` group with **3.9**, `bundle_modern` (`protobuf-py`, which has required 3.10 since its first release) with **3.10**. uv *refuses* a distribution declaring a newer floor, so the build fails instead of the add-on. They are separate dependency groups, so routing never reads markers.

Resolution only sees *declared* floors, so detection still covers the rest — an undeclared floor, a requirement a false marker dropped silently, a fault in assembling the archive — across the build, the packaged archive, and an import inside a real Anki on 3.9.

### The build

- **From `uv.lock`, not re-resolved.** `uv export --locked --only-group <group>` into `uv pip install --no-deps`. `--locked` also fails the build when the lockfile is out of step with `pyproject.toml` instead of quietly preferring one. Side effect: mashumaro is now pinned to the revision the lock recorded rather than tracking the fork's mutable `master`.
- **Every exported requirement must arrive.** A requirement whose marker is false for the building interpreter or platform installs nothing and reports nothing, so its absence is the only signal there is. The build compares the export against the finished bundle's `dist-info` — catching a distribution that never arrived, not one whose files a prune removed.
- **Compiled extensions must be audited.** `abi3` fixes only the interpreter axis — `protobuf-py-ext`'s wheel is `cp310-abi3-manylinux_2_17_x86_64`, unloadable on Windows, macOS or ARM. So what earns a place is the package falling back without it: protobuf-py catches the failed import (kept), nothing imports `playhouse` (its 2 MB dropped). Anything else fails the build.
- **Nothing survives a previous build.** `ankihub/lib` is cleared and the previous `.ankiaddon` deleted — `uv pip install --target` and `zip` both update in place, so unvendored packages were surviving into local artifacts.
- **`media_import` installs with 3.9 too.** Its requirements come from the submodule's own `requirements.txt`, not `uv.lock`, and were installed with whatever Python ran the build — outside every check, all of which were scoped to `ankihub/lib`. One pinned pure-Python package today, so nothing shipped was broken.

### What gets checked

`scripts/check_addon_import.py` imports the built add-on the way Anki does — `aqt.addons` first, then `ankihub.entry_point` — and asserts where each vendored top-level package resolved from. The list comes from the bundle directory, and each assertion's direction follows from whether Anki had already imported that name, so on 2.1.56 `certifi`, `typing_extensions` and `urllib3` must resolve *outside* the bundle and everything else inside it. It then renders a template through the add-on's own `render_template_from_string()`, covering packages nothing imports directly, such as `sqlparse`. It also parses every `.py` in the bundle under 3.9, reaching files nothing pulls in. Point it at a bundle carrying `asgiref 3.12.1` and it reproduces the reported `ImportError`. It runs in the CI 3.9 lane, the only place with an Anki-on-3.9 environment.

`scripts/release.sh` adds three cheap checks over the extracted `.ankiaddon`: required members present, parses under 3.9, and the 3.10-only layer imports under 3.10. These live there because **every** workflow producing an artifact runs that script, so one added later inherits them — previously only the GitHub release was covered, not the copy users install from AnkiWeb. `build.py` is invoked as `uv run --locked` here and in `setup-addon`, since a plain sync or run re-locks a stale lockfile, after which `build.py`'s own `uv export --locked` is satisfied by what it just wrote.

**Why not the test suite.** It runs the add-on on 3.9, but pytest plugins and factory-boy import django, asgiref and urllib3 from the dev environment before `import ankihub` prepends the bundle, so the bundled copies are shadowed and never exercised — that lane vendored the broken `asgiref==3.12.1` and went green. Reordering `conftest.py` fixes it, but the guarantee would then be an import order the import sorter is free to undo, failing silently.

### Smaller changes

- **Cap `urllib3` in `bundle`.** Not the Python floor the layers enforce — urllib3 2.x still supports 3.9 — but sentry-sdk 1.6.0 predates urllib3 2.0's API changes, and only the `dev` group's cap held it at 1.x.
- **Vendor `tzdata` unconditionally.** Django declares it `win32`-only and the bundle is built on Linux, so the marker dropped it for exactly the users who need it. Latent until a template uses a date filter.
- **Django 4.2.27 → 4.2.30**, the final 4.2 security release. Re-locking also moved asgiref, django-cotton 2.5.1→2.7.2, certifi, sqlparse and typing-extensions — already what a fresh resolve produced, but the lock is authoritative for the artifact for the first time, so the `uv.lock` hunks are worth a look.
- **Remove the `sys.path` entry for `ankihub/lib/other`** — it has pointed at nothing since #1176, while sitting ahead of the bundle.
- **`README` and `justfile` gain `--group bundle_modern`**, without which a 3.10+ dev environment has no `protobuf-py` and `mypy` fails on `ankihub/proto/*.py`.
- **`no_absolute_imports_from_ankihub` skips `scripts/`** — the rule exists because Anki installs the add-on under its AnkiWeb id; build scripts are not shipped inside it.

## How to reproduce

```bash
GOOGLE_API_KEY=dummy bash ./scripts/release.sh   # ends "... assembled, parses on Python 3.9, and its Python 3.10 layer loads"
xvfb-run -a uv run --exact --group aqt_legacy --python 3.9 python scripts/check_addon_import.py
```

The install-time refusal, which is what makes the original incident impossible:

```bash
uv pip install --python 3.9 --no-deps --target /tmp/x asgiref==3.12.1
# error: ... asgiref==3.12.1 depends on Python>=3.10 ... requirements are unsatisfiable
```

And detection, for a bundle that acquired a bad version some other way:

```bash
uv pip install --python 3.13 --no-deps --target ankihub/lib asgiref==3.12.1
xvfb-run -a uv run --exact --group aqt_legacy --python 3.9 python scripts/check_addon_import.py
# ImportError: cannot import name 'ParamSpec' from 'typing'
```

Also verified: the artifact holds 15 distributions (one more than before — tzdata) at 7.2 MB compressed; `pytest ./tests/addon -m "not sequential and not performance"` 731 passed; `mypy` clean on 118 files.

### Verified by hand in Anki

The built artifact was installed and exercised in real Anki on three interpreters, since what changed is *what the add-on ships*:

- **Anki 25.02.7 / Python 3.9.23** — the configuration this exists for. Loads; `django`, `asgiref.sync`, `peewee`, `structlog`, `sentry_sdk` resolve from the bundle, `urllib3` from Anki's venv. Sync and deck install work, so peewee runs without the stripped C extensions. django-cotton renders end to end — component loader, attribute expressions, nested components — the extent of what 2.5.1 → 2.7.2 could have broken.
- **Anki 25.09 / Python 3.13 / Linux** — loads; `urllib3` resolves from Anki's site-packages, so the shadowing contract holds in a real host; the `abi3` extension loads.
- **Anki 25.09 / Python 3.13 / macOS arm64** — same Linux-built artifact. `dlopen` fails on the foreign x86_64 ELF, protobuf-py suppresses that `ImportError` and falls back to pure Python; messages still round-trip — the last known limit's fallback working with the wrong OS and architecture at once.

## Further comments

**Known limits**, so nobody assumes more coverage than exists:

- Prevention covers declared floors only. An undeclared one is caught by the 3.9 import check, or not at all.
- That check *imports* the add-on; it does not call `entry_point.run()`, which needs a running Anki, and it imports the package as `ankihub` rather than under its AnkiWeb id.
- It imports each package's *top level*, so a submodule is covered only if something reaches it. `asgiref.sync` — where the incident was — is covered because Django's template stack pulls it in, not because `asgiref` is vendored: `import asgiref` alone passes against a bundle carrying 3.12.1. The parse pass reaches every file but catches only syntax.
- `release.sh`'s parse pass narrows the publish-path gap rather than closing it, for the same reason.
- The vendored protobuf extension is built for the build host; protobuf-py falls back where it cannot load, now confirmed on macOS arm64. Windows is untested, though it exercises the fallback more weakly — it ignores `.so` outright rather than attempting the load.

**Known follow-ups, deliberately not here:**

- The AnkiWeb and S3 upload workflows are `workflow_dispatch` and have no CI gate, so a dispatch can publish without the 3.9 lane ever running. `create_release.yml` has the gate mechanism to copy.
- Make that gate SHA-aware: `create_release.yml` checks the last CI run's conclusion but not its commit, so a push whose run has not been created yet slips through. Affects all regressions, not just 3.9 ones.
- Build isolation is not locked. peewee is an sdist, so the same `uv.lock` can yield a different wheel later via a different build backend.
- The Django render check renders plain HTML, so the cotton component *loader* — the novel vendored machinery — is not covered by it. It was verified by hand above.
- Audit or bump `sentry-sdk` 1.6.0 (June 2022). It declares no `Requires-Python` and is what makes urllib3 a dependency at all.
- `certifi` is still vendored though shadowed, for the same reason urllib3 is. A size cleanup, not a 3.9 fix.
- `create_release.yml` builds the artifact before committing and tagging the version bump. Left alone deliberately: reordering would leave a pushed tag for a release that never shipped whenever a check fails.


[NRT-873]: https://ankihub.atlassian.net/browse/NRT-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ