### PR TITLE
Remove the unsuspend_card_by_default feature flag

### DIFF
--- a/ankihub/main/importing.py
+++ b/ankihub/main/importing.py
@@ -770,9 +770,7 @@ class AnkiHubImporter:
         if is_tag_in_list(TAG_FOR_INSTRUCTION_NOTES, note.tags):
             return []
 
-        if config.get_feature_flags().get("unsuspend_card_by_default", False) and is_tag_in_list(
-            TAG_STARTER_NOTES, note.tags
-        ):
+        if is_tag_in_list(TAG_STARTER_NOTES, note.tags):
             return []
 
         def new_cards() -> List[Card]:

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -4404,6 +4404,23 @@ def test_keep_notes_with_instructions_tag_unsuspended(
         assert new_card.queue == QUEUE_TYPE_NEW
 
 
+def test_keep_starter_notes_unsuspended(
+    anki_session_with_addon_data: AnkiSession,
+    install_ah_deck: InstallAHDeck,
+    import_ah_note: ImportAHNote,
+):
+    anki_session = anki_session_with_addon_data
+    with anki_session.profile_loaded():
+        ah_did = install_ah_deck()
+        config.set_suspend_new_cards_of_new_notes(ah_did, True)
+        note_info = NoteInfoFactory.create(tags=[settings.TAG_STARTER_NOTES])
+        import_ah_note(ah_did=ah_did, note_data=note_info)
+        note = aqt.mw.col.get_note(NoteId(note_info.anki_nid))
+        new_card = note.cards()[0]
+
+        assert new_card.queue == QUEUE_TYPE_NEW
+
+
 def test_unsubscribe_from_deck(
     anki_session_with_addon_data: AnkiSession,
     install_sample_ah_deck: InstallSampleAHDeck,


### PR DESCRIPTION
<!--
How to Use this template:
Everyone likes to review a well written PR, by taking more time to create yours you will identify improvements, make sure all the code is doing what's supposed to and the code review process will run smoothier and faster. After that being said, feel free to modify any of the sections below, this is a guideline to improve your description but some parts may not be applicable to you. While reviewing the code, if you feel the need to left comments we're following this emoji recomendation: https://github.com/erikthedeveloper/code-review-emoji-guide
-->


## Related issues
<!---
Link here any external links related to this changes, could be a Sentry error, a Notion ticket or just the Github Project link.
-->
- [x] Closes # [ACTV-437](https://ankihub.atlassian.net/browse/ACTV-437)


## Proposed changes
Cleans up the `unsuspend_card_by_default` feature flag in the code.


## How to reproduce
#### Setup
1. Ensure you did not have the Anking Step Deck installed

#### Test Case
1. Remove the `unsuspend_card_by_default` feature flag or set it false
2. Download the Anking Step Deck
3. Check if the starter cards are unsuspended



[ACTV-437]: https://ankihub.atlassian.net/browse/ACTV-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ