### PR TITLE
test: cover setup_native_ankihub_token_hook no-op path when set_ankihub_token is missing

### DIFF
--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -2259,6 +2259,23 @@ class TestNativeAnkiHubTokenHook:
         ProfileManager.set_ankihub_token = original
         settings._native_ankihub_token_hook_installed = original_flag
 
+    def test_setup_is_noop_without_set_ankihub_token(
+        self, monkeypatch: MonkeyPatch, anki_session_with_addon_data: AnkiSession
+    ):
+        """Guards the hasattr() branch in setup_native_ankihub_token_hook: on Anki
+        versions without ProfileManager.set_ankihub_token (e.g. the legacy aqt==2.1.56
+        baseline), setup must no-op instead of raising or installing anything."""
+        from aqt.profiles import ProfileManager
+
+        from ankihub import settings
+
+        monkeypatch.delattr(ProfileManager, "set_ankihub_token", raising=False)
+
+        with anki_session_with_addon_data.profile_loaded():
+            setup_native_ankihub_token_hook()  # must not raise
+
+            assert not settings._native_ankihub_token_hook_installed
+
     def test_set_ankihub_token_fires_token_change_hook(self, anki_session_with_addon_data: AnkiSession):
         hook = Mock()
         config.token_change_hook.append(hook)


### PR DESCRIPTION
# Related issues

KNW-219 

# Problem

In #1364, [Luc](https://github.com/AnkiHubSoftware/ankihub_addon/pull/1364#discussion_r3753116385) asked whether `setup_native_ankihub_token_hook()`'s no-op behavior, when `ProfileManager.set_ankihub_token` doesn't exist (e.g. on the legacy `aqt==2.1.56` baseline), was already covered by a test. It wasn't: the whole `TestNativeAnkiHubTokenHook` class is skipped on that Anki version, so the `hasattr()` guard branch had no explicit assertion anywhere.

# What changed

Added `test_setup_is_noop_without_set_ankihub_token`, which uses `monkeypatch.delattr(ProfileManager, "set_ankihub_token", raising=False)` to simulate the missing attribute regardless of the Anki version actually installed, and asserts that `setup_native_ankihub_token_hook()` no-ops (doesn't raise, doesn't install the hook) instead of relying only on the skip.

# How to verify

\`\`\`
pytest tests/addon/test_unit.py -k test_setup_is_noop_without_set_ankihub_token
\`\`\`