### PR TITLE
[ACTV-441] Remove "tour on how to unsuspend cards" paragraph from Congrats screen

### DIFF
--- a/ankihub/gui/web/overview.js
+++ b/ankihub/gui/web/overview.js
@@ -181,15 +181,6 @@ function renderFlashCardSelectorButtonOnDecks() {
     }
 }
 
-function renderTourPrompt() {
-    if (!document.getElementById("{{ TOUR_PROMPT_TEXT_ID }}")) {
-        const p = document.createElement("p");
-        p.id = "{{ TOUR_PROMPT_TEXT_ID }}";
-        p.innerHTML = `If you have doubts on how to get more cards to study, take our <a href="javascript:pycmd('{{ TOUR_OPEN_PYCMD }}')">tour on how to unsuspend cards</a>.`;
-        document.querySelector(".congrats").appendChild(p);
-    }
-}
-
 function waitForElm(selector) {
     return new Promise(resolve => {
         if (document.querySelector(selector)) {
@@ -219,9 +210,6 @@ if (window.location.href.includes("congrats")) {
         if (flashcardSelectorEnabled) {
             renderFlashCardSelectorButtonOnCongrats();
             document.getElementById("{{ FLASHCARD_SELECTOR_OPEN_BUTTON_ID }}").style.display = "flex";
-        }
-        if (tourEnabled) {
-            renderTourPrompt();
         }
     })
 } else if (flashcardSelectorEnabled) {


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-441](https://ankihub.atlassian.net/browse/ACTV-441)


## Proposed changes
Removes the paragraph about the unsuspended cards on the congrats screen

## How to reproduce
1. Click to study the Step Deck
2. See at the end, on the congrats screen, that the paragraph about the unsuspended cards no longer appears.

## Screenshots and videos

<img width="880" height="732" alt="Screenshot from 2026-08-05 14-37-54" src="https://github.com/user-attachments/assets/9a90e7c9-b0ea-4fce-99e8-52d717f23217" />

[ACTV-441]: https://ankihub.atlassian.net/browse/ACTV-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ