### PR TITLE
[KNW-220] Fix signup-code retry so Get code stays available after cooldown ends

### DIFF
--- a/ankihub/gui/ankiweb.py
+++ b/ankihub/gui/ankiweb.py
@@ -979,10 +979,10 @@ class SignupCodeVerificationWidget(BaseSignupWidget):
                 tooltip("Sign-in successful!", parent=aqt.mw)
                 self._dialog._on_success()
             except Exception as exc:
-                if self._timer.remaining_seconds > 0:
-                    remaining_seconds = self._timer.remaining_seconds
-                else:
-                    remaining_seconds = self.remaining_seconds
+                # Only carry over an active cooldown. If it already ran out, leave
+                # Get code enabled — do not restart the full TTL (that should only
+                # begin after a successful Get code / resend request).
+                remaining_seconds = self._timer.remaining_seconds if timer_is_active(self._timer) else 0
                 self._dialog.replace_widget(
                     SignupCodeVerificationWidget(
                         email=self._get_email(),

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1771,15 +1771,23 @@ class TestAnkiwebLoginAndSignupSubmission:
         widget._on_verify_or_resend()
 
         # The retry widget resumes the countdown of the failed one instead of
-        # restarting it from the full TTL.
+        # restarting it from the full TTL, so Get code stays blocked until it ends.
         retry_widget = dialog._widget
         assert retry_widget is not widget
         assert isinstance(retry_widget, SignupCodeVerificationWidget)
         assert retry_widget.remaining_seconds == remaining_seconds
+        assert retry_widget.email_box.button.isEnabled() is False
+        assert "Resend available in" in retry_widget.status_label.text()
 
-    def test_signup_code_verification_restarts_timer_when_it_ran_out(self, qtbot: QtBot, mocker: MockerFixture):
+    def test_signup_code_verification_enables_get_code_when_timer_ran_out(
+        self, qtbot: QtBot, mocker: MockerFixture
+    ):
         resend_cooldown_secs = 3
-        mocker.patch.object(AddonAnkiHubClient, "ankiweb_verify_signup_code", side_effect=Exception("some error"))
+        mocker.patch.object(
+            AddonAnkiHubClient,
+            "ankiweb_verify_signup_code",
+            side_effect=Exception("This code has expired. Request another."),
+        )
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
         widget = SignupCodeVerificationWidget(
@@ -1795,13 +1803,60 @@ class TestAnkiwebLoginAndSignupSubmission:
         widget.code_input.setText("123456")
         widget._on_verify_or_resend()
 
-        # There is no countdown left to resume, so the retry widget starts over from
-        # the full TTL instead of inheriting the expired one.
+        # No active cooldown left — do not restart the full TTL. Get code must be
+        # clickable so the user can request another after an expired code.
         retry_widget = dialog._widget
         assert retry_widget is not widget
         assert isinstance(retry_widget, SignupCodeVerificationWidget)
-        assert retry_widget.remaining_seconds == resend_cooldown_secs
-        assert retry_widget._timer.remaining_seconds == resend_cooldown_secs - 1
+        assert retry_widget.remaining_seconds == 0
+        assert retry_widget.email_box.button.isEnabled() is True
+        assert retry_widget._timer is None or retry_widget._timer.remaining_seconds <= 0
+        assert "expired" in retry_widget.form_widget.error_label.status.text()
+        assert "Resend available in" not in retry_widget.status_label.text()
+
+    def test_signup_code_verification_retry_get_code_starts_cooldown(
+        self, qtbot: QtBot, mocker: MockerFixture
+    ):
+        mocker.patch.object(
+            AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(resend_cooldown_secs=120)
+        )
+        mocker.patch.object(aqt.mw.taskman, "run_in_background", side_effect=_run_in_background_synchronously)
+
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(
+            email="user@example.com",
+            remaining_seconds=0,
+            dialog=dialog,
+            exc=Exception("This code has expired. Request another."),
+        )
+        dialog.replace_widget(widget)
+
+        assert widget.email_box.button.isEnabled() is True
+
+        widget._on_get_code()
+
+        assert widget.email_box.button.isEnabled() is False
+        assert widget.remaining_seconds == 120
+        assert "Resend available in" in widget.status_label.text()
+
+    def test_signup_code_verification_retry_with_zero_remaining_does_not_start_timer(
+        self, qtbot: QtBot
+    ):
+        dialog = AnkiwebSignupDialog()
+        qtbot.addWidget(dialog)
+        widget = SignupCodeVerificationWidget(
+            email="user@example.com",
+            remaining_seconds=0,
+            dialog=dialog,
+            exc=Exception("Invalid code."),
+        )
+        dialog.replace_widget(widget)
+
+        assert widget.remaining_seconds == 0
+        assert widget.email_box.button.isEnabled() is True
+        assert widget._timer is None
+        assert widget.status_label.text() == ""
 
     def test_signup_with_password_success_shows_email_verification_widget(self, qtbot: QtBot, mocker: MockerFixture):
         from ankihub.gui.ankiweb import SignupEmailVerificationWidget

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -1779,9 +1779,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert retry_widget.email_box.button.isEnabled() is False
         assert "Resend available in" in retry_widget.status_label.text()
 
-    def test_signup_code_verification_enables_get_code_when_timer_ran_out(
-        self, qtbot: QtBot, mocker: MockerFixture
-    ):
+    def test_signup_code_verification_enables_get_code_when_timer_ran_out(self, qtbot: QtBot, mocker: MockerFixture):
         resend_cooldown_secs = 3
         mocker.patch.object(
             AddonAnkiHubClient,
@@ -1814,9 +1812,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert "expired" in retry_widget.form_widget.error_label.status.text()
         assert "Resend available in" not in retry_widget.status_label.text()
 
-    def test_signup_code_verification_retry_get_code_starts_cooldown(
-        self, qtbot: QtBot, mocker: MockerFixture
-    ):
+    def test_signup_code_verification_retry_get_code_starts_cooldown(self, qtbot: QtBot, mocker: MockerFixture):
         mocker.patch.object(
             AddonAnkiHubClient, "ankiweb_request_login_code", return_value=Mock(resend_cooldown_secs=120)
         )
@@ -1840,9 +1836,7 @@ class TestAnkiwebLoginAndSignupSubmission:
         assert widget.remaining_seconds == 120
         assert "Resend available in" in widget.status_label.text()
 
-    def test_signup_code_verification_retry_with_zero_remaining_does_not_start_timer(
-        self, qtbot: QtBot
-    ):
+    def test_signup_code_verification_retry_with_zero_remaining_does_not_start_timer(self, qtbot: QtBot):
         dialog = AnkiwebSignupDialog()
         qtbot.addWidget(dialog)
         widget = SignupCodeVerificationWidget(


### PR DESCRIPTION
## Related issue
KNW-220

## Problem
On the magic-code signup verification retry screen, failing to verify a code after the resend countdown had already ended restarted the full cooldown TTL.

That left **Get code** disabled again even though no new code had been requested, so users who mistyped an expired/invalid code could not immediately request another one.

## How to reproduce

### Before
1. Start signup with magic code and wait until the resend countdown reaches 0.
2. Enter an invalid or expired code and submit.
3. On the retry screen, **Get code** is disabled and a full “Resend available in …” countdown starts again — without the user clicking Get code / resend.

### After
1. Same steps as above.
2. On the retry screen, cooldown is `0`, **Get code** is enabled, and no countdown is shown.
3. Clicking **Get code** starts a new cooldown only after a successful request.
4. If verify fails while a countdown is still active, the remaining time is preserved and Get code stays blocked until it ends.