### PR TITLE
chore: Disable Anki's sound setup in tests

### DIFF
--- a/tests/addon/conftest.py
+++ b/tests/addon/conftest.py
@@ -55,8 +55,16 @@ REPO_ROOT_PATH = Path(__file__).absolute().parent.parent.parent
 TEST_PROFILE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 
+@pytest.fixture(autouse=True)
+def disable_sound_setup(monkeypatch: MonkeyPatch):
+    """Disable Anki's sound handling to suppress mpv errors."""
+    monkeypatch.setattr("aqt.main.AnkiQt.setup_sound", lambda *args, **kwargs: None)
+
+
 @pytest.fixture
-def anki_session(request: FixtureRequest, qtbot: QtBot) -> Generator[AnkiSession, None, None]:
+def anki_session(
+    request: FixtureRequest, qtbot: QtBot, disable_sound_setup: None
+) -> Generator[AnkiSession, None, None]:
     """Overwrites the anki_session fixture from pytest-anki to disable web debugging by default.
     This is done because web debugging is not used in any tests and it sometimes leads to errors.
     Otherwise the fixture is the same as the original.


### PR DESCRIPTION
## Related issues

None. Dev-only change.

## Proposed changes

This patches Anki's `aqt.main.AnkiQt.setup_sound` method in tests to suppress mpv errors on some systems (Windows).

## How to reproduce

Try running tests locally on Windows or macOS (?) and confirm you don't see errors such as "mpv timed out, restarting".
