### PR TITLE
fix: Skip rendering tutorial step if no webview context

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -716,6 +716,8 @@ class Tutorial:
         return handled
 
     def _on_webview_will_set_content(self, web_content: WebContent, context: Any) -> None:
+        if context is None:
+            return
         step = self.steps[self.current_step - 1]
         js = ""
         if context == step.tooltip_context:


### PR DESCRIPTION
## Related issues

https://community.ankihub.net/t/cant-open-up-deck/606916

## Proposed changes

We got a report of this error:
> AssertionError: Webview context of type <class 'NoneType'> is not handled

The most likely explanation for how this is being triggered is:
1. The Step Deck tutorial is active at the first step in the browser but `show_current()` was not called as the app was getting closed (`aqt.mw.progress.timer()` skips its callback if the collection is unavailable), so `tooltip_context`/`target_context` stays at `None`.
2. `Tutorial._on_webview_will_set_content()` is triggered by some webview. In the linked report, it's triggered by a `AnkiWebView.stdHtml()` call by another add-on at app shutdown. `_on_webview_will_set_content()` receives `context=None` in this case, so `webview_for_context()` ends up being called with that and the assert fails.

The fix is to simply return early in `_on_webview_will_set_content()` if `context is None`.