### PR TITLE
perf: Speed up media_names_for_ankihub_deck

### DIFF
--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -448,28 +448,38 @@ class _AnkiHubDB:
 
     def media_names_for_ankihub_deck(self, ah_did: uuid.UUID) -> Set[str]:
         """Returns the names of all media files which are referenced on notes in the given deck."""
-        notes = AnkiHubNote.select(AnkiHubNote.anki_note_type_id, AnkiHubNote.fields).filter(
-            NOTE_NOT_DELETED_CONDITION,
-            ankihub_deck_id=ah_did,
+        note_type_ids = set(
+            AnkiHubNote.select(AnkiHubNote.anki_note_type_id)
+            .distinct()
+            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ah_did)
+            .objects(flat)
         )
-        note_type_ids = set(note.anki_note_type_id for note in notes)
         note_types: Dict[int, NotetypeDict] = {
             nt.anki_note_type_id: nt.note_type_dict
             for nt in AnkiHubNoteType.select(AnkiHubNoteType.anki_note_type_id, AnkiHubNoteType.note_type_dict).filter(
                 anki_note_type_id__in=note_type_ids
             )
         }
-        note_type_refs = {
+
+        result: Set[str] = {
             name for note_type in note_types.values() for name in get_media_names_from_note_type(note_type)
         }
-        note_refs = {
-            media_name
-            for note in notes
-            for field_value in (note.fields.values() if note.fields else [])
-            for media_name in get_media_names_from_note_field(field_value, note_types[note.anki_note_type_id])
-        }
 
-        return {*note_type_refs, *note_refs}
+        notes = (
+            AnkiHubNote.select(AnkiHubNote.anki_note_type_id, AnkiHubNote.fields)
+            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ah_did)
+            .iterator()
+        )
+        for note in notes:
+            # Guard against notes referencing a note type which is missing from the AnkiHub DB
+            note_type = note_types.get(note.anki_note_type_id)
+            if note_type is None or not note.fields:
+                continue
+
+            for field_value in note.fields.values():
+                result.update(get_media_names_from_note_field(field_value, note_type))
+
+        return result
 
     def media_names_exist_for_ankihub_deck(self, ah_did: uuid.UUID, media_names: Set[str]) -> Dict[str, bool]:
         """Returns a dictionary where each key is a media name and the corresponding value is a boolean

--- a/ankihub/db/db.py
+++ b/ankihub/db/db.py
@@ -448,35 +448,25 @@ class _AnkiHubDB:
 
     def media_names_for_ankihub_deck(self, ah_did: uuid.UUID) -> Set[str]:
         """Returns the names of all media files which are referenced on notes in the given deck."""
-        note_type_ids = set(
-            AnkiHubNote.select(AnkiHubNote.anki_note_type_id)
-            .distinct()
-            .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ah_did)
-            .objects(flat)
-        )
-        note_types: Dict[int, NotetypeDict] = {
-            nt.anki_note_type_id: nt.note_type_dict
-            for nt in AnkiHubNoteType.select(AnkiHubNoteType.anki_note_type_id, AnkiHubNoteType.note_type_dict).filter(
-                anki_note_type_id__in=note_type_ids
-            )
-        }
-
-        result: Set[str] = {
-            name for note_type in note_types.values() for name in get_media_names_from_note_type(note_type)
-        }
-
-        notes = (
+        result: Set[str] = set()
+        note_types: Dict[int, Optional[NotetypeDict]] = {}
+        rows: Iterable[Tuple[int, Optional[Dict[str, str]]]] = (
             AnkiHubNote.select(AnkiHubNote.anki_note_type_id, AnkiHubNote.fields)
             .filter(NOTE_NOT_DELETED_CONDITION, ankihub_deck_id=ah_did)
+            .tuples()
             .iterator()
         )
-        for note in notes:
-            # Guard against notes referencing a note type which is missing from the AnkiHub DB
-            note_type = note_types.get(note.anki_note_type_id)
-            if note_type is None or not note.fields:
+        for mid, fields in rows:
+            if mid not in note_types:
+                note_type = note_types[mid] = self.note_type_dict(NotetypeId(mid))
+                if note_type is not None:
+                    result.update(get_media_names_from_note_type(note_type))
+
+            note_type = note_types[mid]
+            if note_type is None or not fields:
                 continue
 
-            for field_value in note.fields.values():
+            for field_value in fields.values():
                 result.update(get_media_names_from_note_field(field_value, note_type))
 
         return result

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -336,7 +336,11 @@ class _AnkiHubMediaSync:
             LOGGER.info("No new media updates for deck.", ah_did=ankihub_did)
 
     def _media_referenced_by_notes(self, ah_did: uuid.UUID) -> Set[str]:
-        """Scan all notes in the AnkiHub deck and return the set of referenced media filenames."""
+        """
+        Scan all notes in the AnkiHub deck and return the set of referenced media filenames.
+        This requires scanning the Anki collection rather than the AnkiHub DB
+        to filter out media from emptied protected fields (INTP-338)
+        """
         anki_nids: List[NoteId] = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
 
         media_names: Set[str] = set()

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -10,9 +10,6 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Set, Tuple
 
 import aqt
-from anki.errors import NotFoundError
-from anki.models import NotetypeId
-from anki.notes import NoteId
 from aqt.gui_hooks import theme_did_change, top_toolbar_did_redraw
 from aqt.qt import (
     QAction,
@@ -36,7 +33,6 @@ from aqt.qt import (
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient, CollectionNotAvailableError, collection_or_error
 from ..ankihub_client.models import DeckMedia
-from ..common_utils import get_media_names_from_note_field, get_media_names_from_note_type
 from ..db import ankihub_db
 from ..settings import config, get_anki_profile_id
 from .operations import AddonQueryOp
@@ -335,34 +331,12 @@ class _AnkiHubMediaSync:
         else:
             LOGGER.info("No new media updates for deck.", ah_did=ankihub_did)
 
-    def _media_referenced_by_notes(self, ah_did: uuid.UUID) -> Set[str]:
-        """Scan all notes in the AnkiHub deck and return the set of referenced media filenames."""
-        anki_nids: List[NoteId] = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
-
-        media_names: Set[str] = set()
-        note_type_ids: Set[int] = set()
-        for nid in anki_nids:
-            try:
-                note = collection_or_error().get_note(nid)
-            except NotFoundError:
-                continue
-            note_type_ids.add(note.mid)
-            note_type = note.note_type()
-            for field in note.values():
-                media_names.update(get_media_names_from_note_field(field, note_type))
-        for note_type_id in note_type_ids:
-            note_type = ankihub_db.note_type_dict(NotetypeId(note_type_id))
-            # Guard against notes converted to non-AnkiHub note types
-            if note_type:
-                media_names.update(get_media_names_from_note_type(note_type))
-        return media_names
-
     def _missing_media_for_ah_deck(self, ah_did: uuid.UUID) -> List[str]:
         media_list = ankihub_db.downloadable_media_for_ankihub_deck(ah_did)
         if not media_list:
             return []
 
-        referenced_media = self._media_referenced_by_notes(ah_did)
+        referenced_media = ankihub_db.media_names_for_ankihub_deck(ah_did)
         # Filter to only media that is both downloadable AND referenced by notes
         media_list = [m for m in media_list if m.name in referenced_media]
 

--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from typing import Callable, Iterable, List, Optional, Set, Tuple
 
 import aqt
+from anki.errors import NotFoundError
+from anki.models import NotetypeId
+from anki.notes import NoteId
 from aqt.gui_hooks import theme_did_change, top_toolbar_did_redraw
 from aqt.qt import (
     QAction,
@@ -33,6 +36,7 @@ from aqt.qt import (
 from .. import LOGGER
 from ..addon_ankihub_client import AddonAnkiHubClient, CollectionNotAvailableError, collection_or_error
 from ..ankihub_client.models import DeckMedia
+from ..common_utils import get_media_names_from_note_field, get_media_names_from_note_type
 from ..db import ankihub_db
 from ..settings import config, get_anki_profile_id
 from .operations import AddonQueryOp
@@ -331,12 +335,34 @@ class _AnkiHubMediaSync:
         else:
             LOGGER.info("No new media updates for deck.", ah_did=ankihub_did)
 
+    def _media_referenced_by_notes(self, ah_did: uuid.UUID) -> Set[str]:
+        """Scan all notes in the AnkiHub deck and return the set of referenced media filenames."""
+        anki_nids: List[NoteId] = ankihub_db.anki_nids_for_ankihub_deck(ah_did)
+
+        media_names: Set[str] = set()
+        note_type_ids: Set[int] = set()
+        for nid in anki_nids:
+            try:
+                note = collection_or_error().get_note(nid)
+            except NotFoundError:
+                continue
+            note_type_ids.add(note.mid)
+            note_type = note.note_type()
+            for field in note.values():
+                media_names.update(get_media_names_from_note_field(field, note_type))
+        for note_type_id in note_type_ids:
+            note_type = ankihub_db.note_type_dict(NotetypeId(note_type_id))
+            # Guard against notes converted to non-AnkiHub note types
+            if note_type:
+                media_names.update(get_media_names_from_note_type(note_type))
+        return media_names
+
     def _missing_media_for_ah_deck(self, ah_did: uuid.UUID) -> List[str]:
         media_list = ankihub_db.downloadable_media_for_ankihub_deck(ah_did)
         if not media_list:
             return []
 
-        referenced_media = ankihub_db.media_names_for_ankihub_deck(ah_did)
+        referenced_media = self._media_referenced_by_notes(ah_did)
         # Filter to only media that is both downloadable AND referenced by notes
         media_list = [m for m in media_list if m.name in referenced_media]
 

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -8479,6 +8479,7 @@ class TestMediaSyncMediaDownload:
         self,
         anki_session_with_addon_data: AnkiSession,
         install_sample_ah_deck: InstallSampleAHDeck,
+        import_ah_note: ImportAHNote,
         mocker: MockerFixture,
         qtbot: QtBot,
     ):
@@ -8504,8 +8505,13 @@ class TestMediaSyncMediaDownload:
                 ],
             )
 
-            # Mock the _media_referenced_by_notes method to include the test media
-            mocker.patch.object(media_sync, "_media_referenced_by_notes", return_value={"image.png"})
+            # Add a note to the deck which references the test media
+            import_ah_note(
+                ah_did=ah_did,
+                note_data=NoteInfoFactory.create(
+                    fields=[Field(name="Front", value='<img src="image.png">'), Field(name="Back", value="")],
+                ),
+            )
 
             # Mock the client method for downloading media
             download_media_mock = mocker.patch.object(AnkiHubClient, "download_media")
@@ -8567,6 +8573,7 @@ class TestMediaSyncMediaDownload:
         self,
         anki_session_with_addon_data: AnkiSession,
         install_sample_ah_deck: InstallSampleAHDeck,
+        import_ah_note: ImportAHNote,
         mocker: MockerFixture,
         qtbot: QtBot,
     ):
@@ -8603,8 +8610,16 @@ class TestMediaSyncMediaDownload:
                 ],
             )
 
-            # Mock the _media_referenced_by_notes method to return only one media file
-            mocker.patch.object(media_sync, "_media_referenced_by_notes", return_value={"referenced_image.png"})
+            # Add a note to the deck which references only one of the media files
+            import_ah_note(
+                ah_did=ah_did,
+                note_data=NoteInfoFactory.create(
+                    fields=[
+                        Field(name="Front", value='<img src="referenced_image.png">'),
+                        Field(name="Back", value=""),
+                    ],
+                ),
+            )
 
             download_media_mock = mocker.patch.object(AnkiHubClient, "download_media")
 


### PR DESCRIPTION
## Related issues

This came up after my investigation of this community report: https://community.ankihub.net/t/i-accidently-deleted-the-anking-media-folder-from-my-laptop/605714

## Proposed changes

This implements some small performance improvements for media sync:
- ~Replace `_media_referenced_by_notes` (which extracts media references from the live Anki collection) with a call to `ankihub_db.media_names_for_ankihub_deck()`.~
- Refactor `media_names_for_ankihub_deck` to avoid holding all note rows in memory.

## How to reproduce

Media sync should work normally. This is mostly a performance improvement (but see note below).


## Further comments

- ~Locally deleted notes now count and their media gets downloaded. I think this is acceptable considering that the sync process restores deleted notes if they get updates.~
- This is unlikely to be the cause of the community report (it's most likely an IO issue because removing the .exists() check apparently unblocked the sync).