### PR TITLE
[KNW-218] Fix: prevent duplicate verification email on password signup

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -818,7 +818,10 @@ class SignupEmailVerificationWidget(BaseSignupWidget):
             dialog=dialog,
             extra_bottom_button=login_button,
         )
-        self._resend()
+        # Signup already sent the verification email. Shouldn't call resend here.
+        self.description_label.setText(
+            f"📮 If {self.email} exists, we sent a verification link to its inbox.<br>"
+        )
 
     def _create_form_widget(self) -> FormWidget:
         self.description_label = description_label = QLabel("")

--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -819,9 +819,7 @@ class SignupEmailVerificationWidget(BaseSignupWidget):
             extra_bottom_button=login_button,
         )
         # Signup already sent the verification email. Shouldn't call resend here.
-        self.description_label.setText(
-            f"📮 If {self.email} exists, we sent a verification link to its inbox.<br>"
-        )
+        self.description_label.setText(f"📮 If {self.email} exists, we sent a verification link to its inbox.<br>")
 
     def _create_form_widget(self) -> FormWidget:
         self.description_label = description_label = QLabel("")


### PR DESCRIPTION
# Related issues
[KNW-218](https://ankihub.atlassian.net/browse/KNW-218)

# Problem
After signing up for AnkiWeb with email/password, the verification screen immediately called resend, so AnkiWeb sent a second verification email even though signup had already sent the first one. Users received two emails for a single signup.

# How to reproduce

### Before
1. Open the AnkiWeb signup dialog in the add-on
2. Sign up with email + password (not magic code)
3. Reach the “verify your email” screen
4. Check the inbox → two verification emails arrive

### After
1. Open the AnkiWeb signup dialog in the add-on
2. Sign up with email + password (not magic code)
3. Reach the “verify your email” screen
4. Check the inbox → one verification email arrives
5. “Resend verification email” still works if the user clicks it manually

[KNW-218]: https://ankihub.atlassian.net/browse/KNW-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ