### PR TITLE
[KNW-223] Remove the media_sync_progress_ui feature flag

### DIFF
--- a/ankihub/gui/media_sync.py
+++ b/ankihub/gui/media_sync.py
@@ -50,9 +50,6 @@ from .utils import (
 
 SHOW_MEDIA_PROGRESS_PYCMD = "ankihub_show_media_progress"
 TOOLBAR_BUTTON_ID = "ankihub_media_sync"
-# Gates the media sync progress UI, i.e. the progress dialog and the toolbar button.
-# While it's off, the media sync only reports its status as text on the menu action.
-MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG = "media_sync_progress_ui"
 
 
 class MediaSyncStatus(Enum):
@@ -61,10 +58,6 @@ class MediaSyncStatus(Enum):
     ERROR = "Error"
     CANCELING = "Canceling..."
     IDLE = "Idle"
-
-
-def _progress_ui_enabled() -> bool:
-    return config.get_feature_flags().get(MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG, False)
 
 
 def _is_collection_error(exc: Exception) -> bool:
@@ -221,31 +214,17 @@ class _AnkiHubMediaSync:
     def _dialog(self) -> "MediaSyncProgressDialog":
         return MediaSyncProgressDialog()
 
-    def _dialog_if_enabled(self) -> Optional["MediaSyncProgressDialog"]:
-        """The progress dialog, or None while the progress UI feature flag is off.
-
-        All dialog access goes through here, so that the dialog is never created for users
-        who shouldn't see it.
-        """
-        if not _progress_ui_enabled():
-            return None
-        return self._dialog
-
     def _show_dialog(self) -> None:
-        if (dialog := self._dialog_if_enabled()) is not None:
-            dialog.show()
+        self._dialog.show()
 
     def _update_dialog_status(self, status: MediaSyncStatus, is_retry: bool) -> None:
-        if (dialog := self._dialog_if_enabled()) is not None:
-            dialog.update_status(status, is_retry=is_retry)
+        self._dialog.update_status(status, is_retry=is_retry)
 
     def _reset_dialog_progress(self, maximum: int) -> None:
-        if (dialog := self._dialog_if_enabled()) is not None:
-            dialog.reset_progress(maximum)
+        self._dialog.reset_progress(maximum)
 
     def _increment_dialog_progress(self, increment: int = 1) -> None:
-        if (dialog := self._dialog_if_enabled()) is not None:
-            dialog.increment_progress(increment)
+        self._dialog.increment_progress(increment)
 
     def _media_paths_for_media_names(self, media_names: Iterable[str]) -> Set[Path]:
         media_dir_path = Path(collection_or_error().media.dir())
@@ -418,7 +397,7 @@ class _AnkiHubMediaSync:
         icon = media_sync_error_svg() if status == MediaSyncStatus.ERROR else media_sync_svg()
         # The button is also removed when the feature flag is off, so that it disappears
         # for users who lose access to the feature while Anki is running.
-        if status == MediaSyncStatus.IDLE or not _progress_ui_enabled():
+        if status == MediaSyncStatus.IDLE:
             js = """(() => {
                 const toolbarButton = %(elem_js)s;
                 if(toolbarButton) {

--- a/tests/addon/test_integration.py
+++ b/tests/addon/test_integration.py
@@ -192,7 +192,7 @@ from ankihub.gui.js_message_handling import (
     UNSUSPEND_NOTES_PYCMD,
     _post_message_to_ankihub_js,
 )
-from ankihub.gui.media_sync import MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG, media_sync
+from ankihub.gui.media_sync import media_sync
 from ankihub.gui.menu import (
     AnkiHubLogin,
     _maybe_show_onboarding_tutorial_after_login,
@@ -8977,8 +8977,6 @@ class TestSuggestionsWithMedia:
         qtbot: QtBot,
         set_feature_flag_state: SetFeatureFlagState,
     ):
-        set_feature_flag_state(MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG)
-
         entry_point.run()
 
         with anki_session_with_addon_data.profile_loaded():

--- a/tests/addon/test_unit.py
+++ b/tests/addon/test_unit.py
@@ -143,8 +143,6 @@ from ankihub.gui.errors import (
 )
 from ankihub.gui.exceptions import DeckDownloadAndInstallError
 from ankihub.gui.media_sync import (
-    MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG,
-    TOOLBAR_BUTTON_ID,
     MediaSyncProgressDialog,
     MediaSyncStatus,
     media_sync,
@@ -519,24 +517,12 @@ def media_sync_dialog_mock() -> Generator[Mock, None, None]:
         media_sync.__dict__["_dialog"] = previous
 
 
-def set_media_sync_progress_ui_flag(mocker: MockerFixture, is_active: bool) -> None:
-    mocker.patch.object(
-        config,
-        "get_feature_flags",
-        return_value={MEDIA_SYNC_PROGRESS_UI_FEATURE_FLAG: is_active},
-    )
-
-
 class TestMediaSyncProgressDialogUpdates:
     """Covers that the media sync keeps its progress dialog up to date."""
 
     @pytest.fixture
     def dialog_mock(self, media_sync_dialog_mock: Mock) -> Mock:
         return media_sync_dialog_mock
-
-    @pytest.fixture(autouse=True)
-    def _enable_progress_ui(self, mocker: MockerFixture) -> None:
-        set_media_sync_progress_ui_flag(mocker, is_active=True)
 
     @pytest.fixture(autouse=True)
     def _mock_toolbar_button_status(self, mocker: MockerFixture) -> None:
@@ -634,95 +620,6 @@ class TestMediaSyncProgressDialogUpdates:
         dialog_mock.reset_progress.assert_called_once_with(0)
         assert media_sync._canceling is True
         refresh_sync_status_mock.assert_called_once_with(False)
-
-
-class TestMediaSyncProgressUIFeatureFlag:
-    """Covers that the progress dialog and the toolbar button are gated by the feature flag."""
-
-    def test_dialog_is_not_created_while_the_flag_is_off(self, mocker: MockerFixture):
-        set_media_sync_progress_ui_flag(mocker, is_active=False)
-
-        assert media_sync._dialog_if_enabled() is None
-
-    def test_dialog_is_not_updated_while_the_flag_is_off(self, media_sync_dialog_mock: Mock, mocker: MockerFixture):
-        set_media_sync_progress_ui_flag(mocker, is_active=False)
-        mocker.patch.object(media_sync, "_set_toolbar_button_status")
-        mocker.patch.object(media_sync, "_errors", [])
-
-        media_sync._refresh_media_download_status_inner(is_retry=False)
-        media_sync._on_downloaded_file(future_with_result(None))
-        media_sync._on_media_chunk_uploaded(future_with_result(3))
-
-        assert media_sync_dialog_mock.method_calls == []
-
-    def test_toolbar_button_click_shows_the_dialog_while_the_flag_is_on(
-        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
-    ):
-        set_media_sync_progress_ui_flag(mocker, is_active=True)
-
-        media_sync._on_toolbar_button_clicked()
-
-        media_sync_dialog_mock.show.assert_called_once_with()
-
-    def test_toolbar_button_click_does_not_show_the_dialog_while_the_flag_is_off(
-        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
-    ):
-        set_media_sync_progress_ui_flag(mocker, is_active=False)
-
-        media_sync._on_toolbar_button_clicked()
-
-        media_sync_dialog_mock.show.assert_not_called()
-
-    def test_status_action_does_not_show_the_dialog_while_the_flag_is_off(
-        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
-    ):
-        set_media_sync_progress_ui_flag(mocker, is_active=False)
-        # A sync has to be in progress, otherwise the action doesn't show the dialog anyway.
-        mocker.patch.object(media_sync, "_canceling", False)
-        mocker.patch.object(media_sync, "_download_in_progress", True)
-
-        media_sync._on_status_action_triggered()
-
-        media_sync_dialog_mock.show.assert_not_called()
-
-    def test_toolbar_button_is_added_while_the_flag_is_on(self, mocker: MockerFixture):
-        set_media_sync_progress_ui_flag(mocker, is_active=True)
-        mocker.patch.object(media_sync, "_toolbar_link", f'<a id="{TOOLBAR_BUTTON_ID}"></a>', create=True)
-        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
-
-        media_sync._set_toolbar_button_status(MediaSyncStatus.DOWNLOAD)
-
-        js = toolbar_mock.web.eval.call_args.args[0]
-        assert "insertAdjacentHTML" in js
-        assert TOOLBAR_BUTTON_ID in js
-
-    def test_toolbar_button_is_removed_while_the_flag_is_off(self, mocker: MockerFixture):
-        set_media_sync_progress_ui_flag(mocker, is_active=False)
-        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
-
-        media_sync._set_toolbar_button_status(MediaSyncStatus.DOWNLOAD)
-
-        # The button is removed instead of inserted, so that it also disappears for users who
-        # lose access to the feature while Anki is running.
-        js = toolbar_mock.web.eval.call_args.args[0]
-        assert "insertAdjacentHTML" not in js
-        assert ".remove()" in js
-
-    def test_status_refresh_before_the_private_config_is_set_up(
-        self, media_sync_dialog_mock: Mock, mocker: MockerFixture
-    ):
-        # The toolbar is drawn - and with it the status refreshed - before the private config
-        # of the profile exists, so the flag check must not raise there.
-        mocker.patch.object(config, "_private_config", None)
-        toolbar_mock = mocker.patch.object(aqt.mw, "toolbar")
-        mocker.patch.object(media_sync, "_canceling", False)
-        mocker.patch.object(media_sync, "_download_in_progress", True)
-
-        media_sync._refresh_media_download_status_inner(is_retry=False)
-
-        # Without feature flags, the progress UI stays hidden.
-        assert media_sync_dialog_mock.method_calls == []
-        assert "insertAdjacentHTML" not in toolbar_mock.web.eval.call_args.args[0]
 
 
 def test_lowest_level_common_ancestor_deck_name():


### PR DESCRIPTION
## Related issues

https://ankihub.atlassian.net/browse/KNW-223


## Proposed changes

This removes the `media_sync_progress_ui` feature flag so that the new progress dialog is always shown.

## How to reproduce

Try setting the flag to false on staging and confirm it has no effect.
