### PR TITLE
ACTV-453 Prevent staging Intercom identity leak on env switch

### DIFF
--- a/ankihub/gui/intercom.py
+++ b/ankihub/gui/intercom.py
@@ -25,13 +25,24 @@ from ..settings import config
 
 # Standard Intercom loader snippet (see https://developers.intercom.com/installing-intercom/web/installation).
 # Placeholders are substituted at runtime to avoid str.format/f-string brace escaping.
-# The loader detects an already-booted instance and calls reattach_activator/update
-# instead of loading a second time, so it is safe to inject on every re-render.
+# If Intercom is already loaded with a different app_id or user_id, shut down and boot
+# fresh — Intercom('update') does not switch workspaces or users. Same identity keeps
+# reattach_activator/update so it is safe to inject on every re-render.
 _INTERCOM_LOADER_JS = """
-window.intercomSettings = __SETTINGS__;
 (function(){
-  var w=window;var ic=w.Intercom;
-  if(typeof ic==="function"){
+  var w=window;
+  var next=__SETTINGS__;
+  var prev=w.intercomSettings||{};
+  var ic=w.Intercom;
+  var identityChanged=typeof ic==="function"&&(
+    prev.app_id!==next.app_id||
+    String(prev.user_id||"")!==String(next.user_id||"")
+  );
+  w.intercomSettings=next;
+  if(identityChanged){
+    ic('shutdown');
+    ic('boot',next);
+  }else if(typeof ic==="function"){
     ic('reattach_activator');ic('update',w.intercomSettings);
   }else{
     var d=document;var i=function(){i.c(arguments);};i.q=[];

--- a/ankihub/settings.py
+++ b/ankihub/settings.py
@@ -228,6 +228,9 @@ class PrivateConfig(DataClassJSONMixin):
     show_enable_fsrs_reminder: Optional[bool] = True
     feature_flags: dict = field(default_factory=dict)
     user_details: dict = field(default_factory=dict)
+    # App URL the current token/user_details were issued for. Used to detect
+    # staging↔production switches so we do not reuse credentials across servers.
+    auth_app_url: Optional[str] = None
     block_exams_subdecks: List[BlockExamSubdeckConfig] = field(default_factory=list)
     onboarding_tutorial_pending: bool = False
     onboarding_tutorial_show_on_sync: bool = True
@@ -298,9 +301,6 @@ class _Config:
         if intro_deck_id := os.getenv("INTRO_DECK_ID"):
             self.intro_deck_id = uuid.UUID(intro_deck_id)
 
-        if intercom_app_id := os.getenv("INTERCOM_APP_ID"):
-            self.intercom_app_id = intercom_app_id
-
         if override_url := os.getenv("ANKIWEB_URL"):
             override_url = override_url.rstrip("/")
             self.ankiweb_url = override_url
@@ -333,7 +333,39 @@ class _Config:
                 LOGGER.exception("Failed to load private config. Overwriting it.")
                 self._private_config = PrivateConfig()
 
+        self._invalidate_auth_if_server_changed()
         self._update_private_config()
+
+    def _invalidate_auth_if_server_changed(self) -> None:
+        """Clear credentials when the configured AnkiHub server no longer matches auth.
+
+        Tokens and cached /users/me data are not valid across staging and production.
+        Reusing them would boot Intercom (and other features) with the wrong identity.
+        """
+        if not self.is_logged_in():
+            return
+
+        auth_app_url = self._private_config.auth_app_url
+        if auth_app_url is None:
+            # Upgrade path: stamp the current server without signing out.
+            self._private_config.auth_app_url = self.app_url
+            LOGGER.info("Backfilled auth_app_url for existing login.", auth_app_url=self.app_url)
+            return
+
+        if auth_app_url == self.app_url:
+            return
+
+        LOGGER.info(
+            "signed_out_because_ankihub_server_changed",
+            previous_app_url=auth_app_url,
+            current_app_url=self.app_url,
+        )
+        # Clear token without firing token_change_hook yet — profile hooks may not
+        # be fully wired during setup_private_config. Caller persists via _update_private_config.
+        aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = ""
+        self._private_config.user_details = {}
+        self._private_config.feature_flags = {}
+        self._private_config.auth_app_url = None
 
     def _load_private_config(self) -> PrivateConfig:
         with open(self._private_config_path) as f:
@@ -366,6 +398,10 @@ class _Config:
 
         # aqt.mw.pm.set_ankihub_token(token)
         aqt.mw.pm.profile["thirdPartyAnkiHubToken"] = token
+
+        if self._private_config is not None:
+            self._private_config.auth_app_url = self.app_url if token else None
+            self._update_private_config()
 
         if token_changed:
             for func in self.token_change_hook:

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -6406,7 +6406,6 @@ class TestSetupPublicConfigAndOtherSettings:
         monkeypatch.delenv("ANKIWEB_URL", raising=False)
         monkeypatch.delenv("ANKING_DECK_ID", raising=False)
         monkeypatch.delenv("INTRO_DECK_ID", raising=False)
-        monkeypatch.delenv("INTERCOM_APP_ID", raising=False)
         monkeypatch.setattr("ankihub.settings._get_build_config", lambda: {})
 
     def test_production_defaults(self):
@@ -6485,11 +6484,75 @@ class TestSetupPublicConfigAndOtherSettings:
         config.setup_public_config_and_other_settings()
         assert config.intro_deck_id == uuid.UUID(custom_id)
 
-    def test_intercom_app_id_env_var_override(self, monkeypatch: MonkeyPatch):
-        monkeypatch.setenv("INTERCOM_APP_ID", "env_app_id")
-        config.public_config = {}
-        config.setup_public_config_and_other_settings()
-        assert config.intercom_app_id == "env_app_id"
+
+class TestAuthAppUrlOnServerChange:
+    def test_signs_out_when_auth_app_url_differs_from_current(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+    ) -> None:
+        with anki_session_with_addon_data.profile_loaded():
+            config.app_url = STAGING_APP_URL
+            config.save_token("staging-token")
+            config.set_user_details({"id": 1, "email": "staging@example.com"})
+            config.set_feature_flags({"intercom_desktop_enabled": True})
+            assert config._private_config.auth_app_url == STAGING_APP_URL
+
+            config.app_url = DEFAULT_APP_URL
+            config.setup_private_config()
+
+            assert not config.is_logged_in()
+            assert config.get_user_details() == {}
+            assert config.get_feature_flags() == {}
+            assert config._private_config.auth_app_url is None
+
+    def test_keeps_login_when_auth_app_url_matches(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+    ) -> None:
+        with anki_session_with_addon_data.profile_loaded():
+            config.app_url = DEFAULT_APP_URL
+            config.save_token("prod-token")
+            config.set_user_details({"id": 2, "email": "prod@example.com"})
+            config.set_feature_flags({"intercom_desktop_enabled": True})
+
+            config.setup_private_config()
+
+            assert config.is_logged_in()
+            assert config.token() == "prod-token"
+            assert config.get_user_details() == {"id": 2, "email": "prod@example.com"}
+            assert config.get_feature_flags() == {"intercom_desktop_enabled": True}
+            assert config._private_config.auth_app_url == DEFAULT_APP_URL
+
+    def test_backfills_missing_auth_app_url_without_signing_out(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+    ) -> None:
+        with anki_session_with_addon_data.profile_loaded():
+            config.app_url = DEFAULT_APP_URL
+            config.save_token("legacy-token")
+            config.set_user_details({"id": 3})
+            config._private_config.auth_app_url = None
+            config._update_private_config()
+
+            config.setup_private_config()
+
+            assert config.is_logged_in()
+            assert config.token() == "legacy-token"
+            assert config.get_user_details() == {"id": 3}
+            assert config._private_config.auth_app_url == DEFAULT_APP_URL
+
+    def test_save_token_stamps_and_clears_auth_app_url(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+    ) -> None:
+        with anki_session_with_addon_data.profile_loaded():
+            config.app_url = STAGING_APP_URL
+            config.save_token("staging-token")
+            assert config._private_config.auth_app_url == STAGING_APP_URL
+
+            config.save_token("")
+            assert config._private_config.auth_app_url is None
+            assert not config.is_logged_in()
 
 
 class TestIntercom:
@@ -6654,6 +6717,17 @@ class TestIntercom:
         assert "widget.intercom.io/widget/config_app_id" in web_content.body
         assert '"app_id": "config_app_id"' in web_content.body
         assert "from_server" not in web_content.body
+
+    def test_boot_js_shuts_down_and_boots_on_identity_change(self) -> None:
+        from ankihub.gui import intercom
+
+        boot_js = intercom._build_boot_js()
+        assert boot_js is not None
+        assert "identityChanged" in boot_js
+        assert "ic('shutdown')" in boot_js
+        assert "ic('boot',next)" in boot_js
+        assert "prev.app_id!==next.app_id" in boot_js
+        assert "prev.user_id" in boot_js
 
     def test_sync_with_user_preference_shuts_down_when_disabled(self, mocker: MockerFixture) -> None:
         from ankihub.gui import intercom


### PR DESCRIPTION
## Related issues
- [ ] Closes # [ACTV-453](https://ankihub.atlassian.net/browse/ACTV-453)

## Proposed changes
Switching `use_staging` could leave the add-on logged in with credentials from the other AnkiHub environment. That reused staging/production user details and could boot Intercom with the wrong workspace/user.

This PR:
- Stores `auth_app_url` with the token and clears login when the configured server no longer matches
- Backfills `auth_app_url` for existing sessions (no forced logout on upgrade)
- On Intercom identity change (`app_id` / `user_id`), calls `shutdown` + `boot` instead of `update`
- Removes the `INTERCOM_APP_ID` env override so the app id always follows staging vs production config

## How to reproduce
**Bug (before):**
1. Log in with `use_staging: true` (staging Intercom / staging user).
2. Flip `use_staging` to `false` and restart Anki without signing out first.
3. Intercom could still reflect the previous environment’s identity (or mixed state).

**Fix (after):**
1. Log in on staging (`use_staging: true`).
2. Set `use_staging: false` and restart Anki.
3. Confirm you are signed out and must log in again on production.
4. After login, Intercom uses the production app id / user.
5. Repeat the other direction (prod → staging). Same: forced local sign-out, then fresh login and Intercom boot.

## Further comments
`Intercom('update')` does not switch workspaces or users, so identity changes need `shutdown` + `boot`. Credentials are not valid across staging and production, so clearing them on server change is safer than trying to refresh in place. Upgrade path stamps `auth_app_url` without signing everyone out on first run after the update.

[ACTV-453]: https://ankihub.atlassian.net/browse/ACTV-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ