### PR TITLE
[ACTV-477] Tour does not reopen when closing anki before finish

### DIFF
--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -150,7 +150,7 @@ def _on_profile_did_open() -> None:
 
 def _on_profile_will_close() -> None:
     if tutorial.active_tutorial:
-        tutorial.active_tutorial._skip_tutorial()
+        tutorial.active_tutorial.skip_tutorial()
     media_sync.close_for_profile()
     LOGGER.info("Profile will close, stopping background threads.")
 

--- a/ankihub/entry_point.py
+++ b/ankihub/entry_point.py
@@ -150,7 +150,7 @@ def _on_profile_did_open() -> None:
 
 def _on_profile_will_close() -> None:
     if tutorial.active_tutorial:
-        tutorial.active_tutorial.end()
+        tutorial.active_tutorial._skip_tutorial()
     media_sync.close_for_profile()
     LOGGER.info("Profile will close, stopping background threads.")
 

--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -629,7 +629,7 @@ class Tutorial:
         global active_tutorial
         active_tutorial = None
 
-    def _skip_tutorial(self) -> None:
+    def skip_tutorial(self) -> None:
         self._track_tutorial(event_name="tour_postponed")
         # It copies the end() method because it can be called from the Tutorial children
         self._cleanup_step(all_webviews=True)
@@ -703,7 +703,7 @@ class Tutorial:
             self.end()
             return True, None
         elif message == SKIP_TUTORIAL_PYCMD:
-            self._skip_tutorial()
+            self.skip_tutorial()
             return True, None
         elif message == TARGET_CLICK_PYCMD:
             step = self.steps[self.current_step - 1]

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -594,7 +594,7 @@ class TestEntryPoint:
 
         entry_point._on_profile_will_close()
 
-        active_tutorial_mock._skip_tutorial.assert_called_once()
+        active_tutorial_mock.skip_tutorial.assert_called_once()
         close_for_profile_mock.assert_called_once()
 
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -587,14 +587,14 @@ class TestEntryPoint:
 
         on_profile_did_open_mock.assert_called_once()
 
-    def test_on_profile_will_close_ends_active_tutorial(self, mocker: MockerFixture):
+    def test_on_profile_will_close_skips_active_tutorial(self, mocker: MockerFixture):
         active_tutorial_mock = Mock()
         mocker.patch.object(entry_point.tutorial, "active_tutorial", active_tutorial_mock)
         close_for_profile_mock = mocker.patch.object(entry_point.media_sync, "close_for_profile")
 
         entry_point._on_profile_will_close()
 
-        active_tutorial_mock.end.assert_called_once()
+        active_tutorial_mock._skip_tutorial.assert_called_once()
         close_for_profile_mock.assert_called_once()
 
 

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -3982,7 +3982,7 @@ class TestTutorialProductMetrics:
         mocker.patch("ankihub.gui.tutorial.gui_hooks")
 
         tutorial = OnboardingTutorial()
-        tutorial._skip_tutorial()
+        tutorial.skip_tutorial()
 
         mock_client.track.assert_called_once_with(
             distinct_id="42",


### PR DESCRIPTION
## Related issues
- [x] Closes # [ACTV-477](https://ankihub.atlassian.net/browse/ACTV-447)


## Proposed changes
Calls the `skip` method instead of the `end` method when closing anki.

## How to reproduce

1. Make the prompt of either tour appear
2. Close Anki when the tour is running
3. Reopen Anki and see that it prompts the tour again 