### PR TITLE
[NRT-903] Claim the trial-ended message when showing the upsell

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -1348,6 +1348,19 @@ class AnkiHubClient(AnkiWebClientMixin):
 
         return response.json()
 
+    def claim_trial_ended_message(self) -> bool:
+        """Claim the one-shot "your Premium trial has ended" message.
+
+        The request both reports whether the message was owed and marks it as shown, so it
+        must only be sent when the message is about to be displayed. It is a POST because it
+        has an effect - a retry, prefetch or proxy of a GET would spend the user's only message.
+        """
+        response = self._send_request("POST", API.ANKIHUB, "/users/me/trial-ended-message/claim")
+        if response.status_code != 200:
+            raise AnkiHubHTTPError(response)
+
+        return bool(response.json()["show_trial_ended_message"])
+
     def owned_deck_ids(self) -> List[uuid.UUID]:
         data = self.get_user_details()
         result = [uuid.UUID(deck["id"]) for deck in data["created_decks"]]

--- a/ankihub/gui/flashcard_selector_dialog.py
+++ b/ankihub/gui/flashcard_selector_dialog.py
@@ -70,11 +70,10 @@ UPSELL_SOURCE_TRIAL_ENDED = "trial_ended"
 UPSELL_SOURCE_GENERIC = "generic_upsell"
 
 # Third value in the web's `surface` taxonomy, alongside `web_app` (browser) and
-# `anki_webview` (webview hosted in Anki), which are set in _analytics_state.html:17.
-# Note that Smart Search's webview is also served inside the add-on and reports
-# `anki_webview`, so this value means specifically the add-on's native Qt layer.
-# Both surfaces open the same plans page with no marker of their own, so this property
-# is the only thing preventing double-counting.
+# `anki_webview` (webview hosted in Anki). Smart Search's webview is also served inside
+# the add-on and reports `anki_webview`, so this value means specifically the add-on's
+# native Qt layer. Both surfaces open the same plans page with no marker of their own,
+# so this property is the only thing preventing double-counting.
 UPSELL_SURFACE = "anki_addon"
 
 
@@ -95,8 +94,8 @@ def _track_upsell_event(event_name: str, source: str) -> None:
                 distinct_id=user_id,
                 event_name=event_name,
                 properties={
-                    # Key and values mirror the web upsell's taxonomy so the two channels can
-                    # be reconciled later (ModalUpsellContent.html:40,47 emits `source`).
+                    # `source` and `surface` mirror the web upsell's taxonomy so the two
+                    # channels can be reconciled later.
                     "source": source,
                     "surface": UPSELL_SURFACE,
                     "user": user_id,
@@ -142,7 +141,7 @@ learning experience with Premium. 🌟"
     _track_upsell_event("upgrade_cta_viewed", source)
 
 
-def _show_upsell(user_details: dict, parent=aqt.mw) -> None:
+def _show_upsell(parent=aqt.mw) -> None:
     """Claim the one-shot trial-ended message, then show the upsell with the matching copy.
 
     The claim is what marks the message as shown, so it is sent here - at display time - and
@@ -179,5 +178,5 @@ def show_flashcard_selector(ah_did: UUID, parent=aqt.mw) -> None:
     check_user_feature_access(
         feature_key="has_flashcard_selector_access",
         on_access_granted=on_access_granted,
-        on_access_denied=lambda user_details: _show_upsell(user_details, parent),
+        on_access_denied=lambda _: _show_upsell(parent),
     )

--- a/ankihub/gui/flashcard_selector_dialog.py
+++ b/ankihub/gui/flashcard_selector_dialog.py
@@ -7,7 +7,13 @@ from aqt import QDialogButtonBox, sip
 from aqt.utils import openLink
 
 from .. import LOGGER
+from ..addon_ankihub_client import AddonAnkiHubClient as AnkiHubClient
 from ..gui.webview import AnkiHubWebViewDialog
+from ..product_metrics_client import (
+    ProductMetricsClient,
+    ProductMetricsHTTPError,
+    ProductMetricsRequestException,
+)
 from ..settings import (
     config,
     url_flashcard_selector,
@@ -15,6 +21,7 @@ from ..settings import (
     url_plans_page,
 )
 from ..user_state import check_user_feature_access
+from .operations import AddonQueryOp
 from .utils import show_dialog
 
 
@@ -59,17 +66,66 @@ class FlashCardSelectorDialog(AnkiHubWebViewDialog):
         return url_flashcard_selector(self.ah_did)
 
 
-def _show_upsell(user_details: dict, parent=aqt.mw) -> None:
-    show_trial_ended_message = user_details.get("show_trial_ended_message", False)
+UPSELL_SOURCE_TRIAL_ENDED = "trial_ended"
+UPSELL_SOURCE_GENERIC = "generic_upsell"
+
+# Third value in the web's `surface` taxonomy, alongside `web_app` (browser) and
+# `anki_webview` (webview hosted in Anki), which are set in _analytics_state.html:17.
+# Note that Smart Search's webview is also served inside the add-on and reports
+# `anki_webview`, so this value means specifically the add-on's native Qt layer.
+# Both surfaces open the same plans page with no marker of their own, so this property
+# is the only thing preventing double-counting.
+UPSELL_SURFACE = "anki_addon"
+
+
+def _track_upsell_event(event_name: str, source: str) -> None:
+    """Report an upsell event to the product metrics collector.
+
+    Fire-and-forget: a failed or slow send must never affect the dialog.
+    """
+    user_id = str(config.user_id())
+    plan = config.plan()
+    is_staff = config.is_staff()
+    is_admin = config.is_admin()
+    is_beta_tester = config.is_beta_tester()
+
+    def send_event() -> None:
+        try:
+            ProductMetricsClient(url=config.product_metrics_url).track(
+                distinct_id=user_id,
+                event_name=event_name,
+                properties={
+                    # Key and values mirror the web upsell's taxonomy so the two channels can
+                    # be reconciled later (ModalUpsellContent.html:40,47 emits `source`).
+                    "source": source,
+                    "surface": UPSELL_SURFACE,
+                    "user": user_id,
+                    "plan": plan,
+                    "is_staff_or_admin": is_staff or is_admin,
+                    "beta_tester": is_beta_tester,
+                },
+            )
+        except (ProductMetricsHTTPError, ProductMetricsRequestException) as exc:
+            LOGGER.warning(
+                "failed_to_track_upsell_event",
+                event_name=event_name,
+                exception=str(exc),
+            )
+
+    aqt.mw.taskman.run_in_background(send_event)
+
+
+def _display_upsell(source: str, parent=aqt.mw) -> None:
     text = "Let AI do the heavy lifting! Find flashcards perfectly matched to your study materials and elevate your \
 learning experience with Premium. 🌟"
-    if show_trial_ended_message:
+    if source == UPSELL_SOURCE_TRIAL_ENDED:
         title = "Your Trial Has Ended! 🎓✨"
     else:
         title = "📚 Unlock Your Potential with Premium"
 
     def on_button_clicked(button_index: int) -> None:
         if button_index == 1:
+            _track_upsell_event("upgrade_cta_clicked", source)
             openLink(url_plans_page())
 
     show_dialog(
@@ -82,6 +138,36 @@ learning experience with Premium. 🌟"
         ],
         default_button_idx=1,
         callback=on_button_clicked,
+    )
+    _track_upsell_event("upgrade_cta_viewed", source)
+
+
+def _show_upsell(user_details: dict, parent=aqt.mw) -> None:
+    """Claim the one-shot trial-ended message, then show the upsell with the matching copy.
+
+    The claim is what marks the message as shown, so it is sent here - at display time - and
+    never as a side effect of reading user state. A failed claim degrades to the generic copy
+    instead of surfacing an error; AddonQueryOp re-raises to the central error handler by
+    default, so the failure handler below is required rather than optional.
+    """
+
+    def on_claimed(show_trial_ended_message: bool) -> None:
+        source = UPSELL_SOURCE_TRIAL_ENDED if show_trial_ended_message else UPSELL_SOURCE_GENERIC
+        _display_upsell(source, parent)
+
+    def on_failure(exc: Exception) -> None:
+        LOGGER.warning("failed_to_claim_trial_ended_message", exception=str(exc))
+        _display_upsell(UPSELL_SOURCE_GENERIC, parent)
+
+    (
+        AddonQueryOp(
+            op=lambda _: AnkiHubClient().claim_trial_ended_message(),
+            success=on_claimed,
+            parent=parent or aqt.mw,
+        )
+        .without_collection()
+        .failure(on_failure)
+        .run_in_background()
     )
 
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -9127,19 +9127,15 @@ class TestFlashCardSelector:
             assert FlashCardSelectorDialog.dialog == dialog
 
     @pytest.mark.sequential
-    @pytest.mark.parametrize(
-        "show_trial_ended_message",
-        [False, True],
-    )
-    def test_shows_flashcard_selector_upsell_if_no_access(
+    def test_does_not_claim_trial_ended_message_if_user_has_access(
         self,
         anki_session_with_addon_data: AnkiSession,
         install_ah_deck: InstallAHDeck,
         qtbot: QtBot,
         set_feature_flag_state: SetFeatureFlagState,
         mocker: MockerFixture,
-        show_trial_ended_message: bool,
     ):
+        """The message is one-shot, so only the path that actually displays it may claim it."""
         set_feature_flag_state("show_flashcards_selector_button")
 
         entry_point.run()
@@ -9147,10 +9143,7 @@ class TestFlashCardSelector:
             mocker.patch.object(config, "token", return_value="test_token")
 
             anki_did = DeckId(1)
-            install_ah_deck(
-                anki_did=anki_did,
-                has_note_embeddings=True,
-            )
+            install_ah_deck(anki_did=anki_did, has_note_embeddings=True)
             aqt.mw.deckBrowser.set_current_deck(anki_did)
 
             qtbot.wait(500)
@@ -9161,23 +9154,179 @@ class TestFlashCardSelector:
                 AnkiHubClient,
                 "get_user_details",
                 return_value={
-                    "has_flashcard_selector_access": False,
-                    "show_trial_ended_message": show_trial_ended_message,
+                    "has_flashcard_selector_access": True,
                 },
             )
+            claim_mock = mocker.patch.object(AnkiHubClient, "claim_trial_ended_message")
 
             overview_web: AnkiWebView = aqt.mw.overview.web
             overview_web.eval(
                 f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}').click()",
             )
 
-            def upsell_dialog_opened():
-                dialog: QWidget = aqt.mw.app.activeWindow()
-                if not isinstance(dialog, utils._Dialog):
+            def flashcard_selector_opened() -> bool:
+                if FlashCardSelectorDialog.dialog is None:
                     return False
-                return "Trial" in dialog.windowTitle() if show_trial_ended_message else True
+                return FlashCardSelectorDialog.dialog.isVisible()
 
-            qtbot.wait_until(upsell_dialog_opened)
+            qtbot.wait_until(flashcard_selector_opened)
+
+            claim_mock.assert_not_called()
+
+    def _open_upsell_dialog(
+        self,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        mocker: MockerFixture,
+        claim_result: Union[bool, Exception],
+    ) -> Tuple[utils._Dialog, Mock, Mock]:
+        """Trigger the upsell path with a mocked claim outcome.
+
+        Returns the opened dialog, the mock for ProductMetricsClient.track and the mock for
+        the claim method.
+        """
+        mocker.patch.object(config, "token", return_value="test_token")
+
+        anki_did = DeckId(1)
+        install_ah_deck(
+            anki_did=anki_did,
+            has_note_embeddings=True,
+        )
+        aqt.mw.deckBrowser.set_current_deck(anki_did)
+
+        qtbot.wait(500)
+
+        mocker.patch.object(AnkiWebView, "load_url")
+
+        # The server no longer sends show_trial_ended_message here - it is claimed separately.
+        mocker.patch.object(
+            AnkiHubClient,
+            "get_user_details",
+            return_value={
+                "has_flashcard_selector_access": False,
+            },
+        )
+
+        if isinstance(claim_result, Exception):
+            claim_mock = mocker.patch.object(AnkiHubClient, "claim_trial_ended_message", side_effect=claim_result)
+        else:
+            claim_mock = mocker.patch.object(AnkiHubClient, "claim_trial_ended_message", return_value=claim_result)
+
+        product_metrics_client_mock = mocker.patch("ankihub.gui.flashcard_selector_dialog.ProductMetricsClient")
+        track_mock = product_metrics_client_mock.return_value.track
+
+        overview_web: AnkiWebView = aqt.mw.overview.web
+        overview_web.eval(
+            f"document.getElementById('{FLASHCARD_SELECTOR_OPEN_BUTTON_ID}').click()",
+        )
+
+        def upsell_dialog_opened() -> bool:
+            return isinstance(aqt.mw.app.activeWindow(), utils._Dialog)
+
+        qtbot.wait_until(upsell_dialog_opened)
+
+        return cast(utils._Dialog, aqt.mw.app.activeWindow()), track_mock, claim_mock
+
+    def _tracked_events(self, track_mock: Mock, event_name: str) -> List[Any]:
+        return [call for call in track_mock.call_args_list if call.kwargs["event_name"] == event_name]
+
+    @pytest.mark.sequential
+    @pytest.mark.parametrize(
+        "claim_result, expected_source, expects_trial_ended_title",
+        [
+            pytest.param(True, "trial_ended", True, id="claimed_and_owed"),
+            pytest.param(False, "generic_upsell", False, id="claimed_and_not_owed"),
+            pytest.param(
+                AnkiHubHTTPError(response=Mock(status_code=500)),
+                "generic_upsell",
+                False,
+                id="claim_failed",
+            ),
+        ],
+    )
+    def test_shows_flashcard_selector_upsell_if_no_access(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        set_feature_flag_state: SetFeatureFlagState,
+        mocker: MockerFixture,
+        claim_result: Union[bool, Exception],
+        expected_source: str,
+        expects_trial_ended_title: bool,
+    ):
+        set_feature_flag_state("show_flashcards_selector_button")
+
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            open_link_mock = mocker.patch("ankihub.gui.flashcard_selector_dialog.openLink")
+
+            dialog, track_mock, claim_mock = self._open_upsell_dialog(
+                install_ah_deck=install_ah_deck,
+                qtbot=qtbot,
+                mocker=mocker,
+                claim_result=claim_result,
+            )
+
+            claim_mock.assert_called_once()
+
+            # A failed claim degrades to the generic copy instead of raising an error dialog.
+            if expects_trial_ended_title:
+                assert "Trial" in dialog.windowTitle()
+            else:
+                assert "Trial" not in dialog.windowTitle()
+                assert "Premium" in dialog.windowTitle()
+
+            qtbot.wait_until(lambda: bool(self._tracked_events(track_mock, "upgrade_cta_viewed")))
+
+            viewed_properties = self._tracked_events(track_mock, "upgrade_cta_viewed")[0].kwargs["properties"]
+            assert viewed_properties["source"] == expected_source
+            assert viewed_properties["surface"] == "anki_addon"
+
+            assert not self._tracked_events(track_mock, "upgrade_cta_clicked")
+
+            learn_more_button = next(button for button in dialog.button_box.buttons() if button.text() == "Learn More")
+            learn_more_button.click()
+
+            qtbot.wait_until(lambda: bool(self._tracked_events(track_mock, "upgrade_cta_clicked")))
+
+            clicked_properties = self._tracked_events(track_mock, "upgrade_cta_clicked")[0].kwargs["properties"]
+            assert clicked_properties["source"] == expected_source
+            assert clicked_properties["surface"] == "anki_addon"
+
+            open_link_mock.assert_called_once()
+
+    @pytest.mark.sequential
+    def test_dismissing_flashcard_selector_upsell_does_not_track_a_click(
+        self,
+        anki_session_with_addon_data: AnkiSession,
+        install_ah_deck: InstallAHDeck,
+        qtbot: QtBot,
+        set_feature_flag_state: SetFeatureFlagState,
+        mocker: MockerFixture,
+    ):
+        set_feature_flag_state("show_flashcards_selector_button")
+
+        entry_point.run()
+        with anki_session_with_addon_data.profile_loaded():
+            open_link_mock = mocker.patch("ankihub.gui.flashcard_selector_dialog.openLink")
+
+            dialog, track_mock, _ = self._open_upsell_dialog(
+                install_ah_deck=install_ah_deck,
+                qtbot=qtbot,
+                mocker=mocker,
+                claim_result=False,
+            )
+
+            qtbot.wait_until(lambda: bool(self._tracked_events(track_mock, "upgrade_cta_viewed")))
+
+            not_now_button = next(button for button in dialog.button_box.buttons() if button.text() == "Not Now")
+            not_now_button.click()
+
+            qtbot.wait(500)
+
+            assert not self._tracked_events(track_mock, "upgrade_cta_clicked")
+            open_link_mock.assert_not_called()
 
     def test_with_no_auth_token(
         self,

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -8904,6 +8904,12 @@ def mock_load_url_to_show_page(mocker: MockerFixture, body: str, url_substring: 
     mocker.patch("aqt.webview.AnkiWebView.load_url", new=new_load_url)
 
 
+def _response_with_status(status_code: int) -> Response:
+    response = Response()
+    response.status_code = status_code
+    return response
+
+
 class TestFlashCardSelector:
     @pytest.mark.sequential
     @pytest.mark.parametrize(
@@ -9237,7 +9243,9 @@ class TestFlashCardSelector:
             pytest.param(True, "trial_ended", True, id="claimed_and_owed"),
             pytest.param(False, "generic_upsell", False, id="claimed_and_not_owed"),
             pytest.param(
-                AnkiHubHTTPError(response=Mock(status_code=500)),
+                # A real Response, not a Mock: the failure handler logs str(exc), and
+                # AnkiHubHTTPError.__str__ reads the response body and headers.
+                AnkiHubHTTPError(response=_response_with_status(500)),
                 "generic_upsell",
                 False,
                 id="claim_failed",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -2029,6 +2029,33 @@ class TestGetUserDetails:
         # This test just makes sure that the method does not throw an exception
 
 
+class TestClaimTrialEndedMessage:
+    # These tests use requests_mock instead of a cassette because the endpoint does not exist
+    # on the server yet. Replace with a VCR test once it is deployed.
+
+    def _mock_claim(self, requests_mock: Mocker, client: AnkiHubClient, **kwargs) -> None:
+        requests_mock.post(f"{client.api_url}/users/me/trial-ended-message/claim", **kwargs)
+
+    def test_message_was_owed(self, requests_mock: Mocker):
+        client = AnkiHubClient(local_media_dir_path_cb=lambda: Path("."))
+        self._mock_claim(requests_mock, client, json={"show_trial_ended_message": True})
+
+        assert client.claim_trial_ended_message() is True
+
+    def test_message_was_already_spent(self, requests_mock: Mocker):
+        client = AnkiHubClient(local_media_dir_path_cb=lambda: Path("."))
+        self._mock_claim(requests_mock, client, json={"show_trial_ended_message": False})
+
+        assert client.claim_trial_ended_message() is False
+
+    def test_raises_on_error_response(self, requests_mock: Mocker):
+        client = AnkiHubClient(local_media_dir_path_cb=lambda: Path("."))
+        self._mock_claim(requests_mock, client, status_code=404, reason="Not Found")
+
+        with pytest.raises(AnkiHubHTTPError):
+            client.claim_trial_ended_message()
+
+
 @pytest.mark.vcr()
 class TestSendCardReviewData:
     def test_basic(


### PR DESCRIPTION
## Related issues
- Closes [NRT-903](https://ankihub.atlassian.net/browse/NRT-903)
- Server side: AnkiHubSoftware/ankihub#3910 — removes the field from user details and adds the claim endpoint. **Must be deployed before this PR is released.**

## Proposed changes
- Add `AnkiHubClient.claim_trial_ended_message()` for `POST /users/me/trial-ended-message/claim`.
- Claim the message when the upsell is displayed and pick the trial-ended title from the result. Restores copy that became unreachable once the server stopped sending `show_trial_ended_message` in user details.
- Fail soft: a failed claim logs a warning and shows the generic copy. Needs an explicit `.failure()` handler because `AddonQueryOp` re-raises by default.
- Report `upgrade_cta_viewed` / `upgrade_cta_clicked` with `source` and `surface` matching the web taxonomy. The native dialog never loads a webview, so the add-on CTA was previously invisible to analytics.

## How to reproduce
1. Sign in as a user without Smart Search access whose trial has ended.
2. Open a deck and click the Smart Search button.
3. The upsell shows "Your Trial Has Ended! 🎓✨"; reopening shows the generic title.

## Further comments
Depends on the server endpoint, which is implemented but not yet in production — ship server first. Until then the fail-soft path shows the generic copy.

The `tests/addon` suite was not run locally (segfaults on macOS); CI is the first check on those three tests.


[NRT-903]: https://ankihub.atlassian.net/browse/NRT-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
