### PR TITLE
make support button config tests deterministic on CI

### DIFF
--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -6864,6 +6864,9 @@ class TestIntercom:
         qtbot: QtBot,
     ) -> None:
         with anki_session_with_addon_data.profile_loaded():
+            # Closing ConfigWindow runs execute_on_close hooks. Stub the Intercom sync
+            # side effect so teardown does not depend on webview/event-loop timing.
+            mocker.patch("ankihub.gui.intercom.sync_with_user_preference")
             mocker.patch.object(
                 config,
                 "get_feature_flags",
@@ -6909,6 +6912,9 @@ class TestIntercom:
         qtbot: QtBot,
     ) -> None:
         with anki_session_with_addon_data.profile_loaded():
+            # Closing ConfigWindow runs execute_on_close hooks. Stub the Intercom sync
+            # side effect so teardown does not depend on webview/event-loop timing.
+            mocker.patch("ankihub.gui.intercom.sync_with_user_preference")
             mocker.patch.object(
                 config,
                 "get_feature_flags",


### PR DESCRIPTION

## Summary
- Fixes a CI-only hang in the support-button config tests by removing teardown-time dependence on Intercom/webview behavior.
- Stubs `ankihub.gui.intercom.sync_with_user_preference` in the two config-checkbox tests so closing `ConfigWindow` cannot trigger flaky JS eval paths in headless environments.
- Keeps test intent unchanged: both tests still validate whether the `Support button` checkbox is shown/hidden based on feature-flag state.

## Test plan
- [x] `uv run pytest tests/addon/test_unit.py::TestIntercom::test_support_button_checkbox_in_config_when_flag_enabled tests/addon/test_unit.py::TestIntercom::test_support_button_checkbox_hidden_when_flag_disabled -q`
- [ ] (Optional) Run the full `TestIntercom` class to validate no neighboring regressions.
