### PR TITLE
[KNW-219] Fix Preferences AnkiHub auth so magic-code login and logout UI stay in sync

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -33,7 +33,7 @@ from .gui.config_dialog import setup_config_dialog_manager
 from .gui.enable_fsrs_dialog import maybe_show_enable_fsrs_reminder
 from .gui.errors import setup_error_handler
 from .gui.media_sync import media_sync
-from .gui.menu import menu_state, refresh_ankihub_menu, setup_ankihub_menu
+from .gui.menu import menu_state, refresh_ankihub_menu, setup_ankihub_menu, setup_preferences_ankihub_auth_patch
 from .gui.operations.ankihub_sync import setup_full_sync_patch
 from .gui.optimize_fsrs_dialog import maybe_show_fsrs_optimization_reminder
 from .gui.subdeck_due_date_dialog import maybe_show_subdeck_due_date_reminders
@@ -45,6 +45,7 @@ from .settings import (
     ankihub_db_path,
     config,
     setup_logger,
+    setup_native_ankihub_token_hook,
     setup_profile_data_folder,
 )
 from .user_state import (
@@ -285,6 +286,13 @@ def _general_setup() -> None:
 
     config.token_change_hook.append(refresh_user_state_in_background)
     LOGGER.info("Set up refreshing of user state on token change.")
+
+    # Bridge Anki Preferences → AnkiHub login/logout into token_change_hook.
+    setup_native_ankihub_token_hook()
+
+    # Preferences → Third-party AnkiHub login must use the add-on (staging-aware)
+    # instead of Anki's production-only dialog.
+    setup_preferences_ankihub_auth_patch()
 
     setup_periodic_user_state_refresh(interval_minutes=60)
     LOGGER.info("Set up periodic refresh of feature flags and user details.")

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -240,10 +240,13 @@ class AnkiHubLogin(QWidget):
 def setup_preferences_ankihub_auth_patch() -> None:
     """Route Preferences → Third-party AnkiHub login/logout through the add-on.
 
-    Anki's native dialog always authenticates against production AnkiHub and then
-    installs the AnkiWeb add-on package. That breaks staging (invalid token → no
-    feature flags → magic-code AnkiWeb login patch stays off) and reinstalls a
-    duplicate add-on next to the development symlink.
+    Anki's native dialog does not go through Config.save_token, so feature flags are
+    not refreshed and the magic-code AnkiWeb login patch stays off. It also tries to
+    install the AnkiWeb add-on package, which can collide with a local install.
+
+    Also keep the Preferences AnkiHub login/logout buttons in sync when the user signs
+    in from the AnkiHub menu: Anki's DialogManager may reuse a cached Preferences
+    window, so we implement reopen() and refresh on token_change_hook.
     """
 
     def patched_ankihub_login(
@@ -268,11 +271,23 @@ def setup_preferences_ankihub_auth_patch() -> None:
         _sign_out_action()
         on_success()
 
+    def reopen_preferences(self: aqt.preferences.Preferences, *args, **kwargs) -> None:
+        # DialogManager reuses Preferences without recreating it; refresh auth UI.
+        self.update_login_status()
+
+    def refresh_preferences_ankihub_login_status() -> None:
+        prefs = aqt.dialogs._dialogs.get("Preferences", [None, None])[1]
+        if prefs is not None:
+            prefs.update_login_status()
+
     aqt.ankihub.ankihub_login = patched_ankihub_login
     aqt.ankihub.ankihub_logout = patched_ankihub_logout
     # preferences.py does `from aqt.ankihub import ankihub_login`, so patch both bindings.
     aqt.preferences.ankihub_login = patched_ankihub_login
     aqt.preferences.ankihub_logout = patched_ankihub_logout
+    aqt.preferences.Preferences.reopen = reopen_preferences  # type: ignore[method-assign]
+    if refresh_preferences_ankihub_login_status not in config.token_change_hook:
+        config.token_change_hook.append(refresh_preferences_ankihub_login_status)
     LOGGER.info("Set up Preferences AnkiHub auth patch.")
 
 

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import aqt
-import aqt.ankihub
 import aqt.preferences
 from aqt import (
     AnkiApp,
@@ -249,6 +248,14 @@ def setup_preferences_ankihub_auth_patch() -> None:
     window, so we implement reopen() and refresh on token_change_hook.
     """
 
+    try:
+        import aqt.ankihub
+    except ModuleNotFoundError:
+        # Preferences → Third-party AnkiHub login doesn't exist on older Anki versions
+        # (e.g. the aqt==2.1.56 baseline we still support), so there is nothing to patch.
+        LOGGER.info("aqt.ankihub not available; skipping Preferences AnkiHub auth patch.")
+        return
+
     def patched_ankihub_login(
         mw: aqt.main.AnkiQt,
         on_success: Callable[[], None],
@@ -285,7 +292,7 @@ def setup_preferences_ankihub_auth_patch() -> None:
     # preferences.py does `from aqt.ankihub import ankihub_login`, so patch both bindings.
     aqt.preferences.ankihub_login = patched_ankihub_login
     aqt.preferences.ankihub_logout = patched_ankihub_logout
-    aqt.preferences.Preferences.reopen = reopen_preferences  # type: ignore[method-assign]
+    aqt.preferences.Preferences.reopen = reopen_preferences  # type: ignore[method-assign, attr-defined]
     if refresh_preferences_ankihub_login_status not in config.token_change_hook:
         config.token_change_hook.append(refresh_preferences_ankihub_login_status)
     LOGGER.info("Set up Preferences AnkiHub auth patch.")

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -3,9 +3,11 @@
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import aqt
+import aqt.ankihub
+import aqt.preferences
 from aqt import (
     AnkiApp,
     QHBoxLayout,
@@ -84,6 +86,7 @@ class AnkiHubLogin(QWidget):
 
     def __init__(self):
         super(AnkiHubLogin, self).__init__()
+        self._on_success: Optional[Callable[[], None]] = None
         self.results = None
         self.thread = None  # type: ignore
         self.box_top = QVBoxLayout()
@@ -209,14 +212,18 @@ class AnkiHubLogin(QWidget):
         from ..user_state import add_user_state_refreshed_callback
 
         add_user_state_refreshed_callback(_maybe_show_onboarding_tutorial_after_login)
+        on_success = self._on_success
+        self._on_success = None
         self.close()
+        if on_success:
+            on_success()
 
     def clear_fields(self):
         self.username_or_email_box_text.setText("")
         self.password_box_text.setText("")
 
     @classmethod
-    def display_login(cls):
+    def display_login(cls, on_success: Optional[Callable[[], None]] = None):
         if cls._window is None:
             cls._window = cls()
         else:
@@ -225,8 +232,48 @@ class AnkiHubLogin(QWidget):
             cls._window.raise_()
             cls._window.show()
 
+        cls._window._on_success = on_success
         LOGGER.info("Showed AnkiHub login dialog.")
         return cls._window
+
+
+def setup_preferences_ankihub_auth_patch() -> None:
+    """Route Preferences → Third-party AnkiHub login/logout through the add-on.
+
+    Anki's native dialog always authenticates against production AnkiHub and then
+    installs the AnkiWeb add-on package. That breaks staging (invalid token → no
+    feature flags → magic-code AnkiWeb login patch stays off) and reinstalls a
+    duplicate add-on next to the development symlink.
+    """
+
+    def patched_ankihub_login(
+        mw: aqt.main.AnkiQt,
+        on_success: Callable[[], None],
+        username: str = "",
+        password: str = "",
+        *args,
+        **kwargs,
+    ) -> None:
+        LOGGER.info("Redirecting Preferences AnkiHub login to add-on login dialog.")
+        AnkiHubLogin.display_login(on_success=on_success)
+
+    def patched_ankihub_logout(
+        mw: aqt.main.AnkiQt,
+        on_success: Callable[[], None],
+        token: str,
+        *args,
+        **kwargs,
+    ) -> None:
+        LOGGER.info("Redirecting Preferences AnkiHub logout to add-on sign out.")
+        _sign_out_action()
+        on_success()
+
+    aqt.ankihub.ankihub_login = patched_ankihub_login
+    aqt.ankihub.ankihub_logout = patched_ankihub_logout
+    # preferences.py does `from aqt.ankihub import ankihub_login`, so patch both bindings.
+    aqt.preferences.ankihub_login = patched_ankihub_login
+    aqt.preferences.ankihub_logout = patched_ankihub_logout
+    LOGGER.info("Set up Preferences AnkiHub auth patch.")
 
 
 def _maybe_show_onboarding_tutorial_after_login() -> None:

--- a/ankihub/gui/menu.py
+++ b/ankihub/gui/menu.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 
 import aqt
 import aqt.preferences
+from anki.hooks import wrap
 from aqt import (
     AnkiApp,
     QHBoxLayout,
@@ -280,6 +281,9 @@ def setup_preferences_ankihub_auth_patch() -> None:
 
     def reopen_preferences(self: aqt.preferences.Preferences, *args, **kwargs) -> None:
         # DialogManager reuses Preferences without recreating it; refresh auth UI.
+        _old = kwargs.pop("_old", None)
+        if _old is not None:
+            _old(self, *args, **kwargs)
         self.update_login_status()
 
     def refresh_preferences_ankihub_login_status() -> None:
@@ -292,7 +296,16 @@ def setup_preferences_ankihub_auth_patch() -> None:
     # preferences.py does `from aqt.ankihub import ankihub_login`, so patch both bindings.
     aqt.preferences.ankihub_login = patched_ankihub_login
     aqt.preferences.ankihub_logout = patched_ankihub_logout
-    aqt.preferences.Preferences.reopen = reopen_preferences  # type: ignore[method-assign, attr-defined]
+    if hasattr(aqt.preferences.Preferences, "reopen"):
+        # Call through to Anki's native reopen() instead of clobbering it, in case
+        # a future Anki version defines one.
+        aqt.preferences.Preferences.reopen = wrap(  # type: ignore[method-assign]
+            aqt.preferences.Preferences.reopen,
+            reopen_preferences,
+            "around",
+        )
+    else:
+        aqt.preferences.Preferences.reopen = reopen_preferences  # type: ignore[method-assign, attr-defined]
     if refresh_preferences_ankihub_login_status not in config.token_change_hook:
         config.token_change_hook.append(refresh_preferences_ankihub_login_status)
     LOGGER.info("Set up Preferences AnkiHub auth patch.")

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -835,6 +835,48 @@ def _get_build_config() -> dict:
 
 config = _Config()
 
+_native_ankihub_token_hook_installed = False
+
+
+def setup_native_ankihub_token_hook() -> None:
+    """Fire token_change_hook when Anki Preferences sets the AnkiHub token.
+
+    Preferences → Syncing → AnkiHub login/logout uses ProfileManager.set_ankihub_token,
+    which writes the same profile key as Config.save_token but does not notify the add-on.
+    Without this bridge, feature flags are not refreshed after that login path, so gated
+    behavior (e.g. the AnkiWeb magic-code login dialog) stays inactive until another refresh.
+    """
+    global _native_ankihub_token_hook_installed
+    if _native_ankihub_token_hook_installed:
+        return
+
+    from anki.hooks import wrap
+    from aqt.profiles import ProfileManager
+
+    if not hasattr(ProfileManager, "set_ankihub_token"):
+        LOGGER.info("ProfileManager.set_ankihub_token not available; skipping native token hook.")
+        return
+
+    def _on_set_ankihub_token(*args: Any, **kwargs: Any) -> None:
+        _old = kwargs.pop("_old")
+        pm = args[0]
+        val = args[1] if len(args) > 1 else kwargs.get("val")
+        previous = pm.ankihub_token() if getattr(pm, "profile", None) else None
+        _old(*args, **kwargs)
+        if previous == val:
+            return
+        for func in config.token_change_hook:
+            # Match Config.save_token: run on main so hook exceptions stay isolated.
+            aqt.mw.taskman.run_on_main(func)
+
+    ProfileManager.set_ankihub_token = wrap(  # type: ignore[method-assign]
+        ProfileManager.set_ankihub_token,
+        _on_set_ankihub_token,
+        "around",
+    )
+    _native_ankihub_token_hook_installed = True
+    LOGGER.info("Set up native AnkiHub token change hook.")
+
 
 def setup_profile_data_folder() -> bool:
     """Sets up the profile data folder for the currently open Anki profile.

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Protocol, Tup
 from unittest.mock import MagicMock, Mock, patch
 
 import aqt
+import aqt.profiles
 import pytest
 import requests
 from anki.decks import DeckId
@@ -2236,6 +2237,10 @@ class TestSetupSyncDialogPatchFailure:
         logger_mock.exception.assert_called_once()
 
 
+@pytest.mark.skipif(
+    not hasattr(aqt.profiles.ProfileManager, "set_ankihub_token"),
+    reason="ProfileManager.set_ankihub_token doesn't exist on this Anki version",
+)
 class TestNativeAnkiHubTokenHook:
     """Preferences → Syncing → AnkiHub login uses ProfileManager.set_ankihub_token,
     which must notify the add-on so feature flags (and gated patches) refresh.

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import logging
 import os
@@ -2270,9 +2271,7 @@ class TestNativeAnkiHubTokenHook:
         finally:
             config.token_change_hook.remove(hook)
 
-    def test_unchanged_token_does_not_fire_hook(
-        self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
-    ):
+    def test_unchanged_token_does_not_fire_hook(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
         mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
         hook = Mock()
         try:
@@ -2341,6 +2340,10 @@ class TestNativeAnkiHubTokenHook:
             remove_user_state_refreshed_callback(_patch_or_revert)
 
 
+@pytest.mark.skipif(
+    not importlib.util.find_spec("aqt.ankihub"),
+    reason="Preferences → Third-party AnkiHub login doesn't exist on this Anki version",
+)
 class TestPreferencesAnkiHubAuthPatch:
     """Preferences → Third-party AnkiHub auth should use the add-on and stay in sync
     with menu Sign In / Sign Out.
@@ -2348,6 +2351,8 @@ class TestPreferencesAnkiHubAuthPatch:
 
     @pytest.fixture(autouse=True)
     def _restore_ankihub_auth(self):
+        import aqt.ankihub
+
         original_login = aqt.ankihub.ankihub_login
         original_logout = aqt.ankihub.ankihub_logout
         original_prefs_login = aqt.preferences.ankihub_login
@@ -2395,7 +2400,7 @@ class TestPreferencesAnkiHubAuthPatch:
 
         assert callable(getattr(aqt.preferences.Preferences, "reopen", None))
         prefs = Mock()
-        aqt.preferences.Preferences.reopen(prefs)
+        aqt.preferences.Preferences.reopen(prefs)  # type: ignore[attr-defined]
         prefs.update_login_status.assert_called_once_with()
 
     def test_token_change_refreshes_open_preferences(self, mocker: MockerFixture):

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2402,6 +2402,30 @@ class TestPreferencesAnkiHubAuthPatch:
         aqt.preferences.Preferences.reopen(prefs)  # type: ignore[attr-defined]
         prefs.update_login_status.assert_called_once_with()
 
+    def test_preferences_reopen_calls_through_to_native_reopen_if_present(self):
+        """If a future Anki version defines Preferences.reopen, our patch must call
+        through to it instead of clobbering it (see PR discussion with @abdnh).
+
+        anki.hooks.wrap()'s "around" mode requires the wrapped callable to be
+        introspectable (it needs __name__/__qualname__/a real signature), so a
+        plain function is used here to simulate the native reopen rather than
+        a Mock.
+        """
+        native_reopen_calls = []
+
+        def native_reopen(self, *args, **kwargs):
+            native_reopen_calls.append((self, args, kwargs))
+
+        aqt.preferences.Preferences.reopen = native_reopen  # type: ignore[method-assign, attr-defined]
+
+        setup_preferences_ankihub_auth_patch()
+
+        prefs = Mock()
+        aqt.preferences.Preferences.reopen(prefs, "arg", kw="kwarg")  # type: ignore[attr-defined]
+
+        assert native_reopen_calls == [(prefs, ("arg",), {"kw": "kwarg"})]
+        prefs.update_login_status.assert_called_once_with()
+
     def test_token_change_refreshes_open_preferences(self, mocker: MockerFixture):
         mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
         setup_preferences_ankihub_auth_patch()

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2342,8 +2342,8 @@ class TestNativeAnkiHubTokenHook:
 
 
 class TestPreferencesAnkiHubAuthPatch:
-    """Preferences → Third-party AnkiHub login must use the add-on dialog so staging
-    credentials work and Anki does not reinstall the AnkiWeb add-on package.
+    """Preferences → Third-party AnkiHub auth should use the add-on and stay in sync
+    with menu Sign In / Sign Out.
     """
 
     @pytest.fixture(autouse=True)
@@ -2352,11 +2352,19 @@ class TestPreferencesAnkiHubAuthPatch:
         original_logout = aqt.ankihub.ankihub_logout
         original_prefs_login = aqt.preferences.ankihub_login
         original_prefs_logout = aqt.preferences.ankihub_logout
+        original_reopen = getattr(aqt.preferences.Preferences, "reopen", None)
+        hooks_before = list(config.token_change_hook)
         yield
         aqt.ankihub.ankihub_login = original_login
         aqt.ankihub.ankihub_logout = original_logout
         aqt.preferences.ankihub_login = original_prefs_login
         aqt.preferences.ankihub_logout = original_prefs_logout
+        if original_reopen is None:
+            if hasattr(aqt.preferences.Preferences, "reopen"):
+                delattr(aqt.preferences.Preferences, "reopen")
+        else:
+            aqt.preferences.Preferences.reopen = original_reopen
+        config.token_change_hook[:] = hooks_before
 
     def test_preferences_login_opens_addon_login_dialog(self, mocker: MockerFixture):
         display_login = mocker.patch.object(AnkiHubLogin, "display_login")
@@ -2381,6 +2389,26 @@ class TestPreferencesAnkiHubAuthPatch:
 
         sign_out.assert_called_once_with()
         on_success.assert_called_once_with()
+
+    def test_preferences_reopen_refreshes_ankihub_login_status(self, mocker: MockerFixture):
+        setup_preferences_ankihub_auth_patch()
+
+        assert callable(getattr(aqt.preferences.Preferences, "reopen", None))
+        prefs = Mock()
+        aqt.preferences.Preferences.reopen(prefs)
+        prefs.update_login_status.assert_called_once_with()
+
+    def test_token_change_refreshes_open_preferences(self, mocker: MockerFixture):
+        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+        setup_preferences_ankihub_auth_patch()
+        prefs = Mock()
+        mocker.patch.object(aqt.dialogs, "_dialogs", {"Preferences": [aqt.preferences.Preferences, prefs]})
+
+        # Simulate menu Sign In writing the token via Config.save_token
+        config.save_token("menu-login-token")
+
+        prefs.update_login_status.assert_called_with()
+        config.save_token("")  # cleanup
 
     def test_display_login_invokes_on_success_after_login(self, mocker: MockerFixture, qtbot: QtBot):
         mocker.patch("ankihub.gui.menu.AnkiHubClient.login", return_value="staging-token")

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -147,7 +147,7 @@ from ankihub.gui.media_sync import (
     MediaSyncStatus,
     media_sync,
 )
-from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu
+from ankihub.gui.menu import AnkiHubLogin, menu_state, refresh_ankihub_menu, setup_preferences_ankihub_auth_patch
 from ankihub.gui.operations.deck_creation import (
     DeckCreationConfirmationDialog,
     create_collaborative_deck,
@@ -232,6 +232,7 @@ from ankihub.settings import (
     DatadogLogHandler,
     config,
     log_file_path,
+    setup_native_ankihub_token_hook,
 )
 from ankihub.user_state import (
     _state,
@@ -2232,6 +2233,170 @@ class TestSetupSyncDialogPatchFailure:
         setup_sync_dialog_patch()  # must not raise
 
         logger_mock.exception.assert_called_once()
+
+
+class TestNativeAnkiHubTokenHook:
+    """Preferences → Syncing → AnkiHub login uses ProfileManager.set_ankihub_token,
+    which must notify the add-on so feature flags (and gated patches) refresh.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_set_ankihub_token(self):
+        from aqt.profiles import ProfileManager
+
+        from ankihub import settings
+
+        original = ProfileManager.set_ankihub_token
+        original_flag = settings._native_ankihub_token_hook_installed
+        settings._native_ankihub_token_hook_installed = False
+        yield
+        ProfileManager.set_ankihub_token = original
+        settings._native_ankihub_token_hook_installed = original_flag
+
+    def test_set_ankihub_token_fires_token_change_hook(
+        self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
+    ):
+        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+        hook = Mock()
+        config.token_change_hook.append(hook)
+        try:
+            with anki_session_with_addon_data.profile_loaded():
+                setup_native_ankihub_token_hook()
+
+                aqt.mw.pm.set_ankihub_token("preferences-login-token")
+
+                hook.assert_called_once_with()
+                assert aqt.mw.pm.ankihub_token() == "preferences-login-token"
+        finally:
+            config.token_change_hook.remove(hook)
+
+    def test_unchanged_token_does_not_fire_hook(
+        self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
+    ):
+        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+        hook = Mock()
+        try:
+            with anki_session_with_addon_data.profile_loaded():
+                aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = "same-token"
+                setup_native_ankihub_token_hook()
+                config.token_change_hook.append(hook)
+
+                aqt.mw.pm.set_ankihub_token("same-token")
+
+                hook.assert_not_called()
+        finally:
+            if hook in config.token_change_hook:
+                config.token_change_hook.remove(hook)
+
+    def test_setup_is_idempotent(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
+        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+        hook = Mock()
+        config.token_change_hook.append(hook)
+        try:
+            with anki_session_with_addon_data.profile_loaded():
+                setup_native_ankihub_token_hook()
+                setup_native_ankihub_token_hook()
+
+                aqt.mw.pm.set_ankihub_token("once-only")
+
+                hook.assert_called_once_with()
+        finally:
+            config.token_change_hook.remove(hook)
+
+    @pytest.mark.skipif(using_qt5(), reason="AnkiWeb signup screens are not supported on Qt5")
+    def test_preferences_login_path_enables_magic_code_patch_after_flag_refresh(
+        self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
+    ):
+        """End-to-end for the bug: Preferences AnkiHub login must be able to activate
+        the AnkiWeb magic-code dialog once feature flags are refreshed."""
+        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+        dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
+        feature_flags = {"ankiweb_magic_code_login": False}
+        mocker.patch.object(config, "get_feature_flags", side_effect=lambda: feature_flags)
+        original_sync_login = aqt.sync.sync_login
+
+        def refresh_flags_then_patch() -> None:
+            feature_flags["ankiweb_magic_code_login"] = True
+            _patch_or_revert()
+
+        config.token_change_hook.append(refresh_flags_then_patch)
+        try:
+            with anki_session_with_addon_data.profile_loaded():
+                setup_sync_dialog_patch()
+                assert aqt.sync.sync_login is original_sync_login
+
+                setup_native_ankihub_token_hook()
+                # Simulate Anki Preferences → Syncing → AnkiHub login
+                aqt.mw.pm.set_ankihub_token("preferences-login-token")
+
+                assert aqt.sync.sync_login is not original_sync_login
+                on_success = Mock()
+                aqt.sync.sync_login(aqt.mw, on_success)
+                dialog_mock.assert_called_once_with(on_success=on_success, parent=aqt.mw)
+        finally:
+            config.token_change_hook.remove(refresh_flags_then_patch)
+            aqt.sync.sync_login = original_sync_login
+            aqt.main.sync_login = original_sync_login
+            aqt.preferences.sync_login = original_sync_login
+            remove_user_state_refreshed_callback(_patch_or_revert)
+
+
+class TestPreferencesAnkiHubAuthPatch:
+    """Preferences → Third-party AnkiHub login must use the add-on dialog so staging
+    credentials work and Anki does not reinstall the AnkiWeb add-on package.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_ankihub_auth(self):
+        original_login = aqt.ankihub.ankihub_login
+        original_logout = aqt.ankihub.ankihub_logout
+        original_prefs_login = aqt.preferences.ankihub_login
+        original_prefs_logout = aqt.preferences.ankihub_logout
+        yield
+        aqt.ankihub.ankihub_login = original_login
+        aqt.ankihub.ankihub_logout = original_logout
+        aqt.preferences.ankihub_login = original_prefs_login
+        aqt.preferences.ankihub_logout = original_prefs_logout
+
+    def test_preferences_login_opens_addon_login_dialog(self, mocker: MockerFixture):
+        display_login = mocker.patch.object(AnkiHubLogin, "display_login")
+        on_success = Mock()
+
+        setup_preferences_ankihub_auth_patch()
+
+        aqt.preferences.ankihub_login(aqt.mw, on_success)
+        display_login.assert_called_once_with(on_success=on_success)
+
+        display_login.reset_mock()
+        aqt.ankihub.ankihub_login(aqt.mw, on_success, "user", "pass")
+        display_login.assert_called_once_with(on_success=on_success)
+
+    def test_preferences_logout_uses_addon_sign_out(self, mocker: MockerFixture):
+        sign_out = mocker.patch("ankihub.gui.menu._sign_out_action")
+        on_success = Mock()
+
+        setup_preferences_ankihub_auth_patch()
+
+        aqt.preferences.ankihub_logout(aqt.mw, on_success, "token")
+
+        sign_out.assert_called_once_with()
+        on_success.assert_called_once_with()
+
+    def test_display_login_invokes_on_success_after_login(self, mocker: MockerFixture, qtbot: QtBot):
+        mocker.patch("ankihub.gui.menu.AnkiHubClient.login", return_value="staging-token")
+        mocker.patch("ankihub.gui.menu.tooltip")
+        mocker.patch("ankihub.user_state.add_user_state_refreshed_callback")
+        on_success = Mock()
+
+        AnkiHubLogin.display_login(on_success=on_success)
+        window: AnkiHubLogin = AnkiHubLogin._window
+        window.username_or_email_box_text.setText("staging@example.com")
+        window.password_box_text.setText("secret")
+        window.login_button.click()
+
+        qtbot.wait_until(lambda: not window.isVisible())
+        on_success.assert_called_once_with()
+        assert config.token() == "staging-token"
 
 
 class TestSuggestionDialog:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2262,11 +2262,11 @@ class TestNativeAnkiHubTokenHook:
     def test_set_ankihub_token_fires_token_change_hook(
         self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
     ):
-        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
         hook = Mock()
         config.token_change_hook.append(hook)
         try:
             with anki_session_with_addon_data.profile_loaded():
+                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 setup_native_ankihub_token_hook()
 
                 aqt.mw.pm.set_ankihub_token("preferences-login-token")
@@ -2277,10 +2277,10 @@ class TestNativeAnkiHubTokenHook:
             config.token_change_hook.remove(hook)
 
     def test_unchanged_token_does_not_fire_hook(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
-        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
         hook = Mock()
         try:
             with anki_session_with_addon_data.profile_loaded():
+                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = "same-token"
                 setup_native_ankihub_token_hook()
                 config.token_change_hook.append(hook)
@@ -2293,11 +2293,11 @@ class TestNativeAnkiHubTokenHook:
                 config.token_change_hook.remove(hook)
 
     def test_setup_is_idempotent(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
-        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
         hook = Mock()
         config.token_change_hook.append(hook)
         try:
             with anki_session_with_addon_data.profile_loaded():
+                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 setup_native_ankihub_token_hook()
                 setup_native_ankihub_token_hook()
 
@@ -2313,8 +2313,6 @@ class TestNativeAnkiHubTokenHook:
     ):
         """End-to-end for the bug: Preferences AnkiHub login must be able to activate
         the AnkiWeb magic-code dialog once feature flags are refreshed."""
-        mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
-        dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
         feature_flags = {"ankiweb_magic_code_login": False}
         mocker.patch.object(config, "get_feature_flags", side_effect=lambda: feature_flags)
         original_sync_login = aqt.sync.sync_login
@@ -2326,6 +2324,8 @@ class TestNativeAnkiHubTokenHook:
         config.token_change_hook.append(refresh_flags_then_patch)
         try:
             with anki_session_with_addon_data.profile_loaded():
+                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
+                dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
                 setup_sync_dialog_patch()
                 assert aqt.sync.sync_login is original_sync_login
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2259,14 +2259,11 @@ class TestNativeAnkiHubTokenHook:
         ProfileManager.set_ankihub_token = original
         settings._native_ankihub_token_hook_installed = original_flag
 
-    def test_set_ankihub_token_fires_token_change_hook(
-        self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession
-    ):
+    def test_set_ankihub_token_fires_token_change_hook(self, anki_session_with_addon_data: AnkiSession):
         hook = Mock()
         config.token_change_hook.append(hook)
         try:
             with anki_session_with_addon_data.profile_loaded():
-                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 setup_native_ankihub_token_hook()
 
                 aqt.mw.pm.set_ankihub_token("preferences-login-token")
@@ -2276,11 +2273,10 @@ class TestNativeAnkiHubTokenHook:
         finally:
             config.token_change_hook.remove(hook)
 
-    def test_unchanged_token_does_not_fire_hook(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
+    def test_unchanged_token_does_not_fire_hook(self, anki_session_with_addon_data: AnkiSession):
         hook = Mock()
         try:
             with anki_session_with_addon_data.profile_loaded():
-                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = "same-token"
                 setup_native_ankihub_token_hook()
                 config.token_change_hook.append(hook)
@@ -2292,12 +2288,11 @@ class TestNativeAnkiHubTokenHook:
             if hook in config.token_change_hook:
                 config.token_change_hook.remove(hook)
 
-    def test_setup_is_idempotent(self, mocker: MockerFixture, anki_session_with_addon_data: AnkiSession):
+    def test_setup_is_idempotent(self, anki_session_with_addon_data: AnkiSession):
         hook = Mock()
         config.token_change_hook.append(hook)
         try:
             with anki_session_with_addon_data.profile_loaded():
-                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 setup_native_ankihub_token_hook()
                 setup_native_ankihub_token_hook()
 
@@ -2324,7 +2319,6 @@ class TestNativeAnkiHubTokenHook:
         config.token_change_hook.append(refresh_flags_then_patch)
         try:
             with anki_session_with_addon_data.profile_loaded():
-                mocker.patch.object(aqt.mw.taskman, "run_on_main", side_effect=lambda fn: fn())
                 dialog_mock = mocker.patch("ankihub.gui.ankiweb.AnkiwebLoginDialog")
                 setup_sync_dialog_patch()
                 assert aqt.sync.sync_login is original_sync_login


### PR DESCRIPTION
# Related issues
[KNW-219](https://ankihub.atlassian.net/browse/KNW-219)

# Problem
Signing into AnkiHub from **Preferences → Third-party** did not notify the add-on, so feature flags were not refreshed and the AnkiWeb magic-code login dialog stayed off (old password dialog was shown). That flow could also reinstall the AnkiWeb add-on package.

Separately, after signing in from **AnkiHub menu → Sign In**, Preferences → Third-party still showed **Log in** instead of **Log out**, because Anki may reuse a cached Preferences window without refreshing the auth UI.

# How to reproduce

### Before
1. Open Preferences → Third-party → Log in to AnkiHub (native dialog)
2. Open Preferences → Syncing → Log in to AnkiWeb
3. Observe the old password-based AnkiWeb login dialog (magic-code dialog does not appear)
4. Sign out if needed, then sign in via AnkiHub menu → Sign In
5. Open Preferences → Third-party
6. Observe AnkiHub still shows **Log in** instead of **Log out**

### After
1. Open Preferences → Third-party → Log in to AnkiHub
2. Observe the add-on sign-in dialog opens
3. After login, open Preferences → Syncing → Log in to AnkiWeb
4. Observe the magic-code AnkiWeb login dialog (feature flag on)
5. Sign out, then sign in via AnkiHub menu → Sign In
6. Open Preferences → Third-party
7. Observe AnkiHub shows **Log out**

[KNW-219]: https://ankihub.atlassian.net/browse/KNW-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ