### PR TITLE
[ACTV-448] Improve Step Deck tutorial responsiveness

### DIFF
--- a/ankihub/gui/tutorial.py
+++ b/ankihub/gui/tutorial.py
@@ -1376,7 +1376,7 @@ class StepDeckTutorial(DeckBrowserOverviewBackdropMixin, Tutorial):
 
         # There can be multiple sidebar refresh events at browser startup,
         # so we need to ensure we only call .next() once
-        debouncer = DebouncedDelayedCall(wrapped_on_done, delay_ms=1000)
+        debouncer = DebouncedDelayedCall(wrapped_on_done, delay_ms=800)
 
         def _build_deck_tree(*args: Any, **kwargs: Any) -> None:
             _old: Callable[..., None] = kwargs.pop("_old")


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-448](https://ankihub.atlassian.net/browse/ACTV-448)


## Proposed changes
This PR improves the Step Deck Tutorial transition from Step 1 (“Click Browse”) to Step 2 by reducing the startup debounce in the browser initialization flow from **1000ms to 800ms**.

The goal is to make onboarding feel more responsive while preserving the existing protection against duplicate step advancement during Browser/sidebar startup events.

Users currently experience a noticeable pause (~3s perceived in some environments) before Step 2 appears.  
That delay comes from Browser startup latency plus the debounce window used to wait for stable sidebar state. Reducing the debounce by 200ms improves perceived speed with low regression risk.


## How to reproduce
- Run Step Deck tutorial and verify Step 1 → Step 2 transition feels faster.
- Validate behavior on:
  - normal profile
  - heavy profile (large deck/tag/sidebar state)
- Confirm no regressions:
  - no duplicate step transitions
  - Step 2 highlight/target always resolves correctly
  - downstream tutorial steps continue to work normally

#### Expected Outcome
- Faster, smoother transition into Browser-based tutorial steps.
- Improved perceived responsiveness during onboarding without sacrificing stability.



[ACTV-448]: https://ankihub.atlassian.net/browse/ACTV-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
