### PR TITLE
[KNW-217] Fix AnkiHub sync failing silently after AnkiWeb errors

### DIFF
--- a/ankihub/gui/auto_sync.py
+++ b/ankihub/gui/auto_sync.py
@@ -125,7 +125,7 @@ def _maybe_sync_with_ankihub(on_done: Callable[[Future], None]) -> None:
     if _should_auto_sync_with_ankihub():
         auto_sync_state.attempted_startup_sync = True
         LOGGER.info("Syncing with AnkiHub in _new_sync_collection")
-        sync_with_ankihub(on_done=on_done)
+        sync_with_ankihub(on_done=on_done, report_ankiweb_errors=False)
     else:
         LOGGER.info("Not syncing with AnkiHub")
         on_done(future_with_result(None))

--- a/ankihub/gui/exceptions.py
+++ b/ankihub/gui/exceptions.py
@@ -23,3 +23,12 @@ class FullSyncCancelled(Exception):
     """Raised when a full AnkiWeb sync is cancelled before an AnkiHub sync."""
 
     pass
+
+
+class AnkiWebSyncStatusError(Exception):
+    """Raised when mw.col.sync_status() fails."""
+
+    def __init__(self, original_exception: Exception):
+        super().__init__(str(original_exception))
+        self.original_exception = original_exception
+        self.__cause__ = original_exception

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -55,7 +55,10 @@ def get_sync_status(mw: aqt.main.AnkiQt, on_done: Callable[[Future], None]) -> N
 
     def wrapped_on_done(fut: Future) -> None:
         try:
-            fut.result()
+            status: SyncStatus = fut.result()
+            if new_endpoint := getattr(status, "new_endpoint", None):
+                if hasattr(mw.pm, "set_current_sync_url"):
+                    mw.pm.set_current_sync_url(new_endpoint)
             on_done(fut)
         except Exception as exc:
             LOGGER.warning("AnkiWeb status error", exc_info=exc)

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -107,12 +107,7 @@ def _after_ankiweb_sync(on_done: Callable[[Future], None], skip_summary: bool) -
 
         _sync_with_ankihub_inner(on_done=on_done, skip_summary=skip_summary)
 
-    @pass_exceptions_to_on_done
-    def after_delay(on_done: Callable[[Future], None]) -> None:
-        get_sync_status(aqt.mw, partial(on_sync_status, on_done=on_done))
-
-    # Delay call to ensure server status is updated.
-    aqt.mw.progress.single_shot(1000, partial(after_delay, on_done=on_done))
+    get_sync_status(aqt.mw, partial(on_sync_status, on_done=on_done))
 
 
 @pass_exceptions_to_on_done

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -12,7 +12,7 @@ from anki.hooks import wrap
 from anki.sync import SyncOutput, SyncStatus
 from aqt import QTimer
 from aqt.qt import qconnect
-from aqt.sync import get_sync_status
+from aqt.sync import handle_sync_error
 
 from ... import LOGGER
 from ...addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
@@ -26,7 +26,7 @@ from ...main.utils import collection_schema
 from ...settings import config, get_end_cutoff_date_for_sending_review_summaries
 from ..changes_require_full_sync_dialog import ChangesRequireFullSyncDialog
 from ..deck_updater import ah_deck_updater, show_tooltip_about_last_deck_updates_results
-from ..exceptions import FullSyncCancelled
+from ..exceptions import AnkiWebSyncStatusError, FullSyncCancelled
 from ..utils import extract_argument, logged_into_ankiweb, sync_with_ankiweb
 from .db_check import maybe_check_databases
 from .new_deck_subscriptions import check_and_install_new_deck_subscriptions
@@ -41,8 +41,31 @@ class _SyncState:
 sync_state = _SyncState()
 
 
+def get_sync_status(mw: aqt.main.AnkiQt, on_done: Callable[[Future], None]) -> None:
+    auth = mw.pm.sync_auth()
+    if not auth:
+        on_done(future_with_result(SyncStatus(required=SyncStatus.NO_CHANGES)))
+        return
+
+    def wrapped_on_done(fut: Future) -> None:
+        try:
+            fut.result()
+            on_done(fut)
+        except Exception as exc:
+            LOGGER.warning("AnkiWeb status error", exc_info=exc)
+            on_done(future_with_exception(AnkiWebSyncStatusError(exc)))
+
+    mw.taskman.run_in_background(
+        lambda: mw.col.sync_status(auth),
+        wrapped_on_done,
+        uses_collection=False,
+    )
+
+
 @pass_exceptions_to_on_done
-def sync_with_ankihub(on_done: Callable[[Future], None], skip_summary: bool = False) -> None:
+def sync_with_ankihub(
+    on_done: Callable[[Future], None], skip_summary: bool = False, report_ankiweb_errors: bool = True
+) -> None:
     """Uninstall decks the user is not subscribed to anymore, check for (and maybe install) new deck subscriptions,
     then download updates to decks.
 
@@ -52,8 +75,17 @@ def sync_with_ankihub(on_done: Callable[[Future], None], skip_summary: bool = Fa
     config.log_private_config()
 
     @pass_exceptions_to_on_done
-    def on_sync_status(out: SyncStatus, on_done: Callable[[Future], None]) -> None:
-        if out.required == out.FULL_SYNC:
+    def on_sync_status(fut: Future, on_done: Callable[[Future], None]) -> None:
+        try:
+            status: SyncStatus = fut.result()
+        except Exception as exc:
+            if isinstance(exc, AnkiWebSyncStatusError):
+                exc = exc.original_exception
+            if report_ankiweb_errors:
+                handle_sync_error(aqt.mw, exc)
+            on_done(future_with_result(None))
+            return
+        if status.required == status.FULL_SYNC:
             LOGGER.info("Full sync required. Syncing with AnkiWeb first.")
             sync_with_ankiweb(partial(_after_ankiweb_sync, on_done=on_done, skip_summary=skip_summary))
         else:
@@ -66,8 +98,9 @@ def sync_with_ankihub(on_done: Callable[[Future], None], skip_summary: bool = Fa
 @pass_exceptions_to_on_done
 def _after_ankiweb_sync(on_done: Callable[[Future], None], skip_summary: bool) -> None:
     @pass_exceptions_to_on_done
-    def on_sync_status(out: SyncStatus, on_done: Callable[[Future], None]) -> None:
-        if out.required == out.FULL_SYNC:
+    def on_sync_status(fut: Future, on_done: Callable[[Future], None]) -> None:
+        status: SyncStatus = fut.result()
+        if status.required == status.FULL_SYNC:
             # Stop here if user cancelled full sync
             LOGGER.info("AnkiWeb full sync cancelled.")
             raise FullSyncCancelled()

--- a/ankihub/gui/operations/ankihub_sync.py
+++ b/ankihub/gui/operations/ankihub_sync.py
@@ -2,10 +2,11 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from uuid import UUID
 
 import aqt
+import aqt.main
 import aqt.sync
 from anki.collection import OpChangesWithCount
 from anki.hooks import wrap
@@ -23,7 +24,12 @@ from ...main.deck_unsubscribtion import uninstall_deck
 from ...main.exceptions import ChangesRequireFullSyncError
 from ...main.review_data import send_daily_review_summaries, send_review_data
 from ...main.utils import collection_schema
-from ...settings import config, get_end_cutoff_date_for_sending_review_summaries
+from ...settings import (
+    ANKI_INT_VERSION,
+    ANKI_VERSION_23_10_00,
+    config,
+    get_end_cutoff_date_for_sending_review_summaries,
+)
 from ..changes_require_full_sync_dialog import ChangesRequireFullSyncDialog
 from ..deck_updater import ah_deck_updater, show_tooltip_about_last_deck_updates_results
 from ..exceptions import AnkiWebSyncStatusError, FullSyncCancelled
@@ -55,11 +61,11 @@ def get_sync_status(mw: aqt.main.AnkiQt, on_done: Callable[[Future], None]) -> N
             LOGGER.warning("AnkiWeb status error", exc_info=exc)
             on_done(future_with_exception(AnkiWebSyncStatusError(exc)))
 
-    mw.taskman.run_in_background(
-        lambda: mw.col.sync_status(auth),
-        wrapped_on_done,
-        uses_collection=False,
-    )
+    kwargs: Dict[str, Any] = {"task": lambda: mw.col.sync_status(auth), "on_done": wrapped_on_done}
+    if ANKI_INT_VERSION >= ANKI_VERSION_23_10_00:
+        kwargs["uses_collection"] = False
+
+    mw.taskman.run_in_background(**kwargs)
 
 
 @pass_exceptions_to_on_done

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -31,6 +31,7 @@ from anki.decks import DeckConfigId, DeckId, FilteredDeckConfig
 from anki.errors import NotFoundError
 from anki.models import NotetypeDict, NotetypeId
 from anki.notes import Note, NoteId
+from anki.sync import SyncAuth, SyncStatus
 from aqt import AnkiQt, QMenu, dialogs
 from aqt.addcards import AddCards
 from aqt.addons import InstallOk
@@ -135,7 +136,11 @@ from ankihub.common_utils import get_media_names_from_note_field
 from ankihub.db import ankihub_db
 from ankihub.db.models import AnkiHubNote
 from ankihub.gui import decks_dialog, editor, utils
-from ankihub.gui.auto_sync import SYNC_RATE_LIMIT_SECONDS, _setup_ankihub_sync_on_ankiweb_sync
+from ankihub.gui.auto_sync import (
+    SYNC_RATE_LIMIT_SECONDS,
+    _maybe_sync_with_ankihub,
+    _setup_ankihub_sync_on_ankiweb_sync,
+)
 from ankihub.gui.browser import custom_columns
 from ankihub.gui.browser import setup as setup_browser
 from ankihub.gui.browser.browser import (
@@ -167,7 +172,12 @@ from ankihub.gui.editor import (
     _on_suggestion_button_press,
 )
 from ankihub.gui.errors import upload_logs_and_data_in_background
-from ankihub.gui.exceptions import DeckDownloadAndInstallError, RemoteDeckNotFoundError
+from ankihub.gui.exceptions import (
+    AnkiWebSyncStatusError,
+    DeckDownloadAndInstallError,
+    FullSyncCancelled,
+    RemoteDeckNotFoundError,
+)
 from ankihub.gui.flashcard_selector_dialog import FlashCardSelectorDialog
 from ankihub.gui.js_message_handling import (
     ADD_TO_BLOCK_EXAM_SUBDECK,
@@ -7523,6 +7533,256 @@ class TestSyncWithAnkiHub:
                 notes=notes,
             ),
         )
+
+
+def _future_from_callback(callback: Any) -> Future:
+    return callback.kwargs.get("future") or callback.args[0]
+
+
+class TestGetSyncStatus:
+    """Tests for the get_sync_status wrapper which - unlike Anki's version - always calls its callback,
+    reporting AnkiWeb status errors as an AnkiWebSyncStatusError."""
+
+    def test_without_ankiweb_auth(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=None)
+            sync_status_mock = mocker.patch.object(mw.col, "sync_status")
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.get_sync_status(mw, callback)
+
+            future = _future_from_callback(callback)
+            assert future.result().required == SyncStatus.NO_CHANGES
+
+            # AnkiWeb is not contacted when the user is not logged into it.
+            sync_status_mock.assert_not_called()
+
+    def test_with_successful_status_check(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            auth = SyncAuth(hkey="test_hkey")
+            mocker.patch.object(mw.pm, "sync_auth", return_value=auth)
+            sync_status_mock = mocker.patch.object(
+                mw.col, "sync_status", return_value=SyncStatus(required=SyncStatus.NORMAL_SYNC)
+            )
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.get_sync_status(mw, callback)
+
+            future = _future_from_callback(callback)
+            assert future.result().required == SyncStatus.NORMAL_SYNC
+            sync_status_mock.assert_called_once_with(auth)
+
+    def test_with_failing_status_check(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            exception = Exception("AnkiWeb is down")
+            mocker.patch.object(mw.col, "sync_status", side_effect=exception)
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.get_sync_status(mw, callback)
+
+            future = _future_from_callback(callback)
+            raised = future.exception()
+            assert isinstance(raised, AnkiWebSyncStatusError)
+            assert raised.original_exception is exception
+            assert raised.__cause__ is exception
+            assert str(raised) == "AnkiWeb is down"
+
+
+@pytest.mark.qt_no_exception_capture
+class TestSyncWithAnkiHubAnkiWebStatusErrors:
+    """Tests for how sync_with_ankihub deals with failures of the AnkiWeb sync status check.
+    Such failures used to make the sync end without ever calling its on_done callback."""
+
+    @pytest.mark.parametrize("report_ankiweb_errors", [True, False])
+    def test_status_error_before_ankiweb_sync(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+        report_ankiweb_errors: bool,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            exception = Exception("AnkiWeb is down")
+            mocker.patch.object(mw.col, "sync_status", side_effect=exception)
+
+            handle_sync_error_mock = mocker.patch("ankihub.gui.operations.ankihub_sync.handle_sync_error")
+            get_deck_subscriptions_mock = mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[])
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.sync_with_ankihub(on_done=callback, report_ankiweb_errors=report_ankiweb_errors)
+
+            # The sync ends without an error - the AnkiWeb problem is not an AnkiHub sync failure.
+            future = _future_from_callback(callback)
+            assert future.result() is None
+
+            # The AnkiHub sync itself is not attempted.
+            get_deck_subscriptions_mock.assert_not_called()
+
+            # The original exception is reported to the user via Anki, unless the caller opted out.
+            if report_ankiweb_errors:
+                handle_sync_error_mock.assert_called_once_with(mw, exception)
+            else:
+                handle_sync_error_mock.assert_not_called()
+
+    def test_status_error_after_ankiweb_sync(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            # The first status check requires a full sync, the second one (after the AnkiWeb sync) fails.
+            exception = Exception("AnkiWeb is down")
+            mocker.patch.object(
+                mw.col,
+                "sync_status",
+                side_effect=[SyncStatus(required=SyncStatus.FULL_SYNC), exception],
+            )
+            self._mock_ankiweb_sync(mocker)
+
+            handle_sync_error_mock = mocker.patch("ankihub.gui.operations.ankihub_sync.handle_sync_error")
+            get_deck_subscriptions_mock = mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[])
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.sync_with_ankihub(on_done=callback)
+
+            # Errors of the status check after the AnkiWeb sync are passed to on_done instead of being
+            # reported to the user, so that the caller can decide what to do with them.
+            future = _future_from_callback(callback)
+            raised = future.exception()
+            assert isinstance(raised, AnkiWebSyncStatusError)
+            assert raised.original_exception is exception
+            handle_sync_error_mock.assert_not_called()
+
+            get_deck_subscriptions_mock.assert_not_called()
+
+    def test_full_sync_still_required_after_ankiweb_sync(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            # The user cancelled the full sync, so a full sync is still required afterwards.
+            mocker.patch.object(mw.col, "sync_status", return_value=SyncStatus(required=SyncStatus.FULL_SYNC))
+            sync_with_ankiweb_mock = self._mock_ankiweb_sync(mocker)
+
+            get_deck_subscriptions_mock = mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[])
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.sync_with_ankihub(on_done=callback)
+
+            future = _future_from_callback(callback)
+            assert isinstance(future.exception(), FullSyncCancelled)
+
+            assert sync_with_ankiweb_mock.call_count == 1
+            get_deck_subscriptions_mock.assert_not_called()
+
+    def test_sync_continues_after_ankiweb_full_sync(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+        mock_client_methods_called_during_ankihub_sync: None,
+    ):
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            config.save_token("test_token")
+
+            # The sync completes here, so prevent the post-sync tasks from running after the test
+            # (and its mocks) are gone.
+            mocker.patch("ankihub.gui.operations.ankihub_sync._schedule_post_sync_tasks")
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            mocker.patch.object(
+                mw.col,
+                "sync_status",
+                side_effect=[
+                    SyncStatus(required=SyncStatus.FULL_SYNC),
+                    SyncStatus(required=SyncStatus.NO_CHANGES),
+                ],
+            )
+            sync_with_ankiweb_mock = self._mock_ankiweb_sync(mocker)
+
+            get_deck_subscriptions_mock = mocker.patch.object(AnkiHubClient, "get_deck_subscriptions", return_value=[])
+
+            with qtbot.wait_callback() as callback:
+                ankihub_sync.sync_with_ankihub(on_done=callback)
+
+            future = _future_from_callback(callback)
+            future.result()  # raises if there is an exception
+
+            assert sync_with_ankiweb_mock.call_count == 1
+            get_deck_subscriptions_mock.assert_called_once()
+
+    def _mock_ankiweb_sync(self, mocker: MockerFixture) -> Mock:
+        """Mock the AnkiWeb sync so that it immediately calls its callback."""
+        return mocker.patch(
+            "ankihub.gui.operations.ankihub_sync.sync_with_ankiweb",
+            side_effect=lambda on_done: on_done(),
+        )
+
+
+@pytest.mark.qt_no_exception_capture
+class TestMaybeSyncWithAnkiHub:
+    def test_ankiweb_status_errors_are_not_reported_during_auto_sync(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        mocker: MockerFixture,
+        qtbot: QtBot,
+    ):
+        """AnkiWeb errors are reported by Anki itself when it syncs with AnkiWeb after the AnkiHub sync,
+        so the auto sync must not report them a second time."""
+        with anki_session_with_addon_data.profile_loaded():
+            mw = anki_session_with_addon_data.mw
+
+            config.save_token("test_token")
+            config.public_config["auto_sync"] = "on_ankiweb_sync"
+
+            mocker.patch.object(mw.pm, "sync_auth", return_value=SyncAuth(hkey="test_hkey"))
+            mocker.patch.object(mw.col, "sync_status", side_effect=Exception("AnkiWeb is down"))
+
+            handle_sync_error_mock = mocker.patch("ankihub.gui.operations.ankihub_sync.handle_sync_error")
+
+            with qtbot.wait_callback() as callback:
+                _maybe_sync_with_ankihub(on_done=callback)
+
+            future = _future_from_callback(callback)
+            assert future.result() is None
+
+            handle_sync_error_mock.assert_not_called()
 
 
 def test_uninstalling_deck_removes_related_deck_extension_from_config(


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-217

## Proposed changes

AnkiHub sync fails silently without errors if the user is logged in to an unverified AnkiWeb account or if any other AnkiWeb issue occurs. We started to get more reports of this in Anki 26.08 from new users, as before that Anki used to incorrectly report that a full sync is required for completely new accounts, which made AnkiHub fail visibly with the “AnkiHub sync cancelled” message (fixed in [#5109](https://github.com/ankitects/anki/issues/5109)), reducing the possibility of users hitting the silent failure path.

The issue comes from Anki’s aqt.sync.get_sync_status() function ignoring connection/authentication errors (reason being that it’s intended for display of sync status in the toolbar). The solution implemented here involves using the underlying mw.col.sync_status directly and explicitly handling errors.


## How to reproduce

### Before

To reproduce the issue before this PR, create a new AnkiWeb account but do not verify it. Then log in to it in Anki and log in to an AnkiHub account and try to sync either using the Sync button or from the Deck Management screen. You should notice that nothing happens. If you check the console, you'll see the AnkiWeb error message as printed by Anki (look for for "sync status check failed").

### After

Any errors coming from AnkiWeb should now be visible.
