### PR TITLE
[ACTV-444] [AnKing] Smart Search window freezes during tour at Step 5

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1379,9 +1379,8 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
             )
         )
 
-        smart_search_link = render_link(f'javascript:pycmd("{FLASHCARD_SELECTOR_OPEN_PYCMD}")', "Smart Search")
         body = (
-            f"Or use our AI {smart_search_link}, "
+            "Or use our AI <b>Smart Search</b>, "
             "a Premium feature that helps you search decks for cards"
             " that match your study materials (lecture notes, PDFs, study aids, and more)."
         )


### PR DESCRIPTION
## Related issues
- [x] Closes # [ACTV-444](https://ankihub.atlassian.net/browse/ACTV-444)

## Proposed changes
Removes the link to open the Smart Search on the step 5 of the Step Deck Tour

## How to reproduce
1. Run the Step Deck Tour
2. See on step 5 that the name `Smart Search` is bold instead of having a link.


## Screenshots and videos

<img width="754" height="535" alt="image" src="https://github.com/user-attachments/assets/0a1e73ee-e6e4-4bb9-975f-ac8f5518ad2f" />


[ACTV-444]: https://ankihub.atlassian.net/browse/ACTV-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ