### PR TITLE
[KNW-225] Do not report media sync errors caused by stale DB entries

### DIFF
--- a/ankihub/ankihub_client/ankihub_client.py
+++ b/ankihub/ankihub_client/ankihub_client.py
@@ -681,7 +681,9 @@ class AnkiHubClient(AnkiWebClientMixin):
                 media_remote_path=media_remote_path,
                 status_code=response.status_code,
             )
-            raise AnkiHubMediaDownloadError(response, media_remote_path)
+            # Ignore missing files (e.g. stale media entries in the database)
+            if response.status_code != 403:
+                raise AnkiHubMediaDownloadError(response, media_remote_path)
 
     def stop_background_threads(self) -> None:
         """Can be called to stop all background threads started by this client."""

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1474,10 +1474,13 @@ class TestDownloadMedia:
 
             assert len(futures) == len(media_names)
 
+    @pytest.mark.parametrize("status_code, raises", [(404, True), (403, False)])
     def test_with_failed_download(
         self,
         requests_mock: Mocker,
         next_deterministic_uuid: Callable[[], uuid.UUID],
+        status_code: int,
+        raises: bool,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             client = AnkiHubClient(local_media_dir_path_cb=lambda: Path(temp_dir))
@@ -1485,7 +1488,7 @@ class TestDownloadMedia:
             deck_id = next_deterministic_uuid()
             requests_mock.get(
                 f"{DEFAULT_S3_BUCKET_URL}/deck_assets/{deck_id}/missing.png",
-                status_code=404,
+                status_code=status_code,
                 reason="Not Found",
             )
 
@@ -1494,12 +1497,15 @@ class TestDownloadMedia:
             client.download_media(media_names=["missing.png"], deck_id=deck_id, on_downloaded_file=futures.append)
 
             assert len(futures) == 1
-            with pytest.raises(AnkiHubMediaDownloadError) as exc_info:
+            if raises:
+                with pytest.raises(AnkiHubMediaDownloadError) as exc_info:
+                    futures[0].result()
+                exception = exc_info.value
+                assert exception.filename == f"/deck_assets/{deck_id}/missing.png"
+                assert exception.response.status_code == status_code
+            else:
                 futures[0].result()
 
-            exception = exc_info.value
-            assert exception.filename == f"/deck_assets/{deck_id}/missing.png"
-            assert exception.response.status_code == 404
             assert not (Path(temp_dir) / "missing.png").exists()
 
     def test_failed_download_doesnt_prevent_other_downloads(


### PR DESCRIPTION


## Related issues

[KNW-225](https://ankihub.atlassian.net/browse/KNW-225)

## Proposed changes

The media sync progress dialog implemented in #1339 uncovered an issue where the add-on keeps trying to download media files that were deleted from the backend ([TRIAGE-321](https://ankihub.atlassian.net/browse/TRIAGE-321)). As long as the backend objects are not modified, the add-on will keep reporting errors with such files on every sync.

## How to reproduce

This should not be normally reproducible with fresh deck installs. It usually happens for old users as they are more likely to have media entries belonging to deleted files in their local AnkiHub database. See report: https://community.ankihub.net/t/unable-to-download-media-file-deck-assets-e77aedfe-a636-40e2-8169-2fce2673187e-tmplvqol9-png-403-forbidden/607281



[KNW-225]: https://ankihub.atlassian.net/browse/KNW-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRIAGE-321]: https://ankihub.atlassian.net/browse/TRIAGE-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ